### PR TITLE
fix(sanity): allow empty news content for off-site articles

### DIFF
--- a/sanity-studio/schemaTypes/news.ts
+++ b/sanity-studio/schemaTypes/news.ts
@@ -46,7 +46,7 @@ export default defineType({
 
           // If this is an off-site/external article, allow empty content.
           // Otherwise, require content.
-          const isExternal = Boolean(doc?.offSiteUrl)
+          const isExternal = doc?.offSiteUrl !== undefined
 
           if (isExternal) return true
 


### PR DESCRIPTION
## Description

Fixes #331 

With the current Sanity schema for news articles, content is always required, which leads to external articles (those that link out via offSiteUrl) needing placeholder text like n/a in order to publish.

This updates the news schema validation so that content is optional when an article is external, while still requiring content for standard on-site articles.


## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
