### PR TITLE
feat(auth): combine signup confirmation with sign-in redirect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
-## Commit/Push Workflow
-- Before any commit or push flow that uses `--no-verify`, automatically run: `cd frontend && rm -rf .next && bun i`.
-- If that command fails because of sandbox or permissions, rerun it with elevated permissions.
-- If `git add`/`git commit` fails with `.git/index.lock` permission errors in sandbox, rerun the same git command with elevated permissions.
-- If `git push` fails in sandbox with GitHub host/network resolution errors, rerun the push with elevated permissions.
+## Creating an issue via GitHub's MCP
+
+- If you see "make an issue" or something similar, it's time to make an issue. The following is the workflow:
+- Use the feature or bug template found in the `.github` folder, depending on the request of the user
+
+## Making a pull request via GitHub's MCP
+
+- If you see "make a PR" or something similar, it's time to make a PR. The following is the workflow
+- Add files with `git add .`
+- Ask for user review/QA testing
+- If an only if the user approves, run `bun run validate` inside of the `./frontend` folder
+- Commit the files in conventional commit format with `git commit -m`
+- Push the files with `git push`
+- Make a pull request. Don't request a review from anyone, but fill out all of the other attributes. Use the pull request template found in the `.github` folder.
+- Link the pull request to the user

--- a/frontend/src/app/(unauthenticated)/auth/confirm/route.ts
+++ b/frontend/src/app/(unauthenticated)/auth/confirm/route.ts
@@ -14,7 +14,13 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const token_hash = searchParams.get('token_hash');
   const type = searchParams.get('type') as EmailOtpType | null;
-  const next = searchParams.get('next') ?? '/';
+  const requestedNext = searchParams.get('next');
+  const next =
+    requestedNext &&
+    requestedNext.startsWith('/') &&
+    !requestedNext.startsWith('//')
+      ? requestedNext
+      : '/';
   const redirectTo = request.nextUrl.clone();
   redirectTo.pathname = next;
 

--- a/frontend/src/lib/auth-server.ts
+++ b/frontend/src/lib/auth-server.ts
@@ -59,11 +59,15 @@ export async function signUpUser(
   name: string
 ): Promise<object | Error> {
   const supabase = await createServerClient();
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL?.replace(/\/+$/, '') ??
+    'https://toddagriscience.com';
+
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
     options: {
-      emailRedirectTo: 'https://toddagriscience.com/login',
+      emailRedirectTo: `${baseUrl}/auth/confirm?next=/`,
       data: {
         // This is for the email template
         first_name: name,

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -241,7 +241,7 @@ describe('signUpUser', () => {
       email: 'test@example.com',
       password: 'securePassword123',
       options: {
-        emailRedirectTo: 'https://toddagriscience.com/login',
+        emailRedirectTo: 'https://toddagriscience.com/auth/confirm?next=/',
         data: {
           first_name: 'Oscar',
           name: 'Oscar',
@@ -286,7 +286,7 @@ describe('signUpUser', () => {
       email: 'john@example.com',
       password: 'password123',
       options: {
-        emailRedirectTo: 'https://toddagriscience.com/login',
+        emailRedirectTo: 'https://toddagriscience.com/auth/confirm?next=/',
         data: {
           name: 'John Doe',
           first_name: 'John Doe',


### PR DESCRIPTION
## Description

Fixes #392 

This update combines email confirmation and sign-in so new users can complete onboarding in a single click from the confirmation email.

- Updates signup `emailRedirectTo` to `/auth/confirm?next=/`.
- Keeps session exchange in `/auth/confirm` using `verifyOtp` and redirects to dashboard by default.
- Adds redirect sanitization in `/auth/confirm` so `next` only accepts safe internal paths.
- Updates auth unit tests for the new redirect behavior.
- Includes AGENTS.md updates requested in this thread.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate