### PR TITLE
fix: add loading states for tab actions

### DIFF
--- a/frontend/src/app/(authenticated)/components/tabs/components/new-tab-button.tsx
+++ b/frontend/src/app/(authenticated)/components/tabs/components/new-tab-button.tsx
@@ -1,0 +1,41 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+'use client';
+
+import { Button } from '@/components/ui';
+import type { ButtonProps } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import { cn } from '@/lib/utils';
+import { forwardRef } from 'react';
+import { BiPlus } from 'react-icons/bi';
+
+/** Displays the new-tab trigger and replaces the plus icon with a spinner while a tab creation request is pending. */
+const NewTabButton = forwardRef<
+  HTMLButtonElement,
+  ButtonProps & { pending: boolean }
+>(({ pending, className, ...props }, ref) => {
+  return (
+    <Button
+      ref={ref}
+      type="button"
+      aria-label={pending ? 'Creating a new tab' : 'Open new tab menu'}
+      aria-busy={pending}
+      disabled={pending}
+      className={cn(
+        'ml-3 h-fit w-fit cursor-pointer rounded-sm border-none p-0.5 leading-none hover:bg-[#D9D9D9]/32 hover:shadow-sm focus-visible:ring-0! focus-visible:ring-offset-0! [&_svg]:size-[22px]',
+        className
+      )}
+      {...props}
+    >
+      {pending ? (
+        <Spinner className="text-[#A09C9D] size-[22px]" />
+      ) : (
+        <BiPlus className="text-[#A09C9D]" />
+      )}
+    </Button>
+  );
+});
+
+NewTabButton.displayName = 'NewTabButton';
+
+export default NewTabButton;

--- a/frontend/src/app/(authenticated)/components/tabs/components/tab-close-button.tsx
+++ b/frontend/src/app/(authenticated)/components/tabs/components/tab-close-button.tsx
@@ -1,0 +1,52 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+'use client';
+
+import { Spinner } from '@/components/ui/spinner';
+import { cn } from '@/lib/utils';
+import type { MouseEvent } from 'react';
+import { BiX } from 'react-icons/bi';
+import { useTransition } from 'react';
+
+/** Renders the close control for an individual tab and swaps the icon for a spinner while deletion is in flight. */
+export default function TabCloseButton({
+  onClose,
+  tabName,
+  visible,
+}: {
+  onClose: () => Promise<void>;
+  tabName: string;
+  visible: boolean;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  function handleClick(event: MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    startTransition(async () => {
+      await onClose();
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={`Close ${tabName}`}
+      aria-busy={pending}
+      disabled={pending}
+      onClick={handleClick}
+      className={cn(
+        'hover:bg-foreground/10 hover:cursor-pointer absolute top-1/2 right-1 z-10 flex -translate-y-1/2 rounded-sm p-0.5 transition-opacity',
+        visible ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+        pending ? 'opacity-100' : null
+      )}
+    >
+      {pending ? (
+        <Spinner className="text-foreground/50 size-4" />
+      ) : (
+        <BiX className="text-foreground/40 hover:text-foreground/60 size-5" />
+      )}
+    </button>
+  );
+}

--- a/frontend/src/app/(authenticated)/components/tabs/new-tab-dropdown.tsx
+++ b/frontend/src/app/(authenticated)/components/tabs/new-tab-dropdown.tsx
@@ -12,26 +12,38 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { ManagementZoneSelect } from '@/lib/types/db';
 import Link from 'next/link';
+import { useTransition } from 'react';
+import NewTabButton from './components/new-tab-button';
 
+/** Presents the management zone menu used to create tabs and shows a loading state on the trigger while creation is pending. */
 export default function NewTabDropdown({
   addTab,
-  children,
   managementZones,
 }: {
-  addTab: (managementZoneId: number) => void;
-  children: React.ReactNode;
+  addTab: (managementZoneId: number) => Promise<void>;
   managementZones: ManagementZoneSelect[];
 }) {
+  const [pending, startTransition] = useTransition();
+
+  function handleAddTab(managementZoneId: number) {
+    startTransition(async () => {
+      await addTab(managementZoneId);
+    });
+  }
+
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+      <DropdownMenuTrigger asChild>
+        <NewTabButton pending={pending} />
+      </DropdownMenuTrigger>
       <DropdownMenuContent className="bg-white border-1 border-[#D9D9D9] w-55 translate-x-[98px]">
         {managementZones.length > 0 ? (
           managementZones.map((zone, index) => (
             <div key={zone.id}>
               <DropdownMenuItem
                 className="hover:cursor-pointer"
-                onClick={() => addTab(zone.id)}
+                disabled={pending}
+                onClick={() => handleAddTab(zone.id)}
               >
                 {zone.name || 'Untitled Zone'}
               </DropdownMenuItem>

--- a/frontend/src/app/(authenticated)/components/tabs/tabs.tsx
+++ b/frontend/src/app/(authenticated)/components/tabs/tabs.tsx
@@ -3,18 +3,17 @@
 'use client';
 
 import ToddHeader from '@/components/common/wordmark/todd-wordmark';
-import { Button } from '@/components/ui';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import logger from '@/lib/logger';
 import { ManagementZoneSelect } from '@/lib/types/db';
 import type { AuthenticatedInfo } from '@/lib/types/get-authenticated-info';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-import { BiPlus, BiX } from 'react-icons/bi';
 import updateTabName, {
   createTab as createTabAction,
   deleteTab as deleteTabAction,
 } from './actions';
+import TabCloseButton from './components/tab-close-button';
 import NewTabDropdown from './new-tab-dropdown';
 import { NamedTab } from './types';
 import { getTabHash } from './utils';
@@ -110,47 +109,38 @@ export default function PlatformTabs({
         <ToddHeader className="flex scale-90 flex-row items-center" />
         <TabsList className="mr-auto ml-2 flex h-9 flex-row flex-nowrap justify-start gap-0 bg-gradient-to-r from-[#D9D9D9]/10 to-[#D9D9D9]/0">
           {currentTabs.map((tab, index) => (
-            <TabsTrigger
-              className="group group flex max-w-36 min-w-36 flex-row items-center justify-between truncate border-none px-3 py-1.5 data-[state=active]:bg-[#D9D9D9]/32"
-              key={tab.id}
-              value={getTabHash(tab)}
-              onClick={() => {
-                const nextTabHash = getTabHash(tab);
-                setTab(nextTabHash);
-              }}
-            >
-              <input
-                className="pointer-events-none max-w-25 cursor-pointer truncate text-center group-data-[state=active]:pointer-events-auto focus:ring-0 focus:outline-none"
-                defaultValue={tab.name || `Untitled Zone ${index}`}
-                data-readonly={!canEditFarm}
-                readOnly={!canEditFarm}
-                onChange={(e) => updateTab(e.target.value, tab.id)}
-                onBlur={(e) => (e.target.scrollLeft = 0)}
-              />
-              {canEditFarm && currentTabs.length !== 1 && (
-                <div>
-                  {/** This isn't the best solution, but it's the easiest way to nest buttons. Getting the entire background to render with a wrapping div via data-[state=active] is just a pain */}
-                  <div
-                    aria-roledescription="Close the current tab"
-                    role="button"
-                    onClick={() => deleteTab(tab)}
-                    className="hover:bg-foreground/10 mr-[-10px] hidden h-min rounded-sm p-0 group-hover:block"
-                  >
-                    <BiX className="text-foreground/40 hover:text-foreground/60 size-5" />
-                  </div>
-                </div>
-              )}
-            </TabsTrigger>
+            <div key={tab.id} className="group relative">
+              <TabsTrigger
+                className="group/tab flex max-w-36 min-w-36 flex-row items-center justify-center truncate border-none px-3 py-1.5 pr-8 data-[state=active]:bg-[#D9D9D9]/32"
+                value={getTabHash(tab)}
+                onClick={() => {
+                  const nextTabHash = getTabHash(tab);
+                  setTab(nextTabHash);
+                }}
+              >
+                <input
+                  className="pointer-events-none max-w-25 cursor-pointer truncate text-center group-data-[state=active]/tab:pointer-events-auto focus:ring-0 focus:outline-none"
+                  defaultValue={tab.name || `Untitled Zone ${index}`}
+                  data-readonly={!canEditFarm}
+                  readOnly={!canEditFarm}
+                  onChange={(e) => updateTab(e.target.value, tab.id)}
+                  onBlur={(e) => (e.target.scrollLeft = 0)}
+                />
+              </TabsTrigger>
+              {canEditFarm && currentTabs.length !== 1 ? (
+                <TabCloseButton
+                  onClose={() => deleteTab(tab)}
+                  tabName={tab.name || `Untitled Zone ${index}`}
+                  visible={curTab === getTabHash(tab)}
+                />
+              ) : null}
+            </div>
           ))}
-          {canEditFarm && currentTabs.length <= maxTabs && (
+          {canEditFarm && currentTabs.length < maxTabs && (
             <NewTabDropdown
               managementZones={managementZones}
               addTab={createTab}
-            >
-              <Button className="ml-3 h-fit w-fit cursor-pointer rounded-sm border-none p-0.5 leading-none hover:bg-[#D9D9D9]/32 hover:shadow-sm focus-visible:ring-0! focus-visible:ring-offset-0! [&_svg]:size-[22px]">
-                <BiPlus className="text-[#A09C9D]" />
-              </Button>
-            </NewTabDropdown>
+            />
           )}
         </TabsList>
         <div className="flex flex-row items-center gap-6 border-none">


### PR DESCRIPTION
## Description

Fixes #505

Adds component-based loading states for tab creation and tab deletion in the authenticated tab UI, while preserving inline tab renaming behavior.

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate