### PR TITLE
fix: allow initial farm application autosave

### DIFF
--- a/frontend/src/app/(authenticated)/(misc)/apply/components/farm.tsx
+++ b/frontend/src/app/(authenticated)/(misc)/apply/components/farm.tsx
@@ -121,7 +121,9 @@ export default function Farm() {
                   type="number"
                   step="0.01"
                   placeholder="e.g., 150000.00"
-                  {...register('totalGrossIncome')}
+                  {...register('totalGrossIncome', {
+                    setValueAs: (value) => (value === '' ? undefined : value),
+                  })}
                 />
               </Field>
 
@@ -140,7 +142,10 @@ export default function Farm() {
                   className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                   type="number"
                   placeholder="e.g., 7"
-                  {...register('totalAcreage', { valueAsNumber: true })}
+                  {...register('totalAcreage', {
+                    setValueAs: (value) =>
+                      value === '' ? undefined : Number(value),
+                  })}
                 />
               </Field>
 


### PR DESCRIPTION
## Description

Fixes #645

Normalizes empty numeric farm application inputs to `undefined` so autosave can create the initial `farm_info_internal_application` row instead of being blocked by invalid form values.

Validation note: `bun run validate` was run, but it fails on an unrelated existing test issue in `frontend/src/app/(unauthenticated)/[locale]/(contact)/login/page.test.tsx` due to an unhandled `window is not defined` error from a timeout after the tests complete.

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
