### PR TITLE
Fix add-widget button after widget removal

### DIFF
--- a/frontend/src/components/common/widgets/actions.test.ts
+++ b/frontend/src/components/common/widgets/actions.test.ts
@@ -1,0 +1,122 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import {
+  createWidget,
+  deleteWidget,
+  updateWidget,
+} from '@/components/common/widgets/actions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockDelete,
+  mockDeleteWhere,
+  mockGetAuthenticatedInfo,
+  mockInsert,
+  mockInsertReturning,
+  mockInsertValues,
+  mockLoggerError,
+  mockRevalidatePath,
+  mockUpdate,
+  mockUpdateSet,
+  mockUpdateWhere,
+} = vi.hoisted(() => {
+  const mockInsertReturning = vi.fn();
+  const mockInsertValues = vi.fn(() => ({
+    returning: mockInsertReturning,
+  }));
+  const mockInsert = vi.fn(() => ({
+    values: mockInsertValues,
+  }));
+
+  const mockDeleteWhere = vi.fn();
+  const mockDelete = vi.fn(() => ({
+    where: mockDeleteWhere,
+  }));
+
+  const mockUpdateWhere = vi.fn();
+  const mockUpdateSet = vi.fn(() => ({
+    where: mockUpdateWhere,
+  }));
+  const mockUpdate = vi.fn(() => ({
+    set: mockUpdateSet,
+  }));
+
+  return {
+    mockDelete,
+    mockDeleteWhere,
+    mockGetAuthenticatedInfo: vi.fn(),
+    mockInsert,
+    mockInsertReturning,
+    mockInsertValues,
+    mockLoggerError: vi.fn(),
+    mockRevalidatePath: vi.fn(),
+    mockUpdate,
+    mockUpdateSet,
+    mockUpdateWhere,
+  };
+});
+
+vi.mock('@/lib/db/schema/connection', () => ({
+  db: {
+    insert: mockInsert,
+    delete: mockDelete,
+    update: mockUpdate,
+  },
+}));
+
+vi.mock('@/lib/utils/get-authenticated-info', () => ({
+  getAuthenticatedInfo: mockGetAuthenticatedInfo,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: mockRevalidatePath,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: {
+    error: mockLoggerError,
+  },
+}));
+
+describe('widgets actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuthenticatedInfo.mockResolvedValue({
+      id: 1,
+      farmId: 1,
+    });
+    mockInsertReturning.mockResolvedValue([{ id: 123 }]);
+    mockDeleteWhere.mockResolvedValue(undefined);
+    mockUpdateWhere.mockResolvedValue(undefined);
+  });
+
+  it('revalidates the dashboard after creating a widget', async () => {
+    const result = await createWidget({
+      managementZoneId: 7,
+      name: 'Macro Radar',
+    });
+
+    expect(result).toEqual({ data: { widgetId: 123 } });
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/');
+  });
+
+  it('revalidates the dashboard after deleting a widget', async () => {
+    const result = await deleteWidget(42);
+
+    expect(result).toEqual({ error: null });
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/');
+  });
+
+  it('revalidates the dashboard after updating a widget', async () => {
+    const result = await updateWidget(7, 'Macro Radar', {
+      widgetMetadata: {
+        i: 'Macro Radar',
+        x: 0,
+        y: 1,
+      },
+    });
+
+    expect(result).toEqual({ error: null });
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/');
+  });
+});

--- a/frontend/src/components/common/widgets/actions.ts
+++ b/frontend/src/components/common/widgets/actions.ts
@@ -9,7 +9,10 @@ import { ActionResponse } from '@/lib/types/action-response';
 import { WidgetUpdate } from '@/lib/types/db';
 import { getAuthenticatedInfo } from '@/lib/utils/get-authenticated-info';
 import { and, eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
 import { LayoutItem } from 'react-grid-layout';
+
+const dashboardPath = '/';
 
 /** Create a new widget for a given management zone.
  *
@@ -45,6 +48,8 @@ export async function createWidget({
       })
       .returning();
 
+    revalidatePath(dashboardPath);
+
     return { data: { widgetId: newWidget.id } };
   } catch (error) {
     logger.error(error);
@@ -64,6 +69,8 @@ export async function deleteWidget(widgetId: number): Promise<ActionResponse> {
     await getAuthenticatedInfo();
 
     await db.delete(widget).where(eq(widget.id, widgetId));
+
+    revalidatePath(dashboardPath);
 
     return { error: null };
   } catch (error) {
@@ -94,6 +101,8 @@ export async function updateWidget(
       .where(
         and(eq(widget.managementZone, managementZoneId), eq(widget.name, name))
       );
+
+    revalidatePath(dashboardPath);
 
     return { error: null };
   } catch (error) {


### PR DESCRIPTION
## Description

Fixes #719

Ensures widget create, update, and delete actions revalidate the dashboard so widget changes are reflected immediately after mutation. Adds unit tests covering dashboard revalidation for widget mutations.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate