### PR TITLE
feat: add public inquiry server action

### DIFF
--- a/frontend/src/components/common/public-inquiry-modal/action.test.ts
+++ b/frontend/src/components/common/public-inquiry-modal/action.test.ts
@@ -65,10 +65,9 @@ describe('submitPublicInquiry', () => {
     expect(result.data).toBeNull();
     expect(result.error).toBeTruthy();
 
-    // action.ts now returns z.treeifyError(...) as `error`
-    expect(result.error).toHaveProperty('properties.name.errors');
-    expect(result.error.properties.name.errors[0]).toBe(
-      'Invalid input: expected string, received null'
+    // error is a ZodErrorTree
+    expect((result.error as any).properties?.name?.errors?.[0]).toBe(
+      'Name is required.'
     );
 
     expect(mocks.submitToGoogleSheets).not.toHaveBeenCalled();
@@ -86,10 +85,7 @@ describe('submitPublicInquiry', () => {
     const result = await submitPublicInquiry(fd);
 
     expect(result.data).toBeNull();
-    expect(result.error).toBeTruthy();
-
-    expect(result.error).toHaveProperty('properties.lastKnownEmail.errors');
-    expect(result.error.properties.lastKnownEmail.errors[0]).toBe(
+    expect((result.error as any).properties?.lastKnownEmail?.errors?.[0]).toBe(
       'Please enter a valid email.'
     );
 
@@ -108,10 +104,7 @@ describe('submitPublicInquiry', () => {
     const result = await submitPublicInquiry(fd);
 
     expect(result.data).toBeNull();
-    expect(result.error).toBeTruthy();
-
-    expect(result.error).toHaveProperty('properties.response.errors');
-    expect(result.error.properties.response.errors[0]).toBe(
+    expect((result.error as any).properties?.response?.errors?.[0]).toBe(
       'Response is too long (max 1500 characters).'
     );
 

--- a/frontend/src/components/common/public-inquiry-modal/action.ts
+++ b/frontend/src/components/common/public-inquiry-modal/action.ts
@@ -8,21 +8,23 @@ import type { ActionResponse } from '@/lib/types/action-response';
 import z from 'zod';
 import { publicInquirySchema } from './types';
 
+function getString(formData: FormData, key: string): string {
+  const v = formData.get(key);
+  return typeof v === 'string' ? v.trim() : '';
+}
+
 export async function submitPublicInquiry(
   formData: FormData
 ): Promise<ActionResponse> {
   const raw = {
-    name: formData.get('name'),
-    lastKnownEmail: formData.get('lastKnownEmail'),
-    response: formData.get('response'),
+    name: getString(formData, 'name'),
+    lastKnownEmail: getString(formData, 'lastKnownEmail'),
+    response: getString(formData, 'response'),
   };
 
   const validated = publicInquirySchema.safeParse(raw);
   if (!validated.success) {
-    return {
-      data: null,
-      error: z.treeifyError(validated.error),
-    };
+    return { error: z.treeifyError(validated.error), data: null };
   }
 
   const scriptUrl = process.env.CONTACT_GOOGLE_SCRIPT_URL;
@@ -34,7 +36,7 @@ export async function submitPublicInquiry(
   }
 
   try {
-    // Validated → safe to submit original formData
+    // Per review: if we validated successfully, just submit the original formData
     await submitToGoogleSheets(formData, scriptUrl);
     return { error: null, data: null };
   } catch (err) {

--- a/frontend/src/components/common/public-inquiry-modal/types.ts
+++ b/frontend/src/components/common/public-inquiry-modal/types.ts
@@ -8,17 +8,13 @@ export const publicInquirySchema = z.object({
     .trim()
     .min(1, 'Name is required.')
     .max(200, 'Name is too long.'),
-
   lastKnownEmail: z
     .string()
-    .trim()
     .min(1, 'Email is required.')
     .email('Please enter a valid email.')
     .max(320, 'Email is too long.'),
-
   response: z
     .string()
-    .trim()
     .min(1, 'Response is required.')
     .max(1500, 'Response is too long (max 1500 characters).'),
 });


### PR DESCRIPTION
## Description

Added a new server action for the Public Inquiry Modal that submits optional user input to Google Sheets. The action follows existing patterns in the codebase and reuses the pre-existing Google Sheets helper

Fixes #364 

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
