### PR TITLE
chore: update workflow for migration to staging database

### DIFF
--- a/.github/workflows/pr-database-compatibility-check.yml
+++ b/.github/workflows/pr-database-compatibility-check.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/update-workflow-for-migration-to-staging-database
-  workflow_dispatch:
 
 jobs:
   staging-db-push-dry-run:
@@ -85,5 +83,6 @@ jobs:
         id: push-check
         run: bunx drizzle-kit push --config=drizzle-local.config.ts
 
+        # we are using push instead of generate -> migrate because drizzle-kit is scuffed at the moment when it comes to making enums for some reason
       - name: Push to staging if successful
         run: bunx drizzle-kit push --config=drizzle-staging.config.ts


### PR DESCRIPTION
## Description

Fixes #731

Adds a pull request workflow that:
- Clones the current staging database into an ephemeral local Postgres service
- Runs `drizzle-kit push` with PR schema changes against that cloned DB
- Fails the check and requires manual review when the push fails

Please review and run QA testing on this PR.