### PR TITLE
fix(frontend): enforce farm edit permissions by role

### DIFF
--- a/frontend/src/app/(authenticated)/(accounts)/account/(with-shell)/management-zones/[zone]/actions.ts
+++ b/frontend/src/app/(authenticated)/(accounts)/account/(with-shell)/management-zones/[zone]/actions.ts
@@ -7,6 +7,7 @@ import { db } from '@/lib/db/schema/connection';
 import logger from '@/lib/logger';
 import { ActionResponse } from '@/lib/types/action-response';
 import type { ManagementZoneInsert } from '@/lib/types/db';
+import { assertCanEditFarm } from '@/lib/utils/farm-rbac';
 import { getAuthenticatedInfo } from '@/lib/utils/get-authenticated-info';
 import { and, eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
@@ -25,6 +26,8 @@ export async function updateManagementZone(
     if (!currentUser.farmId) {
       return { error: 'User is not associated with a farm' };
     }
+
+    assertCanEditFarm(currentUser, 'update-management-zone');
 
     await db
       .update(managementZone)

--- a/frontend/src/app/(authenticated)/(accounts)/account/(with-shell)/management-zones/[zone]/management-zone-form.tsx
+++ b/frontend/src/app/(authenticated)/(accounts)/account/(with-shell)/management-zones/[zone]/management-zone-form.tsx
@@ -18,8 +18,10 @@ import { updateManagementZone } from './actions';
 
 export default function ManagementZoneForm({
   zone,
+  canEdit,
 }: {
   zone: ManagementZoneSelect;
+  canEdit: boolean;
 }) {
   const {
     register,
@@ -50,6 +52,12 @@ export default function ManagementZoneForm({
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      {!canEdit && (
+        <p className="rounded-md border border-amber-400/60 bg-amber-50 p-3 text-sm text-amber-800">
+          Your account is read only. Only administrators can edit management
+          zone details.
+        </p>
+      )}
       <div>
         <Label
           htmlFor="name"
@@ -60,6 +68,7 @@ export default function ManagementZoneForm({
         <Input
           className="w-full rounded-md border-[#848484]/80 border-1 bg-transparent text-muted-foreground/70 font-thin"
           id="name"
+          disabled={!canEdit}
           {...register('name')}
         />
       </div>
@@ -77,6 +86,7 @@ export default function ManagementZoneForm({
             id="latitude"
             type="number"
             step="any"
+            disabled={!canEdit}
             {...register('location.0')}
           />
         </div>
@@ -92,6 +102,7 @@ export default function ManagementZoneForm({
             id="longitude"
             type="number"
             step="any"
+            disabled={!canEdit}
             {...register('location.1')}
           />
         </div>
@@ -109,6 +120,7 @@ export default function ManagementZoneForm({
             className="w-full rounded-md border-[#848484]/80 border-1 bg-transparent text-muted-foreground/70 font-thin"
             id="rotationYear"
             type="date"
+            disabled={!canEdit}
             {...register('rotationYear', { valueAsDate: true })}
             defaultValue={zone.rotationYear?.toISOString().split('T')[0]}
           />
@@ -124,6 +136,7 @@ export default function ManagementZoneForm({
             className="w-full rounded-md border-[#848484]/80 border-1 bg-transparent text-muted-foreground/70 font-thin"
             id="npkLastUsed"
             type="date"
+            disabled={!canEdit}
             {...register('npkLastUsed', {
               valueAsDate: true,
             })}
@@ -137,34 +150,46 @@ export default function ManagementZoneForm({
           className="flex items-center gap-2 text-sm leading-tight"
           htmlFor="npk"
         >
-          <Checkbox id="npk" {...register('npk')} />
+          <Checkbox id="npk" disabled={!canEdit} {...register('npk')} />
           NPK in use
         </Label>
         <Label
           className="flex items-center gap-2 text-sm leading-tight"
           htmlFor="irrigation"
         >
-          <Checkbox id="irrigation" {...register('irrigation')} />
+          <Checkbox
+            id="irrigation"
+            disabled={!canEdit}
+            {...register('irrigation')}
+          />
           Irrigation
         </Label>
         <Label
           className="flex items-center gap-2 text-sm leading-tight"
           htmlFor="waterConservation"
         >
-          <Checkbox id="waterConservation" {...register('waterConservation')} />
+          <Checkbox
+            id="waterConservation"
+            disabled={!canEdit}
+            {...register('waterConservation')}
+          />
           Water conservation
         </Label>
       </div>
 
       <div className="flex w-full flex-row items-center justify-between mt-12">
-        <Button
-          variant="brand"
-          type="submit"
-          disabled={isSubmitting}
-          className="rounded-full h-11 w-[144px] disabled:opacity-50"
-        >
-          {isSubmitting ? 'Saving...' : 'Save'}
-        </Button>
+        {canEdit ? (
+          <Button
+            variant="brand"
+            type="submit"
+            disabled={isSubmitting}
+            className="rounded-full h-11 w-[144px] disabled:opacity-50"
+          >
+            {isSubmitting ? 'Saving...' : 'Save'}
+          </Button>
+        ) : (
+          <div />
+        )}
         <div className="flex flex-row items-center gap-4">
           {errors.root && errors.root.message && (
             <div className="space-y-1">

--- a/frontend/src/app/(authenticated)/(accounts)/account/(with-shell)/management-zones/[zone]/page.tsx
+++ b/frontend/src/app/(authenticated)/(accounts)/account/(with-shell)/management-zones/[zone]/page.tsx
@@ -40,9 +40,16 @@ export default async function ManagementZonePage({
   return (
     <AccountInfo
       title={curManagementZone.name ?? 'Unnamed zone'}
-      description="Edit management zone details."
+      description={
+        currentUser.role === 'Admin'
+          ? 'Edit management zone details.'
+          : 'View management zone details.'
+      }
     >
-      <ManagementZoneForm zone={curManagementZone} />
+      <ManagementZoneForm
+        zone={curManagementZone}
+        canEdit={currentUser.role === 'Admin'}
+      />
     </AccountInfo>
   );
 }

--- a/frontend/src/app/(authenticated)/(misc)/apply/actions.test.ts
+++ b/frontend/src/app/(authenticated)/(misc)/apply/actions.test.ts
@@ -1,10 +1,12 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import { FarmInfoInternalApplicationInsert } from '@/lib/types/db';
+import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   inviteUserToFarm,
   saveApplication,
+  saveGeneralBusinessInformation,
   submitApplication,
 } from './actions';
 
@@ -40,8 +42,8 @@ vi.mock('@/lib/auth-server', async () => {
   };
 });
 
-const { db, mockSubmitToGoogleSheets, testUserEmail } = await vi.hoisted(
-  async () => {
+const { db, mockSubmitToGoogleSheets, testUserEmail, userTable } =
+  await vi.hoisted(async () => {
     // Polyfill for PGlite
     Blob.prototype.arrayBuffer = function () {
       return new Promise((resolve) => {
@@ -108,9 +110,9 @@ const { db, mockSubmitToGoogleSheets, testUserEmail } = await vi.hoisted(
       db,
       mockSubmitToGoogleSheets,
       testUserEmail,
+      userTable: user,
     };
-  }
-);
+  });
 
 vi.mock('@/lib/db/schema/connection', async (importOriginal) => {
   return {
@@ -128,6 +130,13 @@ vi.mock('next/headers', () => {
         ['host', 'localhost:3000'],
       ]),
   };
+});
+
+beforeEach(async () => {
+  await db
+    .update(userTable)
+    .set({ role: 'Admin' })
+    .where(eq(userTable.email, testUserEmail));
 });
 
 describe('saveApplication', () => {
@@ -166,6 +175,47 @@ describe('saveApplication', () => {
     const result = await saveApplication({ farmId: 1 });
     expect(result.error).not.toBeNull();
   });
+
+  it('returns an authorization error for viewers', async () => {
+    mockGetClaims.mockReturnValue({
+      data: { claims: { email: testUserEmail } },
+      error: null,
+    });
+
+    await db
+      .update(userTable)
+      .set({ role: 'Viewer' })
+      .where(eq(userTable.email, testUserEmail));
+
+    const result = await saveApplication({ farmId: 1 });
+
+    expect(result.error).toBe(
+      'You do not have permission to edit farm information'
+    );
+  });
+});
+
+describe('saveGeneralBusinessInformation', () => {
+  it('returns an authorization error for viewers', async () => {
+    mockGetClaims.mockReturnValue({
+      data: { claims: { email: testUserEmail } },
+      error: null,
+    });
+
+    await db
+      .update(userTable)
+      .set({ role: 'Viewer' })
+      .where(eq(userTable.email, testUserEmail));
+
+    const result = await saveGeneralBusinessInformation({
+      farmId: 1,
+      businessName: 'Viewer Farm',
+    });
+
+    expect(result.error).toBe(
+      'You do not have permission to edit farm information'
+    );
+  });
 });
 
 describe('sendApplicationToGoogleSheets', () => {
@@ -189,6 +239,10 @@ describe('sendApplicationToGoogleSheets', () => {
 describe('inviteUserToFarm', () => {
   afterEach(async () => {
     mockInviteUser.mockReset();
+    await db
+      .update(userTable)
+      .set({ role: 'Admin' })
+      .where(eq(userTable.email, testUserEmail));
   });
 
   /** Creates valid UserInsert data that matches the user schema from Drizzle */
@@ -305,5 +359,24 @@ describe('inviteUserToFarm', () => {
     const result = await inviteUserToFarm(userData);
 
     expect(result.error).not.toBeNull();
+  });
+
+  it('returns an authorization error for viewers', async () => {
+    mockGetClaims.mockReturnValue({
+      data: { claims: { email: testUserEmail } },
+      error: null,
+    });
+
+    await db
+      .update(userTable)
+      .set({ role: 'Viewer' })
+      .where(eq(userTable.email, testUserEmail));
+
+    const result = await inviteUserToFarm(createValidUserData());
+
+    expect(result.error).toBe(
+      'You do not have permission to edit farm information'
+    );
+    expect(mockInviteUser).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/(authenticated)/(misc)/apply/actions.ts
+++ b/frontend/src/app/(authenticated)/(misc)/apply/actions.ts
@@ -24,6 +24,7 @@ import {
   FarmLocationInsert,
   UserInsert,
 } from '@/lib/types/db';
+import { assertCanEditFarm } from '@/lib/utils/farm-rbac';
 import { getAuthenticatedInfo } from '@/lib/utils/get-authenticated-info';
 import {
   farmInfoInternalApplicationInsertSchema,
@@ -48,12 +49,14 @@ export async function saveGeneralBusinessInformation(
   formData: GeneralBusinessInformationInsert
 ) {
   try {
-    const result = await getAuthenticatedInfo();
-    const farmId = result.farmId;
+    const currentUser = await getAuthenticatedInfo();
+    const farmId = currentUser.farmId;
 
     if (!farmId) {
       return { error: 'User is not associated with a farm' };
     }
+
+    assertCanEditFarm(currentUser, 'save-general-business-information');
 
     const validated = generalBusinessInformationInsertSchema.safeParse({
       ...formData,
@@ -137,12 +140,14 @@ export async function saveApplication(
   formData: FarmInfoInternalApplicationInsert
 ): Promise<ActionResponse> {
   try {
-    const result = await getAuthenticatedInfo();
-    const farmId = result.farmId;
+    const currentUser = await getAuthenticatedInfo();
+    const farmId = currentUser.farmId;
 
     if (!farmId) {
       return { error: 'User is not associated with a farm' };
     }
+
+    assertCanEditFarm(currentUser, 'save-application');
 
     const validated = farmInfoInternalApplicationInsertSchema
       .omit({
@@ -200,6 +205,8 @@ export async function submitApplication(): Promise<ActionResponse> {
       return { error: 'User is not associated with a farm' };
     }
 
+    assertCanEditFarm(result, 'submit-application');
+
     const canSubmit = await isApplicationReadyForSubmission(farmId);
     if (!canSubmit) {
       return {
@@ -235,6 +242,11 @@ export async function createStripeSubscriptionCheckoutSession(): Promise<ActionR
     const stripe = getStripeClient();
     const currentUser = await getAuthenticatedInfo();
     const farmId = currentUser.farmId;
+
+    assertCanEditFarm(
+      currentUser,
+      'create-stripe-subscription-checkout-session'
+    );
 
     const [currentFarm] = await db
       .select({
@@ -344,12 +356,14 @@ export async function inviteUserToFarm(
   formData: UserInsert
 ): Promise<ActionResponse> {
   try {
-    const result = await getAuthenticatedInfo();
-    const farmId = result.farmId;
+    const currentUser = await getAuthenticatedInfo();
+    const farmId = currentUser.farmId;
 
     if (!farmId) {
       return { error: 'User is not associated with a farm' };
     }
+
+    assertCanEditFarm(currentUser, 'invite-user-to-farm');
 
     // Multiple admins aren't allowed
     const [doesAdminExist] = await db

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/application-tabs.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/application-tabs.tsx
@@ -32,6 +32,7 @@ export const ApplicationContext = createContext({
   invitedUserVerificationStatus: [{} as VerificationStatus],
   setCurrentTab: (_tab: TabTypes) => {},
   canSubmitApplication: false,
+  canEditFarm: false,
 });
 
 /** The tabs for the application */
@@ -56,6 +57,7 @@ export default function ApplicationTabs({
   const hasActiveSubscription = ['active', 'trialing'].includes(
     farmSubscription?.status ?? ''
   );
+  const canEditFarm = currentUser.role === 'Admin';
 
   useEffect(() => {
     async function helper() {
@@ -77,9 +79,16 @@ export default function ApplicationTabs({
         invitedUserVerificationStatus,
         setCurrentTab,
         canSubmitApplication,
+        canEditFarm,
       }}
     >
       <Tabs defaultValue="general" value={currentTab}>
+        {!canEditFarm && (
+          <p className="mt-6 rounded-md border border-amber-400/60 bg-amber-50 p-3 text-sm text-amber-800">
+            Your account is read only. Only administrators can edit farm
+            information or submit the application.
+          </p>
+        )}
         <TabsList className="flex h-auto flex-wrap items-center justify-start gap-3 bg-transparent max-md:mt-6">
           <TabsTrigger onClick={() => setCurrentTab('general')} value="general">
             General Business Information

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/colleagues.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/colleagues.tsx
@@ -26,8 +26,6 @@ import { Button } from '@/components/ui';
 import SelfSelectAdmin from './colleagues/self-select-admin';
 import { formatActionResponseErrors } from '@/lib/utils/actions';
 import { ApplicationContext } from './application-tabs';
-import { resendVerificationEmail } from './colleagues/action';
-import { RefreshCw } from 'lucide-react';
 import InvitedUser from './colleagues/invited-user';
 
 const userRoles = userRoleEnum.enumValues;
@@ -51,6 +49,7 @@ export default function Colleagues() {
     allUsers,
     invitedUserVerificationStatus,
     setCurrentTab,
+    canEditFarm,
   } = useContext(ApplicationContext);
 
   const [users, setUsers] = useState(allUsers);
@@ -106,6 +105,7 @@ export default function Colleagues() {
                   invitedUser={singleUser}
                   isCurrentUser={singleUser.id === currentUser.id}
                   isVerified={isVerified(singleUser)}
+                  canEditFarm={canEditFarm}
                   key={index}
                   onUninvited={(id) =>
                     setUsers(users.filter((u) => u.id !== id))
@@ -119,209 +119,220 @@ export default function Colleagues() {
             </p>
           )}
         </div>
-        <SelfSelectAdmin role={currentUser.role} />
+        <SelfSelectAdmin role={currentUser.role} canEditFarm={canEditFarm} />
 
-        <h2 className="mb-4 text-lg font-semibold">Invite a New Team Member</h2>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <FieldSet className="flex flex-col gap-6">
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Field>
-                <div className="flex flex-row justify-between">
-                  <FieldLabel>First Name</FieldLabel>
-                  <ErrorMessage
-                    errors={errors}
-                    name="firstName"
-                    render={({ message }) => (
-                      <FormErrorMessage errorMessage={message} />
+        {canEditFarm ? (
+          <>
+            <h2 className="mb-4 text-lg font-semibold">
+              Invite a New Team Member
+            </h2>
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <FieldSet className="flex flex-col gap-6">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <Field>
+                    <div className="flex flex-row justify-between">
+                      <FieldLabel>First Name</FieldLabel>
+                      <ErrorMessage
+                        errors={errors}
+                        name="firstName"
+                        render={({ message }) => (
+                          <FormErrorMessage errorMessage={message} />
+                        )}
+                      />
+                    </div>
+                    <Input
+                      type="text"
+                      placeholder="First name"
+                      {...register('firstName')}
+                    />
+                  </Field>
+
+                  <Field>
+                    <div className="flex flex-row justify-between">
+                      <FieldLabel>Last Name</FieldLabel>
+                      <ErrorMessage
+                        errors={errors}
+                        name="lastName"
+                        render={({ message }) => (
+                          <FormErrorMessage errorMessage={message} />
+                        )}
+                      />
+                    </div>
+                    <Input
+                      type="text"
+                      placeholder="Last name"
+                      {...register('lastName')}
+                    />
+                  </Field>
+                </div>
+
+                <Field>
+                  <div className="flex flex-row justify-between">
+                    <FieldLabel>Email</FieldLabel>
+                    <ErrorMessage
+                      errors={errors}
+                      name="email"
+                      render={({ message }) => (
+                        <FormErrorMessage errorMessage={message} />
+                      )}
+                    />
+                  </div>
+                  <Input
+                    type="email"
+                    placeholder="colleague@example.com"
+                    {...register('email')}
+                  />
+                </Field>
+
+                <Field>
+                  <div className="flex flex-row justify-between">
+                    <FieldLabel>Phone (optional)</FieldLabel>
+                    <ErrorMessage
+                      errors={errors}
+                      name="phone"
+                      render={({ message }) => (
+                        <FormErrorMessage errorMessage={message} />
+                      )}
+                    />
+                  </div>
+                  <Input
+                    type="tel"
+                    placeholder="+1234567890"
+                    {...register('phone')}
+                  />
+                </Field>
+
+                <Field>
+                  <div className="flex flex-row justify-between">
+                    <FieldLabel>Job Title (optional)</FieldLabel>
+                    <ErrorMessage
+                      errors={errors}
+                      name="job"
+                      render={({ message }) => (
+                        <FormErrorMessage errorMessage={message} />
+                      )}
+                    />
+                  </div>
+                  <Input
+                    type="text"
+                    placeholder="e.g., Farm Manager"
+                    {...register('job')}
+                  />
+                </Field>
+
+                <Field>
+                  <div className="flex flex-row justify-between">
+                    <FieldLabel>Role</FieldLabel>
+                    <ErrorMessage
+                      errors={errors}
+                      name="role"
+                      render={({ message }) => (
+                        <FormErrorMessage errorMessage={message} />
+                      )}
+                    />
+                  </div>
+                  <Controller
+                    name="role"
+                    control={control}
+                    render={({ field }) => (
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value || ''}
+                      >
+                        <SelectTrigger className="rounded-md border px-3">
+                          <SelectValue placeholder="Select a role" />
+                        </SelectTrigger>
+                        <SelectContent className="bg-white">
+                          {userRolesWithDescription.map((role) => (
+                            <SelectItem key={role.role} value={role.role}>
+                              {role.role} - {role.description}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     )}
                   />
-                </div>
-                <Input
-                  type="text"
-                  placeholder="First name"
-                  {...register('firstName')}
-                />
-              </Field>
+                </Field>
 
-              <Field>
-                <div className="flex flex-row justify-between">
-                  <FieldLabel>Last Name</FieldLabel>
-                  <ErrorMessage
-                    errors={errors}
-                    name="lastName"
-                    render={({ message }) => (
-                      <FormErrorMessage errorMessage={message} />
-                    )}
-                  />
-                </div>
-                <Input
-                  type="text"
-                  placeholder="Last name"
-                  {...register('lastName')}
-                />
-              </Field>
-            </div>
-
-            <Field>
-              <div className="flex flex-row justify-between">
-                <FieldLabel>Email</FieldLabel>
-                <ErrorMessage
-                  errors={errors}
-                  name="email"
-                  render={({ message }) => (
-                    <FormErrorMessage errorMessage={message} />
-                  )}
-                />
-              </div>
-              <Input
-                type="email"
-                placeholder="colleague@example.com"
-                {...register('email')}
-              />
-            </Field>
-
-            <Field>
-              <div className="flex flex-row justify-between">
-                <FieldLabel>Phone (optional)</FieldLabel>
-                <ErrorMessage
-                  errors={errors}
-                  name="phone"
-                  render={({ message }) => (
-                    <FormErrorMessage errorMessage={message} />
-                  )}
-                />
-              </div>
-              <Input
-                type="tel"
-                placeholder="+1234567890"
-                {...register('phone')}
-              />
-            </Field>
-
-            <Field>
-              <div className="flex flex-row justify-between">
-                <FieldLabel>Job Title (optional)</FieldLabel>
-                <ErrorMessage
-                  errors={errors}
-                  name="job"
-                  render={({ message }) => (
-                    <FormErrorMessage errorMessage={message} />
-                  )}
-                />
-              </div>
-              <Input
-                type="text"
-                placeholder="e.g., Farm Manager"
-                {...register('job')}
-              />
-            </Field>
-
-            <Field>
-              <div className="flex flex-row justify-between">
-                <FieldLabel>Role</FieldLabel>
-                <ErrorMessage
-                  errors={errors}
-                  name="role"
-                  render={({ message }) => (
-                    <FormErrorMessage errorMessage={message} />
-                  )}
-                />
-              </div>
-              <Controller
-                name="role"
-                control={control}
-                render={({ field }) => (
-                  <Select
-                    onValueChange={field.onChange}
-                    value={field.value || ''}
-                  >
-                    <SelectTrigger className="rounded-md border px-3">
-                      <SelectValue placeholder="Select a role" />
-                    </SelectTrigger>
-                    <SelectContent className="bg-white">
-                      {userRolesWithDescription.map((role) => (
-                        <SelectItem key={role.role} value={role.role}>
-                          {role.role} - {role.description}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-            </Field>
-
-            <Field>
-              <div className="flex flex-row items-center gap-3">
-                <Controller
-                  name="didOwnAndControlParcel"
-                  control={control}
-                  render={({ field }) => (
-                    <Checkbox
-                      id="didOwnAndControlParcel"
-                      checked={field.value ?? false}
-                      onCheckedChange={field.onChange}
+                <Field>
+                  <div className="flex flex-row items-center gap-3">
+                    <Controller
+                      name="didOwnAndControlParcel"
+                      control={control}
+                      render={({ field }) => (
+                        <Checkbox
+                          id="didOwnAndControlParcel"
+                          checked={field.value ?? false}
+                          onCheckedChange={field.onChange}
+                        />
+                      )}
                     />
-                  )}
-                />
-                <FieldLabel htmlFor="didOwnAndControlParcel">
-                  This person owned and controlled the parcel for the past 3
-                  years
-                </FieldLabel>
-                <ErrorMessage
-                  errors={errors}
-                  name="didOwnAndControlParcel"
-                  render={({ message }) => (
-                    <FormErrorMessage errorMessage={message} />
-                  )}
-                />
-              </div>
-            </Field>
-
-            <Field>
-              <div className="flex flex-row items-center gap-3">
-                <Controller
-                  name="didManageAndControl"
-                  control={control}
-                  render={({ field }) => (
-                    <Checkbox
-                      id="didManageAndControl"
-                      checked={field.value ?? false}
-                      onCheckedChange={field.onChange}
+                    <FieldLabel htmlFor="didOwnAndControlParcel">
+                      This person owned and controlled the parcel for the past 3
+                      years
+                    </FieldLabel>
+                    <ErrorMessage
+                      errors={errors}
+                      name="didOwnAndControlParcel"
+                      render={({ message }) => (
+                        <FormErrorMessage errorMessage={message} />
+                      )}
                     />
-                  )}
-                />
-                <FieldLabel htmlFor="didManageAndControl">
-                  This person managed and controlled (but did not own) the
-                  parcel for the past 3 years
-                </FieldLabel>
-                <ErrorMessage
-                  errors={errors}
-                  name="didManageAndControl"
-                  render={({ message }) => (
-                    <FormErrorMessage errorMessage={message} />
-                  )}
-                />
-              </div>
-            </Field>
-          </FieldSet>
+                  </div>
+                </Field>
 
-          <div className="mt-10 flex flex-row gap-6">
-            <SubmitButton
-              buttonText="Invite team member"
-              className="basis-2/3"
-              reactHookFormPending={isSubmitting}
-            />
-            <Button
-              onClick={() => {
-                setCurrentTab('farm');
-                scrollTo(0, 0);
-              }}
-              className="w-full basis-1/3 bg-black text-white hover:cursor-pointer hover:bg-black/80"
-            >
-              Next
-            </Button>
-          </div>
-        </form>
+                <Field>
+                  <div className="flex flex-row items-center gap-3">
+                    <Controller
+                      name="didManageAndControl"
+                      control={control}
+                      render={({ field }) => (
+                        <Checkbox
+                          id="didManageAndControl"
+                          checked={field.value ?? false}
+                          onCheckedChange={field.onChange}
+                        />
+                      )}
+                    />
+                    <FieldLabel htmlFor="didManageAndControl">
+                      This person managed and controlled (but did not own) the
+                      parcel for the past 3 years
+                    </FieldLabel>
+                    <ErrorMessage
+                      errors={errors}
+                      name="didManageAndControl"
+                      render={({ message }) => (
+                        <FormErrorMessage errorMessage={message} />
+                      )}
+                    />
+                  </div>
+                </Field>
+              </FieldSet>
+
+              <div className="mt-10 flex flex-row gap-6">
+                <SubmitButton
+                  buttonText="Invite team member"
+                  className="basis-2/3"
+                  reactHookFormPending={isSubmitting}
+                />
+                <Button
+                  onClick={() => {
+                    setCurrentTab('farm');
+                    scrollTo(0, 0);
+                  }}
+                  className="w-full basis-1/3 bg-black text-white hover:cursor-pointer hover:bg-black/80"
+                >
+                  Next
+                </Button>
+              </div>
+            </form>
+          </>
+        ) : (
+          <p className="rounded-md border border-amber-400/60 bg-amber-50 p-3 text-sm text-amber-800">
+            Your account is read only. Only administrators can invite or manage
+            team members.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/colleagues/action.ts
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/colleagues/action.ts
@@ -6,6 +6,7 @@ import { deleteAuthUserByEmail, resendEmailInvite } from '@/lib/auth-server';
 import { user } from '@/lib/db/schema';
 import { db } from '@/lib/db/schema/connection';
 import { ActionResponse } from '@/lib/types/action-response';
+import { assertCanEditFarm } from '@/lib/utils/farm-rbac';
 import { getAuthenticatedInfo } from '@/lib/utils/get-authenticated-info';
 import { and, eq } from 'drizzle-orm';
 
@@ -13,6 +14,7 @@ import { and, eq } from 'drizzle-orm';
 export async function updateRole(): Promise<ActionResponse> {
   try {
     const result = await getAuthenticatedInfo();
+    assertCanEditFarm(result, 'update-role');
     const newRole = result.role === 'Admin' ? 'Viewer' : 'Admin';
 
     await db.update(user).set({ role: newRole }).where(eq(user.id, result.id));
@@ -34,7 +36,8 @@ export async function resendVerificationEmail(
   email: string
 ): Promise<ActionResponse> {
   try {
-    await getAuthenticatedInfo();
+    const currentUser = await getAuthenticatedInfo();
+    assertCanEditFarm(currentUser, 'resend-verification-email');
 
     await resendEmailInvite(email);
 
@@ -56,6 +59,7 @@ export async function resendVerificationEmail(
 export async function uninviteUser(userId: number): Promise<ActionResponse> {
   try {
     const currentUser = await getAuthenticatedInfo();
+    assertCanEditFarm(currentUser, 'uninvite-user');
 
     const [targetUser] = await db
       .select()

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/colleagues/invited-user.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/colleagues/invited-user.tsx
@@ -13,11 +13,13 @@ export default function InvitedUser({
   isVerified,
   invitedUser,
   isCurrentUser = false,
+  canEditFarm,
   onUninvited,
 }: {
   isVerified: boolean;
   invitedUser: UserSelect;
   isCurrentUser?: boolean;
+  canEditFarm: boolean;
   onUninvited?: (userId: number) => void;
 }) {
   const [isResendActive, setIsResendActive] = useState(true);
@@ -60,7 +62,7 @@ export default function InvitedUser({
           >
             {isVerified ? 'Verified' : 'Not verified'}
           </span>
-          {!isVerified && (
+          {canEditFarm && !isVerified && (
             <Button
               onClick={handleResend}
               className="hover:cursor-pointer"
@@ -71,7 +73,7 @@ export default function InvitedUser({
               />
             </Button>
           )}
-          {!isCurrentUser && (
+          {canEditFarm && !isCurrentUser && (
             <Button
               onClick={handleUninvite}
               className="hover:cursor-pointer"

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/colleagues/self-select-admin.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/colleagues/self-select-admin.tsx
@@ -8,7 +8,13 @@ import { Label } from '@/components/ui/label';
 import { useForm } from 'react-hook-form';
 import { updateRole } from './action';
 
-export default function SelfSelectAdmin({ role }: { role: string }) {
+export default function SelfSelectAdmin({
+  role,
+  canEditFarm,
+}: {
+  role: string;
+  canEditFarm: boolean;
+}) {
   const { handleSubmit, register, getValues, setValue } = useForm({
     defaultValues: { isAdmin: role === 'Admin' },
   });
@@ -20,16 +26,22 @@ export default function SelfSelectAdmin({ role }: { role: string }) {
         Only one administrator account is permitted per farm. Please contact
         support for more information.
       </p>
-      <form onChange={handleSubmit(updateRole)} className="mb-8">
-        <Field orientation={'horizontal'}>
-          <Checkbox
-            onCheckedChange={() => setValue('isAdmin', !getValues().isAdmin)}
-            {...register('isAdmin')}
-            defaultChecked={getValues().isAdmin}
-          />
-          <Label>I am an administrator</Label>
-        </Field>
-      </form>
+      {canEditFarm ? (
+        <form onChange={handleSubmit(updateRole)} className="mb-8">
+          <Field orientation={'horizontal'}>
+            <Checkbox
+              onCheckedChange={() => setValue('isAdmin', !getValues().isAdmin)}
+              {...register('isAdmin')}
+              defaultChecked={getValues().isAdmin}
+            />
+            <Label>I am an administrator</Label>
+          </Field>
+        </form>
+      ) : (
+        <p className="mb-8 text-sm text-muted-foreground">
+          Your role is {role}. Only administrators can change farm permissions.
+        </p>
+      )}
     </>
   );
 }

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/farm.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/farm.tsx
@@ -8,6 +8,7 @@ import {
   FarmInfoInternalApplicationSelect,
   FarmInfoInternalApplicationInsert,
 } from '@/lib/types/db';
+import { cn } from '@/lib/utils';
 import { farmInfoInternalApplicationInsertSchema } from '@/lib/zod-schemas/db';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ErrorMessage } from '@hookform/error-message';
@@ -40,7 +41,7 @@ import { ApplicationContext } from './application-tabs';
 
 /** The 3rd page of the application (and absolutely the longest). This is where the majority of farm related information is collected. */
 export default function Farm() {
-  const { internalApplication, farmInfo, setCurrentTab } =
+  const { internalApplication, farmInfo, setCurrentTab, canEditFarm } =
     useContext(ApplicationContext);
   const defaultValues = {
     ...internalApplication,
@@ -59,10 +60,18 @@ export default function Farm() {
   const [lastSaved, setLastSaved] = useState<Date>(new Date());
 
   async function save(formData: FarmInfoInternalApplicationInsert) {
+    if (!canEditFarm) {
+      return;
+    }
+
     await saveApplication(formData);
   }
 
   async function onChangeHelper() {
+    if (!canEditFarm) {
+      return;
+    }
+
     const delay = 5 * 1000;
     if (new Date().getTime() - lastSaved.getTime() > delay) {
       handleSubmit(save)();
@@ -75,7 +84,10 @@ export default function Farm() {
       <div>
         <FormProvider {...methods}>
           <form
-            className="mt-6 flex max-w-3xl flex-col gap-6"
+            className={cn(
+              'mt-6 flex max-w-3xl flex-col gap-6',
+              !canEditFarm && 'pointer-events-none opacity-70'
+            )}
             onSubmit={() => {
               handleSubmit(save)();
               setCurrentTab('subscription');
@@ -83,6 +95,11 @@ export default function Farm() {
             }}
             onChange={onChangeHelper}
           >
+            {!canEditFarm && (
+              <p className="rounded-md border border-amber-400/60 bg-amber-50 p-3 text-sm text-amber-800">
+                Viewers can review this section but cannot edit it.
+              </p>
+            )}
             <h2 className="text-lg font-semibold">General Farm Information</h2>
             <FieldSet className="mx-auto mb-8 flex flex-col gap-6">
               <Field>
@@ -446,10 +463,12 @@ export default function Farm() {
               <ProductDifferentiation />
             </FieldSet>
 
-            <SubmitButton
-              reactHookFormPending={isSubmitting}
-              buttonText="Save and next"
-            />
+            {canEditFarm && (
+              <SubmitButton
+                reactHookFormPending={isSubmitting}
+                buttonText="Save and next"
+              />
+            )}
           </form>
         </FormProvider>
       </div>

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/general-business-information.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/general-business-information.tsx
@@ -13,15 +13,16 @@ import { ErrorMessage } from '@hookform/error-message';
 import FormErrorMessage from '@/components/common/form-error-message/form-error-message';
 import { useForm, FormProvider } from 'react-hook-form';
 import SubmitButton from '@/components/common/utils/submit-button/submit-button';
-import { FadeIn } from '@/components/common';
 import { saveGeneralBusinessInformation } from '../actions';
 import { Address, Certifications } from './general-business-information/index';
 import { useState, useContext } from 'react';
 import { ApplicationContext } from './application-tabs';
+import { cn } from '@/lib/utils';
 
 /** The 1st tab in the application page for general business information */
 export default function GeneralBusinessInformation() {
-  const { farmInfo, setCurrentTab } = useContext(ApplicationContext);
+  const { farmInfo, setCurrentTab, canEditFarm } =
+    useContext(ApplicationContext);
   const defaultValues = farmInfo;
   const methods = useForm<GeneralBusinessInformationInsert>({
     defaultValues: defaultValues ?? {},
@@ -36,10 +37,18 @@ export default function GeneralBusinessInformation() {
   const [lastSaved, setLastSaved] = useState<Date>(new Date());
 
   async function save(formData: GeneralBusinessInformationInsert) {
+    if (!canEditFarm) {
+      return;
+    }
+
     await saveGeneralBusinessInformation(formData);
   }
 
   async function onChangeHelper() {
+    if (!canEditFarm) {
+      return;
+    }
+
     const delay = 5 * 1000;
     if (new Date().getTime() - lastSaved.getTime() > delay) {
       handleSubmit(save)();
@@ -51,7 +60,10 @@ export default function GeneralBusinessInformation() {
     <div className="mt-6">
       <FormProvider {...methods}>
         <form
-          className="mt-6 flex max-w-3xl flex-col gap-6"
+          className={cn(
+            'mt-6 flex max-w-3xl flex-col gap-6',
+            !canEditFarm && 'pointer-events-none opacity-70'
+          )}
           onSubmit={() => {
             handleSubmit(save)();
             setCurrentTab('colleagues');
@@ -59,6 +71,11 @@ export default function GeneralBusinessInformation() {
           }}
           onChange={onChangeHelper}
         >
+          {!canEditFarm && (
+            <p className="rounded-md border border-amber-400/60 bg-amber-50 p-3 text-sm text-amber-800">
+              Viewers can review this section but cannot edit it.
+            </p>
+          )}
           <h2 className="text-lg font-semibold">Business Information</h2>
           <FieldSet className="flex flex-col gap-6">
             <Field>
@@ -144,10 +161,12 @@ export default function GeneralBusinessInformation() {
 
           <Certifications />
 
-          <SubmitButton
-            buttonText="Save & next"
-            reactHookFormPending={isSubmitting}
-          ></SubmitButton>
+          {canEditFarm && (
+            <SubmitButton
+              buttonText="Save & next"
+              reactHookFormPending={isSubmitting}
+            ></SubmitButton>
+          )}
         </form>
       </FormProvider>
     </div>

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/subscription.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/subscription.tsx
@@ -10,7 +10,8 @@ import { createStripeSubscriptionCheckoutSession } from '../actions';
 
 /** The 4th tab in the application page for starting the Stripe Platform License. */
 export default function Subscription() {
-  const { farmSubscription, setCurrentTab } = useContext(ApplicationContext);
+  const { farmSubscription, setCurrentTab, canEditFarm } =
+    useContext(ApplicationContext);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
@@ -40,6 +41,12 @@ export default function Subscription() {
 
   return (
     <div className="mt-6 flex max-w-3xl flex-col gap-6">
+      {!canEditFarm && (
+        <p className="rounded-md border border-amber-400/60 bg-amber-50 p-3 text-sm text-amber-800">
+          Your account is read only. Only administrators can manage the Platform
+          License.
+        </p>
+      )}
       <div>
         <h2 className="text-lg font-semibold">
           Activate Your Todd Partnership
@@ -77,7 +84,7 @@ export default function Subscription() {
           type="button"
           className="w-full bg-black text-white hover:cursor-pointer hover:bg-black/80"
           onClick={beginStripeCheckout}
-          disabled={isLoading || hasActiveSubscription}
+          disabled={!canEditFarm || isLoading || hasActiveSubscription}
         >
           {hasActiveSubscription
             ? 'Platform License Active'

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/terms-and-conditions.test.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/terms-and-conditions.test.tsx
@@ -25,12 +25,13 @@ const mockContextValue = {
   invitedUserVerificationStatus: [] as VerificationStatus[],
   setCurrentTab: () => {},
   canSubmitApplication: true,
+  canEditFarm: true,
 };
 
 /** Renders the component inside ApplicationContext. Provider for tests. */
-function renderWithContext() {
+function renderWithContext(overrides: Partial<typeof mockContextValue> = {}) {
   return render(
-    <ApplicationContext.Provider value={mockContextValue}>
+    <ApplicationContext.Provider value={{ ...mockContextValue, ...overrides }}>
       <TermsAndConditions />
     </ApplicationContext.Provider>
   );
@@ -99,5 +100,16 @@ describe('TermsAndConditions', () => {
     expect(
       screen.queryByText('There was an error submitting your application.')
     ).not.toBeInTheDocument();
+  });
+
+  it('disables submission for read-only users', () => {
+    renderWithContext({ canEditFarm: false });
+
+    expect(
+      screen.getByText(
+        'Your account is read only. Only administrators can submit the application.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /AGREE/i })).toBeDisabled();
   });
 });

--- a/frontend/src/app/(authenticated)/(misc)/apply/components/terms-and-conditions.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/terms-and-conditions.tsx
@@ -26,7 +26,7 @@ const waitTime = 5000;
 
 /** Terms and conditions page */
 export default function TermsAndConditions() {
-  const { canSubmitApplication, farmSubscription, setCurrentTab } =
+  const { canSubmitApplication, farmSubscription, setCurrentTab, canEditFarm } =
     useContext(ApplicationContext);
   const { handleSubmit } = useForm();
   const [finalSubmitDisabled, setFinalSubmitDisabled] = useState(true);
@@ -78,6 +78,12 @@ export default function TermsAndConditions() {
         </p>
       )}
       <div className="mt-12 mb-6 flex w-full max-w-300 flex-col gap-4 font-light">
+        {!canEditFarm && (
+          <p className="rounded-md border border-amber-400/60 bg-amber-50 p-3 text-sm text-amber-800">
+            Your account is read only. Only administrators can submit the
+            application.
+          </p>
+        )}
         <h2 className="text-xl font-medium">
           Electronic Delivery of Documents
         </h2>
@@ -183,9 +189,9 @@ export default function TermsAndConditions() {
           <Button
             type="button"
             className="w-full bg-black text-white hover:cursor-pointer hover:bg-black/80"
-            disabled={!canSubmitApplication}
+            disabled={!canEditFarm || !canSubmitApplication}
             onClick={() => {
-              if (!canSubmitApplication) {
+              if (!canEditFarm || !canSubmitApplication) {
                 return;
               }
               setTimeout(() => setFinalSubmitDisabled(false), waitTime);

--- a/frontend/src/app/(authenticated)/(widgets)/page.tsx
+++ b/frontend/src/app/(authenticated)/(widgets)/page.tsx
@@ -101,18 +101,20 @@ export default async function DashboardPage({
         </div>
       }
       addWidgetDropdown={
-        <AddWidgetDropdown
-          managementZoneId={selectedTab.managementZone}
-          availableWidgets={availableWidgets}
-        >
-          <Button
-            size="sm"
-            variant="default"
-            className="h-[34px] w-[96px] hover:cursor-pointer hover:shadow-sm bg-[#D9D9D9]/32 text-foreground border-none focus-visible:ring-transparent! focus-visible:ring-offset-transparent!"
+        currentUser.role === 'Admin' ? (
+          <AddWidgetDropdown
+            managementZoneId={selectedTab.managementZone}
+            availableWidgets={availableWidgets}
           >
-            Add widget
-          </Button>
-        </AddWidgetDropdown>
+            <Button
+              size="sm"
+              variant="default"
+              className="h-[34px] w-[96px] hover:cursor-pointer hover:shadow-sm bg-[#D9D9D9]/32 text-foreground border-none focus-visible:ring-transparent! focus-visible:ring-offset-transparent!"
+            >
+              Add widget
+            </Button>
+          </AddWidgetDropdown>
+        ) : null
       }
     >
       <PlatformTabContent

--- a/frontend/src/app/(authenticated)/components/tabs/actions.ts
+++ b/frontend/src/app/(authenticated)/components/tabs/actions.ts
@@ -5,6 +5,7 @@
 import { managementZone, tab } from '@/lib/db/schema';
 import { db } from '@/lib/db/schema/connection';
 import { ActionResponse } from '@/lib/types/action-response';
+import { assertCanEditFarm } from '@/lib/utils/farm-rbac';
 import { getAuthenticatedInfo } from '@/lib/utils/get-authenticated-info';
 import { and, eq } from 'drizzle-orm';
 
@@ -31,6 +32,8 @@ export default async function updateTabName({
     if (!farmId) {
       return { error: 'User is not associated with a farm' };
     }
+
+    assertCanEditFarm(result, 'update-tab-name');
 
     if (oldName) {
       await db
@@ -87,6 +90,8 @@ export async function deleteTab({
       return { error: 'User is not associated with a farm' };
     }
 
+    assertCanEditFarm(result, 'delete-tab');
+
     if (!name && !tabId) {
       return { error: 'Please provide either oldName or tabId' };
     }
@@ -125,6 +130,8 @@ export async function createTab(
   try {
     const result = await getAuthenticatedInfo();
     const userId = result.id;
+
+    assertCanEditFarm(result, 'create-tab');
 
     // Check to see if user has the max tabs saved
     const currentTabs = await db

--- a/frontend/src/app/(authenticated)/components/tabs/tabs.tsx
+++ b/frontend/src/app/(authenticated)/components/tabs/tabs.tsx
@@ -42,6 +42,7 @@ export default function PlatformTabs({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [curTab, setCurTab] = useState(selectedTabHash);
+  const canEditFarm = currentUser.role === 'Admin';
 
   /** Sets the current tab */
   function setTab(nextTabHash: string) {
@@ -118,12 +119,14 @@ export default function PlatformTabs({
               }}
             >
               <input
-                className="pointer-events-none max-w-25 cursor-pointer truncate group-data-[state=active]:pointer-events-auto focus:ring-0 focus:outline-none text-center"
+                className="max-w-25 truncate text-center focus:ring-0 focus:outline-none data-[readonly=true]:cursor-default"
                 defaultValue={tab.name || `Untitled Zone ${index}`}
+                data-readonly={!canEditFarm}
+                readOnly={!canEditFarm}
                 onChange={(e) => updateTab(e.target.value, tab.id)}
                 onBlur={(e) => (e.target.scrollLeft = 0)}
               />
-              {currentTabs.length !== 1 && (
+              {canEditFarm && currentTabs.length !== 1 && (
                 <div>
                   {/** This isn't the best solution, but it's the easiest way to nest buttons. Getting the entire background to render with a wrapping div via data-[state=active] is just a pain */}
                   <div
@@ -138,7 +141,7 @@ export default function PlatformTabs({
               )}
             </TabsTrigger>
           ))}
-          {currentTabs.length <= maxTabs && (
+          {canEditFarm && currentTabs.length <= maxTabs && (
             <NewTabDropdown
               managementZones={managementZones}
               addTab={createTab}
@@ -150,6 +153,9 @@ export default function PlatformTabs({
           )}
         </TabsList>
         <div className="flex-row flex gap-6 border-none">
+          {!canEditFarm && (
+            <p className="text-sm text-muted-foreground">Read only</p>
+          )}
           {addWidgetDropdown}
           {header}
         </div>

--- a/frontend/src/components/common/widgets/actions.ts
+++ b/frontend/src/components/common/widgets/actions.ts
@@ -7,6 +7,7 @@ import { db } from '@/lib/db/schema/connection';
 import logger from '@/lib/logger';
 import { ActionResponse } from '@/lib/types/action-response';
 import { WidgetUpdate } from '@/lib/types/db';
+import { assertCanEditFarm } from '@/lib/utils/farm-rbac';
 import { getAuthenticatedInfo } from '@/lib/utils/get-authenticated-info';
 import { and, eq } from 'drizzle-orm';
 import { LayoutItem } from 'react-grid-layout';
@@ -27,7 +28,8 @@ export async function createWidget({
   widgetMetadata?: LayoutItem;
 }): Promise<{ data?: { widgetId: number }; error?: string | null }> {
   try {
-    await getAuthenticatedInfo();
+    const currentUser = await getAuthenticatedInfo();
+    assertCanEditFarm(currentUser, 'create-widget');
 
     // Place the widget at the top left, let RGL handle it
     const newWidgetMetadata = {
@@ -61,7 +63,8 @@ export async function createWidget({
  * */
 export async function deleteWidget(widgetId: number): Promise<ActionResponse> {
   try {
-    await getAuthenticatedInfo();
+    const currentUser = await getAuthenticatedInfo();
+    assertCanEditFarm(currentUser, 'delete-widget');
 
     await db.delete(widget).where(eq(widget.id, widgetId));
 
@@ -86,7 +89,8 @@ export async function updateWidget(
   updates: WidgetUpdate
 ): Promise<ActionResponse> {
   try {
-    await getAuthenticatedInfo();
+    const currentUser = await getAuthenticatedInfo();
+    assertCanEditFarm(currentUser, 'update-widget');
 
     await db
       .update(widget)

--- a/frontend/src/lib/utils/farm-rbac.ts
+++ b/frontend/src/lib/utils/farm-rbac.ts
@@ -1,0 +1,30 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import logger from '@/lib/logger';
+import type { AuthenticatedInfo } from '@/lib/types/get-authenticated-info';
+
+export const farmEditRoles = ['Admin'] as const;
+
+export function canEditFarm(
+  currentUser: Pick<AuthenticatedInfo, 'id' | 'farmId' | 'role'>
+): boolean {
+  return currentUser.role === 'Admin';
+}
+
+export function assertCanEditFarm(
+  currentUser: Pick<AuthenticatedInfo, 'id' | 'farmId' | 'role'>,
+  action: string
+): void {
+  if (canEditFarm(currentUser)) {
+    return;
+  }
+
+  logger.warn('Denied farm edit attempt', {
+    action,
+    userId: currentUser.id,
+    farmId: currentUser.farmId,
+    role: currentUser.role,
+  });
+
+  throw new Error('You do not have permission to edit farm information');
+}


### PR DESCRIPTION
## Description

Fixes #711

Enforces farm edit RBAC across the authenticated frontend so viewer-role users can access farm data in a read-only state without being able to mutate application, management zone, tab, or widget data.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate