### PR TITLE
style: update footer typography and global underline styles

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -218,7 +218,7 @@ header {
   bottom: 0;
   left: 50%;
   width: 0;
-  height: 2px;
+  height: 1px;
   background-color: currentColor;
   transition: all 0.3s ease-in-out;
   transform: translateX(-50%);
@@ -259,7 +259,7 @@ header {
   border-bottom-width: 0;
   background-image:
     linear-gradient(transparent, transparent), linear-gradient(#fff, #fff);
-  background-size: 0 2px;
+  background-size: 0 1px;
   background-position: 0 100%;
   background-repeat: no-repeat;
   transition: background-size 0.5s ease-in-out;
@@ -271,6 +271,6 @@ header {
 }
 
 .text-underline-left:hover {
-  background-size: 100% 3px;
+  background-size: 100% 1px;
   background-position: 0 100%;
 }

--- a/frontend/src/components/common/cookie-preferences-modal/cookie-preferences-modal.tsx
+++ b/frontend/src/components/common/cookie-preferences-modal/cookie-preferences-modal.tsx
@@ -42,7 +42,7 @@ export default function CookiePreferencesModal({
       <DialogTrigger asChild>
         {trigger ? (
           <Button
-            className="m-0 h-min p-0 text-base hover:cursor-pointer"
+            className="m-0 h-min w-auto !justify-start p-0 text-base font-light hover:cursor-pointer"
             onClick={() => setIsOpen(true)}
             asChild
           >

--- a/frontend/src/components/landing/footer/footer.tsx
+++ b/frontend/src/components/landing/footer/footer.tsx
@@ -66,17 +66,17 @@ const Footer = () => {
   ];
 
   return (
-    <footer className="bg-background text-foreground mt-8 mb-8 px-4 py-10 sm:mb-0 md:px-6 lg:px-12 xl:px-18">
+    <footer className="bg-background text-foreground font-light mt-8 mb-8 px-4 py-10 sm:mb-0 md:px-6 lg:px-12 xl:px-18">
       <div className="flex flex-col md:flex-row">
         <div className="flex w-full flex-col justify-between md:mb-16 md:flex-row">
-          <ToddHeader className="md:text-5xl lg:text-6xl" />
+          <ToddHeader className="md:text-4xl lg:text-5xl" />
           <div className="flex flex-row gap-32 max-md:mt-8 md:ml-auto">
             <div className="flex flex-col gap-4">
               {siteLinks.slice(0, 4).map((val, index) => (
                 <Link
                   key={index}
                   href={val.href}
-                  className="text-md md:text-lg"
+                  className="text-base md:text-base"
                 >
                   <span className="link text-underline-left text-underline-left-black text-black">
                     {val.label}
@@ -89,7 +89,7 @@ const Footer = () => {
                 <Link
                   key={index}
                   href={val.href}
-                  className="text-md md:text-lg"
+                  className="text-base md:text-base"
                 >
                   <span className="link text-underline-left text-underline-left-black text-black">
                     {val.label}
@@ -113,7 +113,7 @@ const Footer = () => {
           <span>{t('location')}</span>
         </div>
         <p>© Todd Agriscience 2025</p>
-        <div className="flex flex-col flex-wrap gap-6 md:flex-row">
+        <div className="flex flex-col flex-wrap gap-6 items-start md:flex-row">
           {legalLinks.map((val, index) => (
             <Link key={index} href={val.href}>
               {val.label}
@@ -121,7 +121,7 @@ const Footer = () => {
           ))}
           <CookiePreferencesModal
             trigger={
-              <div>
+              <div className="flex items-center gap-2">
                 <span>{tCookiePreferences('managePreferences')}</span>
                 <Image
                   alt=""


### PR DESCRIPTION
- Change footer font weight from 400 to 300 (light) for all footer text
- Reduce footer wordmark size on desktop (md:text-4xl lg:text-5xl)
- Reduce footer navigation link size on desktop (md:text-base)
- Keep mobile text sizes unchanged
- Move 'Your Privacy Choices' to legal links section
- Reduce underline weight from 2-3px to 1px globally (header and footer)
- Apply lighter underline style across entire site for consistency

## Description

Fixes #{issue number}

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] Any components that you've modified are accessible.
- [ ] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
