### PR TITLE
feat: update scroll shrink wrapper accordingly & related pages

### DIFF
--- a/frontend/src/app/[locale]/investors/governance/[...slug]/page.tsx
+++ b/frontend/src/app/[locale]/investors/governance/[...slug]/page.tsx
@@ -70,13 +70,11 @@ export default async function GovernancePage({ params }: GovernancePageProps) {
       />
 
       {/* Content Section */}
-      <ScrollShrinkWrapper>
-        <div className="w-full rounded-2xl flex flex-col bg-secondary h-fit px-8 lg:px-16 py-16 lg:py-24">
-          <div className="mx-auto px-4 sm:px-6 lg:px-8">
-            <TeamMemberCard teamMember={teamMember} />
-          </div>
+      <div className="w-full max-w-6xl mx-auto lg:rounded-2xl flex flex-col bg-secondary h-fit px-8 lg:px-16 py-16 lg:py-24">
+        <div className="mx-auto px-4 sm:px-6 lg:px-8">
+          <TeamMemberCard teamMember={teamMember} />
         </div>
-      </ScrollShrinkWrapper>
+      </div>
     </>
   );
 }

--- a/frontend/src/app/[locale]/investors/governance/components/team-member-card/team-member-card.tsx
+++ b/frontend/src/app/[locale]/investors/governance/components/team-member-card/team-member-card.tsx
@@ -16,7 +16,7 @@ const TeamMemberCard = ({ teamMember }: TeamMemberCardProps) => {
       className="flex justify-end items-start w-full"
     >
       <div className="w-full md:w-1/2">
-        <hr className="border-t border-gray-300 my-6 pb-6" />
+        <hr className="border-t border-gray-100 my-6 pb-6" />
 
         <div className="space-y-6 text-lg leading-relaxed text-foreground">
           {teamMember.bio.map((paragraph, index) => (

--- a/frontend/src/app/[locale]/who-we-are/components/values-card.tsx
+++ b/frontend/src/app/[locale]/who-we-are/components/values-card.tsx
@@ -53,7 +53,7 @@ const ValuesCard = () => {
     <div>
       <h2 className="text-4xl xl:text-6xl mb-0 xl:mb-36 font-light">Values</h2>
 
-      <div className="hidden xl:grid grid-cols-1 xl:grid-cols-3 gap-[180px]">
+      <div className="hidden xl:grid grid-cols-1 xl:grid-cols-3 gap-8">
         {valuesSections.map((section, sectionIndex) => (
           <div key={sectionIndex} className="flex flex-col">
             <div className="h-full flex flex-col gap-16 md:gap-20">
@@ -79,10 +79,8 @@ const ValuesCard = () => {
             <div key={sectionIndex} className="space-y-8">
               {section.items.map((item, itemIndex) => (
                 <div key={itemIndex}>
-                  <h4 className="text-lg md:text-xl font-light mb-3">
-                    {item.title}
-                  </h4>
-                  <p className="text-muted-foreground leading-relaxed text-sm md:text-base">
+                  <h4 className="text-lg md:text-xl mb-3">{item.title}</h4>
+                  <p className="font-light leading-relaxed text-base md:text-base">
                     {item.description}
                   </p>
                 </div>
@@ -95,8 +93,8 @@ const ValuesCard = () => {
   );
 
   return (
-    <div className="mx-auto px-4 sm:px-6 lg:px-8">
-      <Card className="relative p-8 md:p-14 lg:p-36">
+    <div className="">
+      <Card className="p-8 md:p-14 lg:p-36">
         <CardContent className="p-0">{valuesContent}</CardContent>
       </Card>
     </div>

--- a/frontend/src/app/[locale]/who-we-are/page.test.tsx
+++ b/frontend/src/app/[locale]/who-we-are/page.test.tsx
@@ -50,15 +50,11 @@ describe('WhoWeArePage', () => {
   it('has proper layout structure', () => {
     const { container } = renderWithNextIntl(<WhoWeArePage />);
 
-    // Check for ScrollShrinkWrapper
-    expect(screen.getByTestId('scroll-shrink-wrapper')).toBeInTheDocument();
-
     // Check for background styling
     expect(container.querySelector('.bg-secondary')).toBeInTheDocument();
 
     // Check for grid layout
     expect(container.querySelector('.grid-cols-1')).toBeInTheDocument();
-    expect(container.querySelector('.md\\:grid-cols-2')).toBeInTheDocument();
   });
 
   it('uses shadcn/ui Card components', () => {

--- a/frontend/src/app/[locale]/who-we-are/page.tsx
+++ b/frontend/src/app/[locale]/who-we-are/page.tsx
@@ -1,10 +1,8 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import React from 'react';
 import { useTranslations } from 'next-intl';
 import { PageHero } from '@/components/common';
 import { Card, CardContent } from '@/components/ui';
-import { ScrollShrinkWrapper } from '@/components/landing';
 import ValuesCard from './components/values-card';
 import { Metadata } from 'next';
 import { Disclaimer } from '@/components/common/disclaimer/disclaimer';
@@ -22,40 +20,34 @@ export default function WhoWeArePage() {
 
   return (
     <>
-      {/* Hero Section */}
       <PageHero title={t('title')} subtitle={t('subtitle')} />
-
-      {/* Mission, Vision, and Values Section */}
-      <ScrollShrinkWrapper>
-        <div className="w-full mb-32 rounded-2xl flex flex-col bg-secondary h-fit px-8 lg:px-16 py-16 lg:py-24">
-          {/* Mission and Vision Cards Section */}
-          <div className="mx-auto pb-4 px-4 sm:px-6 lg:px-8">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <Card className="relative p-8 md:p-14 lg:p-36 aspect-square">
-                <CardContent className="p-0 h-full flex flex-col justify-center">
-                  <h2 className="text-4xl xl:text-6xl font-light mb-12 lg:mb-24">
-                    {t('mission.title')}
-                  </h2>
-                  <p className="text-base xl:text-xl font-light">
-                    {t('mission.description')}
-                  </p>
-                </CardContent>
-              </Card>
-              <Card className="relative p-8 md:p-14 lg:p-36 aspect-square">
-                <CardContent className="p-0 h-full flex flex-col justify-center">
-                  <h2 className="text-4xl xl:text-6xl font-light mb-12 lg:mb-24">
-                    {t('vision.title')}
-                  </h2>
-                  <p className="text-base xl:text-xl font-light">
-                    {t('vision.description')}
-                  </p>
-                </CardContent>
-              </Card>
-            </div>
+      <div className="w-full mb-32 flex flex-col bg-secondary h-fit px-8 lg:px-16 py-16 lg:py-24">
+        <div className="flex flex-col gap-4 max-w-[900px] mx-auto">
+          <div className="flex lg:flex-row flex-col flex-wrap gap-4">
+            <Card className="lg:max-w-110">
+              <CardContent className="p-4 h-full flex flex-col justify-center">
+                <h2 className="text-4xl font-light md:mb-6 mb-4 lg:mb-14">
+                  {t('mission.title')}
+                </h2>
+                <p className="md:text-lg text-base font-light">
+                  {t('mission.description')}
+                </p>
+              </CardContent>
+            </Card>
+            <Card className="lg:max-w-110">
+              <CardContent className="p-4 h-full flex flex-col justify-center">
+                <h2 className="text-4xl font-light md:mb-6 mb-4 lg:mb-14">
+                  {t('vision.title')}
+                </h2>
+                <p className="md:text-lg text-base font-light">
+                  {t('vision.description')}
+                </p>
+              </CardContent>
+            </Card>
           </div>
           <ValuesCard />
         </div>
-      </ScrollShrinkWrapper>
+      </div>
       <Disclaimer translationLoc="whoWeAre.disclaimers" disclaimerCount={7} />
     </>
   );

--- a/frontend/src/components/common/news-card/news-card.tsx
+++ b/frontend/src/components/common/news-card/news-card.tsx
@@ -34,7 +34,7 @@ const NewsCard = ({
 }: NewsCardProps) => {
   return (
     <div
-      className={`text-foreground md:mr-4 max-w-150 px-1 py-4 font-light transition-colors duration-300 ${className}`}
+      className={`text-foreground max-w-150 px-1 py-4 font-light transition-colors duration-300 ${className}`}
     >
       <Link href={link} className="mb-16">
         <div className="rounded-xl bg-transparent">

--- a/frontend/src/components/landing/news-highlights/news-highlights.tsx
+++ b/frontend/src/components/landing/news-highlights/news-highlights.tsx
@@ -46,7 +46,7 @@ export default function NewsHighlights() {
         </FadeIn>
       ) : (
         <FadeIn>
-          <div className="mb-8 gap-8 mx-auto flex flex-row max-w-[95%] flex-wrap justify-center">
+          <div className="mb-8 gap-8 mx-auto items-center flex flex-row max-w-[95%] flex-wrap justify-center">
             {featuredNews.map((article) => (
               <NewsCard
                 key={article.slug.current}

--- a/frontend/src/components/landing/page/landing-page.tsx
+++ b/frontend/src/components/landing/page/landing-page.tsx
@@ -67,22 +67,21 @@ export default function LandingPage() {
   }, [detectTheme]);
 
   return (
-    <div className="mb-32">
-      <ScrollShrinkWrapper>
+    // Note the use of `sm:` and `stopWidth={640}`
+    <div className="mb-32 sm:max-w-232 sm:mx-auto sm:w-[80%]">
+      <ScrollShrinkWrapper stopWidth={640}>
         <div ref={heroRef} className="h-[40vh]">
           <Hero />
         </div>
         <motion.div
-          className="flex h-fit  mx-auto flex-col justify-center rounded-2xl bg-[#CCC5B5]"
+          className="flex h-fit pt-6 mx-auto flex-col justify-center rounded-2xl bg-[#CCC5B5]"
           animate={{
             backgroundColor: contextIsDark ? '#2A2727' : '#CCC5B5',
             color: contextIsDark ? '#FDFDFB' : '#2A2727',
           }}
           ref={newsCarouselRef}
         >
-          <div className="xl:max-w-400 max-w-200 mx-auto">
-            <NewsHighlights />
-          </div>
+          <NewsHighlights />
           <Quote isDark={contextIsDark} />
         </motion.div>
       </ScrollShrinkWrapper>

--- a/frontend/src/components/landing/scroll-shrink-wrapper/scroll-shrink-wrapper.test.tsx
+++ b/frontend/src/components/landing/scroll-shrink-wrapper/scroll-shrink-wrapper.test.tsx
@@ -35,7 +35,7 @@ describe('ScrollShrinkWrapper', () => {
 
   it('renders children within the wrapper', () => {
     render(
-      <ScrollShrinkWrapper>
+      <ScrollShrinkWrapper stopWidth={400}>
         <div data-testid="test-child">Test content</div>
         <span data-testid="another-child">Another element</span>
       </ScrollShrinkWrapper>

--- a/frontend/src/components/landing/scroll-shrink-wrapper/scroll-shrink-wrapper.tsx
+++ b/frontend/src/components/landing/scroll-shrink-wrapper/scroll-shrink-wrapper.tsx
@@ -4,6 +4,7 @@
 
 import React, { useRef } from 'react';
 import { useScroll, useTransform, motion } from 'framer-motion';
+import useWindowWidth from '@/lib/hooks/useWindowWidth';
 
 /**
  * Scroll shrink wrapper component
@@ -12,9 +13,18 @@ import { useScroll, useTransform, motion } from 'framer-motion';
  * - shrinks the width of the container as the user scrolls
  *
  * @param {React.ReactNode} children - The children to be wrapped
+ * @param {number} stopWidth - The width at witch this component should be disabled, in px. Defaults to 10,000px
  * @returns {JSX.Element} - The scroll shrink wrapper component
  */
-const ScrollShrinkWrapper = ({ children }: { children: React.ReactNode }) => {
+const ScrollShrinkWrapper = ({
+  children,
+  stopWidth = 10000,
+}: {
+  children: React.ReactNode;
+  stopWidth?: number;
+}) => {
+  const windowWidth = useWindowWidth();
+
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
@@ -25,6 +35,10 @@ const ScrollShrinkWrapper = ({ children }: { children: React.ReactNode }) => {
     [0, 0.15, 1],
     ['76vw', '100vw', '100vw']
   );
+
+  if ((windowWidth && windowWidth > stopWidth) || !windowWidth) {
+    return <div ref={containerRef}>{children}</div>;
+  }
 
   return (
     <div ref={containerRef} className="w-full">

--- a/frontend/src/lib/hooks/useWindowWidth.tsx
+++ b/frontend/src/lib/hooks/useWindowWidth.tsx
@@ -1,0 +1,26 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { useState, useEffect } from 'react';
+
+/**
+ * Helper hook for getting the width of the window. This hook is throttled to only be able to update `width` once every 100ms.
+ *
+ * @returns {number} - The width of the window*/
+export default function useWindowWidth() {
+  const [width, setWidth] = useState<number>();
+  useEffect(() => {
+    const handleResize = () =>
+      setTimeout(() => setWidth(window.innerWidth), 100);
+    window.addEventListener('resize', handleResize);
+
+    const helper = async () => {
+      setWidth(window.innerWidth);
+    };
+    helper();
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  });
+  return width;
+}


### PR DESCRIPTION
## Description

Fixes #336. Updates the `<ScrollShrinkWrapper>` component to only function when the screen is a certain size, and adds the `useCurrentWidth` hook to help with this functionality. This PR also updates a few pages to scale appropriately with the given modification, specifically:
- Landing page
- Investors/governance
- Who we are

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] Any components that you've modified are accessible.
- [ ] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
