### PR TITLE
feat: add canonical /index/[slug] CMS articles with legacy /news redirects

### DIFF
--- a/apps/sanity/schemaTypes/news.ts
+++ b/apps/sanity/schemaTypes/news.ts
@@ -4,12 +4,73 @@ import {DocumentTextIcon} from '@sanity/icons'
 import {format, parseISO} from 'date-fns'
 import {defineField, defineType} from 'sanity'
 
+/** Shared article model — `_type` remains `news` for migration parity. */
 export default defineType({
   name: 'news',
-  title: 'News Article',
+  title: 'Article',
   icon: DocumentTextIcon,
   type: 'document',
   fields: [
+    defineField({
+      name: 'contentType',
+      title: 'Content type',
+      type: 'string',
+      initialValue: 'news',
+      options: {
+        list: [
+          {title: 'News', value: 'news'},
+          {title: 'Research', value: 'research'},
+          {title: 'Story', value: 'story'},
+          {title: 'Product release', value: 'product-release'},
+          {title: 'Press', value: 'press'},
+        ],
+        layout: 'radio',
+      },
+      description:
+        'Primary category for routing and parent pages (newsroom, research, stories, etc.). Defaults to news for older posts.',
+    }),
+    defineField({
+      name: 'collections',
+      title: 'Additional collections',
+      type: 'array',
+      of: [{type: 'string'}],
+      options: {
+        list: [
+          {title: 'News', value: 'news'},
+          {title: 'Research', value: 'research'},
+          {title: 'Story', value: 'story'},
+          {title: 'Product release', value: 'product-release'},
+          {title: 'Press', value: 'press'},
+        ],
+        layout: 'tags',
+      },
+      description:
+        'Optional extra groupings when an article should appear on more than one parent page.',
+    }),
+    defineField({
+      name: 'canonicalParent',
+      title: 'Canonical parent (optional)',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'News', value: 'news'},
+          {title: 'Research', value: 'research'},
+          {title: 'Story', value: 'story'},
+          {title: 'Product release', value: 'product-release'},
+          {title: 'Press', value: 'press'},
+        ],
+      },
+      description:
+        'Preferred parent for breadcrumbs or analytics when an article spans multiple collections.',
+    }),
+    defineField({
+      name: 'excludeFromSitemap',
+      title: 'Exclude from sitemap',
+      type: 'boolean',
+      initialValue: false,
+      description:
+        'Internal articles only: when enabled, no XML sitemap entry is generated. External articles are always excluded.',
+    }),
     defineField({
       name: 'title',
       title: 'Title',
@@ -182,7 +243,7 @@ export default defineType({
       title: 'Off Site Link',
       type: 'url',
       description:
-        'If a URL is present in this field, no news page will exist for this article. Specifically, navigating to a URL such as `/en/news/{your-slug}` will redirect to this URL.',
+        'When set, navigating to `/[locale]/news/{slug}`, `/[locale]/index/{slug}`, or older legacy links redirects to this external URL.',
     }),
     defineField({
       name: 'isFeatured',

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/news-highlights/news-highlights.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/news-highlights/news-highlights.tsx
@@ -5,13 +5,28 @@
 import { FadeIn, NewsCard } from '@/components/common';
 import { Spinner } from '@/components/ui/spinner';
 import { useTheme } from '@/context/theme/ThemeContext';
-import sanityQuery from '@/lib/sanity/query';
+import { loadArticlesForHighlights } from '@/lib/sanity/article-actions';
+import type { SanityArticle } from '@/lib/sanity/article-types';
+import { getArticleCardHref } from '@/lib/sanity/article-urls';
 import { urlFor } from '@/lib/sanity/utils';
 import { useLocale } from 'next-intl';
-import { SanityDocument } from 'next-sanity';
 import { useEffect, useState } from 'react';
 
 const articlePlaceholderRoute = '/article-placeholder.webp';
+
+/** Formats listing dates with a safe fallback when `date` is missing. */
+function formatArticleListingDate(
+  dateValue: string | undefined,
+  locale: string
+): string {
+  const safe = dateValue !== undefined && dateValue.length > 0 ? dateValue : '';
+  if (safe.length === 0) return '';
+  return new Date(safe).toLocaleDateString(locale, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
 
 /**
  * News highlight card component
@@ -19,7 +34,7 @@ const articlePlaceholderRoute = '/article-placeholder.webp';
  */
 export default function NewsHighlights() {
   const { isDark: contextIsDark } = useTheme();
-  const [allNews, setAllNews] = useState<SanityDocument[]>();
+  const [allNews, setAllNews] = useState<SanityArticle[]>();
   const [isLoading, setIsLoading] = useState(true);
 
   const featuredNews = allNews
@@ -30,9 +45,7 @@ export default function NewsHighlights() {
 
   useEffect(() => {
     async function getNews() {
-      const news = (await sanityQuery(
-        'news'
-      )) as unknown as Array<SanityDocument>;
+      const news = await loadArticlesForHighlights('news');
       setAllNews(news);
       setIsLoading(false);
     }
@@ -57,11 +70,12 @@ export default function NewsHighlights() {
                 image={
                   article.thumbnail && article.thumbnail.asset
                     ? {
-                        url: urlFor(article.thumbnail)
-                          ?.width(400)
-                          .height(400)
-                          .url(),
-                        alt: article.thumbnail.alt,
+                        url:
+                          urlFor(article.thumbnail)
+                            ?.width(400)
+                            .height(400)
+                            .url() ?? articlePlaceholderRoute,
+                        alt: article.thumbnail.alt ?? '',
                         height: 400,
                         width: 400,
                       }
@@ -72,18 +86,10 @@ export default function NewsHighlights() {
                         width: 400,
                       }
                 }
-                source={article.source}
-                date={new Date(article.date).toLocaleDateString(locale, {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}
-                excerpt={article.summary}
-                link={
-                  article.offSiteUrl && article.offSiteUrl.length > 0
-                    ? article.offSiteUrl
-                    : `${locale}/news/${article.slug.current}`
-                }
+                source={article.source ?? ''}
+                date={formatArticleListingDate(article.date, locale)}
+                excerpt={article.summary ?? ''}
+                link={getArticleCardHref(article)}
               />
             ))}
           </div>

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/components/article-body.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/components/article-body.tsx
@@ -1,0 +1,46 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import SanityHeaderImage from '@/components/sanity/news/sanity-header-image';
+import type { SanityArticle } from '@/lib/sanity/article-types';
+import { PortableText } from 'next-sanity';
+import type { PortableTextReactComponents } from 'next-sanity';
+
+/**
+ * Main article column: hero image slot and Sanity Portable Text.
+ *
+ * @param props - Image and Portable Text payloads
+ */
+export function ArticleBody({
+  headerImageAlt,
+  headerImageUrl,
+  headerImageAsset,
+  content,
+  portableTextComponents,
+}: {
+  headerImageAlt?: string;
+  headerImageUrl: string | undefined;
+  headerImageAsset: SanityArticle['headerImage'];
+  content: SanityArticle['content'];
+  portableTextComponents: Partial<PortableTextReactComponents>;
+}) {
+  return (
+    <>
+      {headerImageAsset !== undefined && headerImageAsset !== null ? (
+        <div className="mt-8 mb-8 md:mb-12 lg:mb-16 flex flex-col items-center justify-center w-full mx-auto">
+          <SanityHeaderImage
+            headerImage={headerImageAsset}
+            src={headerImageUrl}
+            alt={headerImageAlt ?? ''}
+            wrapperClassName="w-full"
+            overlayClassName="transition-all duration-200 ease-in-out"
+          />
+        </div>
+      ) : null}
+      <div className="mt-10 mb-10 sm:mb-20 md:mb-26 flex w-full max-w-[685px] flex-col gap-[7px] mx-auto text-left">
+        {Array.isArray(content) && (
+          <PortableText value={content} components={portableTextComponents} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/components/article-footer.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/components/article-footer.tsx
@@ -1,0 +1,70 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import type { ArticleUiSubscript } from '../types';
+
+/**
+ * Author line and footnotes area below the article body.
+ *
+ * @param props - Author, optional repeated subtitle, and subscript list
+ */
+export function ArticleFooter({
+  author,
+  footerSubtitle,
+  subscripts,
+}: {
+  author?: string;
+  footerSubtitle?: string;
+  subscripts: ArticleUiSubscript[];
+}) {
+  if (!author && subscripts.length === 0) return null;
+
+  return (
+    <section className="mb-10 w-full max-w-[685px] mx-auto text-left">
+      {author !== undefined && author !== null && author.length > 0 ? (
+        <>
+          <p className="text-[14px] font-normal leading-[32px] tracking-normal text-[#848484]">
+            Author
+          </p>
+          <p className="text-[14px] font-normal leading-[32px] tracking-normal text-foreground">
+            {author}
+          </p>
+        </>
+      ) : null}
+      {subscripts.length > 0 ? (
+        <div className="mt-6 w-full max-w-[645px]">
+          {footerSubtitle !== undefined && footerSubtitle.length > 0 ? (
+            <p className="text-[14px] font-normal leading-[32px] tracking-normal text-foreground">
+              {footerSubtitle}
+            </p>
+          ) : null}
+          <div className="mt-4 flex flex-col gap-3">
+            {subscripts.map((subscript, index) => (
+              <p
+                key={`${subscript.label ?? index}-${subscript.text}`}
+                className="text-[14px] italic font-normal leading-[22px] tracking-normal text-foreground"
+              >
+                <sup className="mr-1 inline-block align-super text-[10px] not-italic leading-none text-[#848484]">
+                  {subscript.label !== undefined && subscript.label.length > 0
+                    ? subscript.label
+                    : `${index + 1}`}
+                </sup>
+                {subscript.url !== undefined ? (
+                  <a
+                    href={subscript.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2"
+                  >
+                    {subscript.text}
+                  </a>
+                ) : (
+                  subscript.text
+                )}
+              </p>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/components/article-header.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/components/article-header.tsx
@@ -1,0 +1,59 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import ArticleShareCopyLink from '@/components/common/news/article-share-copy-link';
+
+/**
+ * Hero block for CMS article titles and metadata lines.
+ *
+ * @param props - Header content fields
+ */
+export function ArticleHeader({
+  title,
+  subtitle,
+  company,
+  dateTime,
+  formattedDate,
+}: {
+  /** Article headline */
+  title: string;
+  /** Optional deck line */
+  subtitle?: string;
+  /** Optional company attribution */
+  company?: string;
+  /** ISO date for `<time datetime>` when present */
+  dateTime?: string;
+  /** Already localized date presentation */
+  formattedDate?: string;
+}) {
+  return (
+    <header className="flex w-full max-w-[686px] flex-col items-center mx-auto lg:mb-6">
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-center text-[14px] font-normal leading-[28px] tracking-normal">
+        {formattedDate !== undefined && formattedDate.length > 0 ? (
+          <time
+            dateTime={
+              dateTime !== undefined && dateTime.length > 0
+                ? dateTime
+                : undefined
+            }
+          >
+            {formattedDate}
+          </time>
+        ) : null}
+        {company !== undefined && company !== null ? (
+          <span className="text-[#848484]">{company}</span>
+        ) : null}
+      </div>
+      <h2 className="w-full max-w-[664px] mx-auto text-balance text-center font-normal tracking-normal text-[2rem] leading-[2rem] sm:text-[2.5rem] sm:leading-[2.5rem] md:text-[3rem] md:leading-[3rem] lg:text-[64px] lg:leading-[64px] mt-4 mb-4">
+        {title}
+      </h2>
+      {subtitle !== undefined ? (
+        <p className="w-full max-w-[661px] mx-auto mb-6 text-center text-[16px] font-normal leading-[27px] tracking-normal text-foreground">
+          {subtitle}
+        </p>
+      ) : null}
+      <div className="mt-6 w-full border-t-[1px] border-[#EFEFEF] pt-6">
+        <ArticleShareCopyLink />
+      </div>
+    </header>
+  );
+}

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/layout.tsx
@@ -1,0 +1,51 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { createMetadata } from '@/lib/metadata';
+import { getArticleBySlug, isInternalArticle } from '@/lib/sanity/articles';
+import type { Metadata } from 'next';
+
+/**
+ * SEO metadata for the canonical CMS article route.
+ *
+ * @param params - Locale and slug
+ */
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; slug: string }>;
+}): Promise<Metadata> {
+  const { locale, slug } = await params;
+  const article = await getArticleBySlug(slug, {
+    next: { revalidate: 60 * 60 },
+  });
+  if (article === undefined || article === null) {
+    return {};
+  }
+  if (!isInternalArticle(article)) {
+    return {};
+  }
+  const path = `/${locale}/index/${slug}`;
+  const summary = article.summary;
+  const description =
+    summary !== undefined && summary !== null && summary.length > 0
+      ? summary
+      : 'Todd Agriscience articles and announcements.';
+  return createMetadata({
+    title: article.title,
+    description,
+    path,
+  });
+}
+
+/**
+ * Transparent layout wrapper — structure lives in page components.
+ *
+ * @param props - React children slot
+ */
+export default function ArticleIndexLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/page.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/page.test.tsx
@@ -1,0 +1,110 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { renderWithNextIntl, screen } from '@/test/test-utils';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+import ArticleIndexPage from './page';
+
+const { item } = vi.hoisted(() => {
+  return {
+    item: {
+      title: 'New AI Model Sets Performance Record',
+      source: 'TechCrunch',
+      date: '2024-11-20T00:00:00.000Z',
+      summary:
+        'A breakthrough AI model has surpassed previous benchmarks, signaling a major shift in machine learning research.',
+      slug: { current: 'new-ai' },
+      content: [
+        {
+          _key: 'ce12009ed6af',
+          _type: 'block',
+          children: [
+            {
+              _key: '64e6a6b07265',
+              _type: 'span',
+              marks: [],
+              text: 'Test content.',
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      headerImage: {
+        _type: 'image',
+        alt: 'Header image',
+        asset: {
+          _ref: 'image-test-asset-2518x1690-png',
+          _type: 'reference',
+        },
+      },
+    },
+  };
+});
+
+// Mock embla-carousel-react
+vi.mock('embla-carousel-react', () => {
+  const mockEmblaApi = {
+    scrollSnapList: vi.fn(() => [0, 1, 2]),
+    selectedScrollSnap: vi.fn(() => 0),
+    scrollPrev: vi.fn(),
+    scrollNext: vi.fn(),
+    scrollTo: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    canScrollPrev: vi.fn(() => true),
+    canScrollNext: vi.fn(() => true),
+  };
+
+  return {
+    __esModule: true,
+    default: vi.fn(() => [vi.fn(), mockEmblaApi]),
+  };
+});
+
+vi.mock('@/lib/sanity/articles', () => ({
+  getArticleBySlug: vi.fn().mockResolvedValue(item),
+  isInternalArticle: vi.fn(() => true),
+}));
+
+const builder = {
+  width: vi.fn().mockReturnThis(),
+  height: vi.fn().mockReturnThis(),
+  src: vi.fn().mockReturnValue('mocked-url'),
+  url: vi.fn().mockReturnValue('https://google.com/test.png'),
+};
+
+vi.mock('@/lib/sanity/utils', () => {
+  return {
+    urlFor: vi.fn(() => builder),
+  };
+});
+
+describe('Article index Page', () => {
+  it('renders Portable Text headline and formatted date', async () => {
+    renderWithNextIntl(
+      <TooltipProvider>
+        {await ArticleIndexPage({
+          params: Promise.resolve({ slug: 'new-ai', locale: 'en' }),
+        })}
+      </TooltipProvider>
+    );
+
+    expect(screen.getByText(item.title)).toBeInTheDocument();
+
+    const formattedDate = new Date(item.date)
+      .toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      })
+      .replace(/\s(\d{4})$/, ', $1');
+
+    expect(screen.getByText(formattedDate)).toBeInTheDocument();
+    expect(screen.getByText(item.summary)).toBeInTheDocument();
+    expect(
+      screen.getByText(item.content[0].children[0].text)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/page.tsx
@@ -1,0 +1,109 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import SanityNormal from '@/components/sanity/news/sanity-normal';
+import SanityLink from '@/components/sanity/sanity-link';
+import { getArticleBySlug, isInternalArticle } from '@/lib/sanity/articles';
+import { urlFor } from '@/lib/sanity/utils';
+import { PortableTextReactComponents } from 'next-sanity';
+import { notFound, redirect } from 'next/navigation';
+
+import { ArticleBody } from './components/article-body';
+import { ArticleFooter } from './components/article-footer';
+import { ArticleHeader } from './components/article-header';
+import { formatArticleHeroDate, parseArticleSubscripts } from './utils';
+
+/**
+ * Canonical CMS article page at `/index/[slug]`.
+ *
+ * @param params - Slug for the article
+ */
+export default async function ArticleIndexPage({
+  params,
+}: {
+  params: Promise<{ locale: string; slug: string }>;
+}) {
+  const { slug } = await params;
+  const article = await getArticleBySlug(slug, {
+    next: { revalidate: 60 * 60 },
+  });
+
+  if (article == null) {
+    notFound();
+    return;
+  }
+
+  if (!isInternalArticle(article)) {
+    redirect(article.offSiteUrl as string);
+    return;
+  }
+
+  const headerImageUrl = article.headerImage
+    ? urlFor(article.headerImage)?.url()
+    : undefined;
+
+  const formattedDate = formatArticleHeroDate(article.date);
+  const subscripts = parseArticleSubscripts(article);
+
+  const portableTextComponents: Partial<PortableTextReactComponents> = {
+    block: {
+      normal: (props) => <SanityNormal {...props} summary={article.summary} />,
+
+      h1: ({ children }) => (
+        <h1 className="mt-[53px] text-3xl md:text-4xl lg:text-5xl font-normal leading-snug mb-2">
+          {children}
+        </h1>
+      ),
+      h2: ({ children }) => (
+        <h2 className="mt-[53px] text-2xl md:text-3xl lg:text-[30px]/[41px] font-normal leading-snug mb-2">
+          {children}
+        </h2>
+      ),
+      h3: ({ children }) => (
+        <h3 className="mt-[53px] text-xl md:text-2xl lg:text-3xl font-normal leading-snug mb-2">
+          {children}
+        </h3>
+      ),
+      h4: ({ children }) => (
+        <h4 className="mt-[53px] text-xl md:text-2xl lg:text-3xl font-normal leading-snug mb-2">
+          {children}
+        </h4>
+      ),
+      h5: ({ children }) => (
+        <h5 className="mt-[53px] text-lg md:text-xl lg:text-[20px]/[28px] font-normal leading-snug mb-2">
+          {children}
+        </h5>
+      ),
+    },
+    marks: {
+      link: (props) => <SanityLink {...props} />,
+    },
+  };
+
+  const dateIso = article.date != null ? String(article.date) : '';
+
+  return (
+    <div className="max-w-[80%] mx-auto">
+      <main className="mt-20 container mx-auto min-h-screen flex flex-col gap-10 md:gap-4">
+        <ArticleHeader
+          company={article.company}
+          subtitle={article.subtitle}
+          title={article.title}
+          dateTime={dateIso !== '' ? dateIso : undefined}
+          formattedDate={formattedDate !== '' ? formattedDate : undefined}
+        />
+        <ArticleBody
+          portableTextComponents={portableTextComponents}
+          headerImageAsset={article.headerImage}
+          headerImageUrl={headerImageUrl}
+          headerImageAlt={article.headerImage?.alt ?? article.title}
+          content={article.content}
+        />
+        <ArticleFooter
+          author={article.author}
+          footerSubtitle={article.subtitle}
+          subscripts={subscripts}
+        />
+      </main>
+    </div>
+  );
+}

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/types.ts
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/types.ts
@@ -1,0 +1,10 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * Parsed subscript validated for Portable Text footer rendering.
+ */
+export interface ArticleUiSubscript {
+  label?: string;
+  text: string;
+  url?: string;
+}

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/utils.ts
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/utils.ts
@@ -1,0 +1,41 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import type { SanityArticle } from '@/lib/sanity/article-types';
+
+import type { ArticleUiSubscript } from './types';
+
+/**
+ * Formats a Sanity article ISO date string for hero display (British-style ordering).
+ *
+ * @param isoDate - ISO date string when present
+ * @returns Formatted string such as \"20 November 2025\" or empty when missing
+ */
+export function formatArticleHeroDate(isoDate: unknown): string {
+  return isoDate != null
+    ? new Date(isoDate as string)
+        .toLocaleDateString('en-GB', {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        })
+        .replace(/\s(\d{4})$/, ', $1')
+    : '';
+}
+
+/**
+ * Returns subscript rows safe for rendering beneath the article body.
+ *
+ * @param article - Sanity article
+ * @returns Filtered footnote list
+ */
+export function parseArticleSubscripts(
+  article: SanityArticle
+): ArticleUiSubscript[] {
+  const raw = article.subscripts;
+  return Array.isArray(raw)
+    ? raw.filter(
+        (item): item is ArticleUiSubscript =>
+          typeof item?.text === 'string' && item.text.trim().length > 0
+      )
+    : [];
+}

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/[slug]/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/[slug]/layout.tsx
@@ -1,30 +1,11 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import sanityQuery from '@/lib/sanity/query';
-import { Metadata } from 'next';
-
-export async function generateMetadata({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}): Promise<Metadata> {
-  // This should be cached from `page.tsx` (metadata is rendered after RSC)
-  const article = await sanityQuery(
-    'news',
-    await params,
-    {
-      next: { revalidate: 60 * 60 },
-    },
-    0
-  );
-
-  return {
-    title: { default: article.title, template: '%s | Todd United States' },
-    description: article.summary,
-  };
-}
-
-export default async function Layout({
+/**
+ * Transparent layout wrapper for deprecated `/news/[slug]` paths (redirect handlers).
+ *
+ * @param props - Layout children slot
+ */
+export default function LegacyNewsSlugLayout({
   children,
 }: {
   children: React.ReactNode;

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/[slug]/page.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/[slug]/page.test.tsx
@@ -1,113 +1,81 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import { TooltipProvider } from '@/components/ui/tooltip';
-import { renderWithNextIntl, screen } from '@/test/test-utils';
 import '@testing-library/jest-dom';
-import { describe, expect, it, vi } from 'vitest';
-import NewsPage from './page';
+import { redirect, permanentRedirect, notFound } from 'next/navigation';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import LegacyNewsArticleRedirect from './page';
 
-const { item } = vi.hoisted(() => {
-  return {
-    item: {
-      title: 'New AI Model Sets Performance Record',
-      source: 'TechCrunch',
-      date: '2024-11-20T00:00:00.000Z',
-      summary:
-        'A breakthrough AI model has surpassed previous benchmarks, signaling a major shift in machine learning research.',
-      slug: { current: 'new-ai' },
-      content: [
-        {
-          _key: 'ce12009ed6af',
-          _type: 'block',
-          children: [
-            {
-              _key: '64e6a6b07265',
-              _type: 'span',
-              marks: [],
-              text: 'Test content.',
-            },
-          ],
-          markDefs: [],
-          style: 'normal',
-        },
-      ],
-      headerImage: {
-        _type: 'image',
-        alt: 'Header image',
-        asset: {
-          _ref: 'image-test-asset-2518x1690-png',
-          _type: 'reference',
-        },
-      },
-    },
-  };
-});
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
+  notFound: vi.fn(),
+}));
 
-// Mock embla-carousel-react
-vi.mock('embla-carousel-react', () => {
-  const mockEmblaApi = {
-    scrollSnapList: vi.fn(() => [0, 1, 2]),
-    selectedScrollSnap: vi.fn(() => 0),
-    scrollPrev: vi.fn(),
-    scrollNext: vi.fn(),
-    scrollTo: vi.fn(),
-    on: vi.fn(),
-    off: vi.fn(),
-    canScrollPrev: vi.fn(() => true),
-    canScrollNext: vi.fn(() => true),
-  };
+const { getArticleBySlugMock, isInternalArticleMock } = vi.hoisted(() => ({
+  getArticleBySlugMock: vi.fn(),
+  isInternalArticleMock: vi.fn(),
+}));
 
-  return {
-    __esModule: true,
-    default: vi.fn(() => [
-      vi.fn(), // emblaRef
-      mockEmblaApi, // emblaApi
-    ]),
-  };
-});
+vi.mock('@/lib/sanity/articles', () => ({
+  getArticleBySlug: getArticleBySlugMock,
+  isInternalArticle: isInternalArticleMock,
+}));
 
-vi.mock('@/lib/sanity/query', () => {
-  return {
-    default: vi.fn().mockResolvedValue(item),
-  };
-});
+describe('Legacy /news/[slug] redirect handler', () => {
+  beforeEach(() => {
+    vi.mocked(redirect).mockClear();
+    vi.mocked(permanentRedirect).mockClear();
+    vi.mocked(notFound).mockClear();
+    getArticleBySlugMock.mockReset();
+    isInternalArticleMock.mockReset();
+  });
 
-const builder = {
-  width: vi.fn().mockReturnThis(),
-  height: vi.fn().mockReturnThis(),
-  src: vi.fn().mockReturnValue('mocked-url'),
-  url: vi.fn().mockReturnValue('https://google.com/test.png'),
-};
+  it('redirects externally when off-site URL is set', async () => {
+    getArticleBySlugMock.mockResolvedValueOnce({
+      _id: '1',
+      _type: 'news',
+      title: 'External story',
+      slug: { current: 'ext' },
+      offSiteUrl: 'https://press.example/ext',
+      summary: '',
+    });
+    isInternalArticleMock.mockReturnValueOnce(false);
 
-vi.mock('@/lib/sanity/utils', () => {
-  return {
-    urlFor: vi.fn(() => builder),
-  };
-});
+    await LegacyNewsArticleRedirect({
+      params: Promise.resolve({ locale: 'en', slug: 'ext' }),
+    });
 
-describe('News Page', () => {
-  it('renders without exploding', async () => {
-    // ??? tbh idk why this works exactly
-    renderWithNextIntl(
-      <TooltipProvider>
-        {await NewsPage({ params: Promise.resolve({ slug: 'news-article' }) })}
-      </TooltipProvider>
-    );
+    expect(permanentRedirect).not.toHaveBeenCalled();
+    expect(redirect).toHaveBeenCalledWith('https://press.example/ext');
+  });
 
-    expect(screen.getByText(item.title)).toBeInTheDocument();
+  it('permanent-redirects internal articles to /index/[slug]', async () => {
+    getArticleBySlugMock.mockResolvedValueOnce({
+      _id: '2',
+      _type: 'news',
+      title: 'Internal piece',
+      slug: { current: 'internal-piece' },
+      summary: '',
+    });
+    isInternalArticleMock.mockReturnValueOnce(true);
 
-    const formattedDate = new Date(item.date)
-      .toLocaleDateString('en-GB', {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-      })
-      .replace(/\s(\d{4})$/, ', $1');
+    await LegacyNewsArticleRedirect({
+      params: Promise.resolve({ locale: 'es', slug: 'internal-piece' }),
+    });
 
-    expect(screen.getByText(formattedDate)).toBeInTheDocument();
-    expect(screen.getByText(item.summary)).toBeInTheDocument();
-    expect(
-      screen.getByText(item.content[0].children[0].text)
-    ).toBeInTheDocument();
+    expect(redirect).not.toHaveBeenCalled();
+    expect(permanentRedirect).toHaveBeenCalledWith('/es/index/internal-piece');
+  });
+
+  it('calls notFound when article is missing', async () => {
+    getArticleBySlugMock.mockResolvedValueOnce(null);
+
+    await LegacyNewsArticleRedirect({
+      params: Promise.resolve({ locale: 'en', slug: 'missing' }),
+    });
+
+    expect(notFound).toHaveBeenCalled();
+    expect(permanentRedirect).not.toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
   });
 });

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/[slug]/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/[slug]/page.tsx
@@ -1,196 +1,29 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import ArticleShareCopyLink from '@/components/common/news/article-share-copy-link';
-import SanityHeaderImage from '@/components/sanity/news/sanity-header-image';
-import SanityNormal from '@/components/sanity/news/sanity-normal';
-import SanityLink from '@/components/sanity/sanity-link';
-import sanityQuery from '@/lib/sanity/query';
-import { urlFor } from '@/lib/sanity/utils';
-import { PortableText, PortableTextReactComponents } from 'next-sanity';
-import { notFound, redirect } from 'next/navigation';
+import { getArticleBySlug, isInternalArticle } from '@/lib/sanity/articles';
+import { notFound, permanentRedirect, redirect } from 'next/navigation';
 
 /**
- * A news article page, rendered with Sanity CMS.
+ * Legacy `/news/[slug]` entry point preserved with redirects to `/index/[slug]` or outbound URLs.
  *
- * @param {Promise<{ slug: string }>} params - The slug of the article
- * @returns {JSX.Element} - The rendered news article*/
-export default async function NewsPage({
+ * @param params - Locale and slug
+ */
+export default async function LegacyNewsArticleRedirect({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ locale: string; slug: string }>;
 }) {
-  const article = await sanityQuery(
-    'news',
-    await params,
-    { next: { revalidate: 60 * 60 } },
-    0
-  );
-
-  if (!article) {
+  const { locale, slug } = await params;
+  const article = await getArticleBySlug(slug, {
+    next: { revalidate: 60 * 60 },
+  });
+  if (article === undefined || article === null) {
     notFound();
+    return;
   }
-
-  if (article.offSiteUrl && article.offSiteUrl.length > 0) {
-    redirect(article.offSiteUrl);
+  if (!isInternalArticle(article)) {
+    redirect(String(article.offSiteUrl));
+    return;
   }
-
-  const headerImageUrl = article.headerImage
-    ? urlFor(article.headerImage)?.url()
-    : undefined;
-
-  const formattedDate =
-    article.date != null
-      ? new Date(article.date as string)
-          .toLocaleDateString('en-GB', {
-            day: 'numeric',
-            month: 'long',
-            year: 'numeric',
-          })
-          .replace(/\s(\d{4})$/, ', $1')
-      : '';
-  const company = article.company;
-  const author = article.author;
-  const subtitle = article.subtitle;
-  const parsedSubscripts = Array.isArray(article.subscripts)
-    ? article.subscripts.filter(
-        (item): item is { label?: string; text: string; url?: string } =>
-          typeof item?.text === 'string' && item.text.trim().length > 0
-      )
-    : [];
-  const subscripts = parsedSubscripts;
-
-  /** Sanity helpers. See: https://github.com/portabletext/react-portabletext#customizing-components */
-  const portableTextComponents: Partial<PortableTextReactComponents> = {
-    block: {
-      normal: (props) => <SanityNormal {...props} summary={article.summary} />,
-
-      h1: ({ children }) => (
-        <h1 className="mt-[53px] text-3xl md:text-4xl lg:text-5xl font-normal leading-snug mb-2">
-          {children}
-        </h1>
-      ),
-      h2: ({ children }) => (
-        <h2 className="mt-[53px] text-2xl md:text-3xl lg:text-[30px]/[41px] font-normal leading-snug mb-2">
-          {children}
-        </h2>
-      ),
-      h3: ({ children }) => (
-        <h3 className="mt-[53px] text-xl md:text-2xl lg:text-3xl font-normal leading-snug mb-2">
-          {children}
-        </h3>
-      ),
-      h4: ({ children }) => (
-        <h4 className="mt-[53px] text-xl md:text-2xl lg:text-3xl font-normal leading-snug mb-2">
-          {children}
-        </h4>
-      ),
-      h5: ({ children }) => (
-        <h5 className="mt-[53px] text-lg md:text-xl lg:text-[20px]/[28px] font-normal leading-snug mb-2">
-          {children}
-        </h5>
-      ),
-    },
-    marks: {
-      link: (props) => <SanityLink {...props} />,
-    },
-  };
-
-  return (
-    <div className="max-w-[80%] mx-auto">
-      <main className="mt-20 container mx-auto min-h-screen flex flex-col gap-10 md:gap-4">
-        {/* Article Header */}
-        <header className="flex w-full max-w-[686px] flex-col items-center mx-auto lg:mb-6">
-          <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-center text-[14px] font-normal leading-[28px] tracking-normal">
-            {formattedDate ? (
-              <time dateTime={String(article.date)}>{formattedDate}</time>
-            ) : null}
-            {company ? (
-              <>
-                <span className="text-[#848484]">{company}</span>
-              </>
-            ) : null}
-          </div>
-          <h2 className="w-full max-w-[664px] mx-auto text-balance text-center font-normal tracking-normal text-[2rem] leading-[2rem] sm:text-[2.5rem] sm:leading-[2.5rem] md:text-[3rem] md:leading-[3rem] lg:text-[64px] lg:leading-[64px] mt-4 mb-8">
-            {article.title}
-          </h2>
-          {subtitle ? (
-            <p className="w-full max-w-[661px] mx-auto mb-8 text-center text-[16px] font-normal leading-[27px] tracking-normal text-foreground">
-              {subtitle}
-            </p>
-          ) : null}
-          <div className="mt-10 w-full border-t-[1px] border-[#EFEFEF] pt-6">
-            <ArticleShareCopyLink />
-          </div>
-        </header>
-        {/* Article Header Image */}
-        {article.headerImage && (
-          <div className="mt-8 mb-8 md:mb-12 lg:mb-16 flex flex-col items-center justify-center w-full mx-auto">
-            <SanityHeaderImage
-              headerImage={article.headerImage}
-              src={headerImageUrl}
-              alt={article.headerImage.alt ?? article.title ?? ''}
-              wrapperClassName="w-full"
-              overlayClassName="transition-all duration-200 ease-in-out"
-            />
-          </div>
-        )}
-        {/* Article Content */}
-        <div className="mt-10 mb-10 sm:mb-20 md:mb-26 flex w-full max-w-[685px] flex-col gap-[7px] mx-auto text-left">
-          {Array.isArray(article.content) && (
-            <PortableText
-              value={article.content}
-              components={portableTextComponents}
-            />
-          )}
-        </div>
-        {author || subscripts.length > 0 ? (
-          <section className="mb-10 w-full max-w-[685px] mx-auto text-left">
-            {author ? (
-              <>
-                <p className="text-[14px] font-normal leading-[32px] tracking-normal text-[#848484]">
-                  Author
-                </p>
-                <p className="text-[14px] font-normal leading-[32px] tracking-normal text-foreground">
-                  {author}
-                </p>
-              </>
-            ) : null}
-            {subscripts.length > 0 ? (
-              <div className="mt-6 w-full max-w-[645px]">
-                {subtitle ? (
-                  <p className="text-[14px] font-normal leading-[32px] tracking-normal text-foreground">
-                    {subtitle}
-                  </p>
-                ) : null}
-                <div className="mt-4 flex flex-col gap-3">
-                  {subscripts.map((subscript, index) => (
-                    <p
-                      key={`${subscript.label ?? index}-${subscript.text}`}
-                      className="text-[14px] italic font-normal leading-[22px] tracking-normal text-foreground"
-                    >
-                      <sup className="mr-1 inline-block align-super text-[10px] not-italic leading-none text-[#848484]">
-                        {subscript.label || `${index + 1}`}
-                      </sup>
-                      {subscript.url ? (
-                        <a
-                          href={subscript.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="underline underline-offset-2"
-                        >
-                          {subscript.text}
-                        </a>
-                      ) : (
-                        subscript.text
-                      )}
-                    </p>
-                  ))}
-                </div>
-              </div>
-            ) : null}
-          </section>
-        ) : null}
-      </main>
-    </div>
-  );
+  permanentRedirect(`/${locale}/index/${slug}`);
 }

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/page.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/page.test.tsx
@@ -111,11 +111,10 @@ vi.mock('embla-carousel-react', () => {
   };
 });
 
-vi.mock('@/lib/sanity/query', () => {
-  return {
-    default: vi.fn().mockResolvedValue(items),
-  };
-});
+vi.mock('@/lib/sanity/articles', () => ({
+  getArticlesByCollection: vi.fn().mockResolvedValue(items),
+  getFeaturedArticles: vi.fn().mockResolvedValue(items.slice(0, 2)),
+}));
 
 const builder = {
   width: vi.fn().mockReturnThis(),

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/page.tsx
@@ -4,21 +4,21 @@
 
 import { FeaturedNewsCarousel } from '@/components/common/news/featured-news-carousel';
 import { LatestNewsTable } from '@/components/common/news/latest-news-table';
-import sanityQuery from '@/lib/sanity/query';
-import { SanityDocument } from 'next-sanity';
+import {
+  getArticlesByCollection,
+  getFeaturedArticles,
+} from '@/lib/sanity/articles';
 
 /**
- * Highlighted news & general news
+ * Highlighted news & general news — only articles in the news collection.
+ *
  * @returns {JSX.Element} - The news page
  */
 export default async function News() {
-  const allNews = (await sanityQuery(
-    'news'
-  )) as unknown as Array<SanityDocument>;
-
-  const featuredNews = allNews
-    ? allNews.filter((article) => article.isFeatured)
-    : [];
+  const [allNews, featuredNews] = await Promise.all([
+    getArticlesByCollection('news'),
+    getFeaturedArticles('news'),
+  ]);
 
   return (
     <section id="newsroom" className="max-w-[1200px] mx-auto">

--- a/apps/site/src/app/sitemap.ts
+++ b/apps/site/src/app/sitemap.ts
@@ -3,9 +3,8 @@
 import { routing } from '@/i18n/config';
 import { env } from '@/lib/env';
 import { logger } from '@/lib/logger';
-import sanityQuery from '@/lib/sanity/query';
+import { getSitemapArticles } from '@/lib/sanity/articles';
 import type { MetadataRoute } from 'next';
-import { SanityDocument } from 'next-sanity';
 import { Languages } from 'next/dist/lib/metadata/types/alternative-urls-types';
 
 const baseUrl = env.baseUrl;
@@ -20,7 +19,7 @@ export const revalidate = 86400;
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemapEntries: MetadataRoute.Sitemap = getStaticSitemap().concat(
-    await getSanityNewsSitemap()
+    await getSanityArticleIndexSitemap()
   );
 
   return sitemapEntries;
@@ -76,37 +75,30 @@ function getStaticSitemap(): MetadataRoute.Sitemap {
   return sitemapEntries;
 }
 
-/** Generates sitemap entries based off of all of the documents from Sanity. Ignores articles with offsite URLs. Note the potentially scuffed type assertion:
+/** Sanity-driven article URLs (`/index/[slug]`), excluding outbound links and explicit SEO exclusions via `excludeFromSitemap`.
  *
- * ```ts
- * const newsArticles = (await sanityQuery(
- *   'news'
- * )) as unknown as Array<SanityDocument>;
- * ```
- *
- * @returns {MetadataRoute.Sitemap} Sitemap entries for news articles
+ * @returns {MetadataRoute.Sitemap} Sitemap rows for canonical article detail pages
  */
-async function getSanityNewsSitemap(): Promise<MetadataRoute.Sitemap> {
+async function getSanityArticleIndexSitemap(): Promise<MetadataRoute.Sitemap> {
   const sitemapEntries: MetadataRoute.Sitemap = [];
 
   try {
-    // Valid
-    const newsArticles = (await sanityQuery(
-      'news'
-    )) as unknown as Array<SanityDocument>;
+    const articles = await getSitemapArticles({
+      next: { revalidate: 86400 },
+    });
 
     for (const locale of routing.locales) {
-      for (const newsArticle of newsArticles) {
-        if (newsArticle.offSiteUrl && newsArticle.offSiteUrl.length > 0) {
+      for (const article of articles) {
+        const slug = article.slug?.current;
+
+        if (slug === undefined || slug === null || slug.length === 0) {
           continue;
         }
-        const slug = newsArticle.slug.current;
-        const lastModified = newsArticle._updatedAt;
 
-        // Normalize internal article links so sitemap URLs are:
-        // toddagriscience.com/{locale}/news/{example-article-title}
-        // instead of toddagriscience.com/{locale}/news/articles/{example-article-title}
-        const url = `${baseUrl}/${locale}/news/${slug}`;
+        const lastModified =
+          article._updatedAt !== undefined ? article._updatedAt : new Date();
+        /** toddagriscience.com/{locale}/index/{slug} */
+        const url = `${baseUrl}/${locale}/index/${slug}`;
 
         sitemapEntries.push({
           url,
@@ -114,64 +106,16 @@ async function getSanityNewsSitemap(): Promise<MetadataRoute.Sitemap> {
           changeFrequency: 'weekly',
           priority: 0.7,
           alternates: {
-            // Ensure alternates match the normalized news URL shape
-            languages: getSupportedLanguages(`/news/${slug}`),
+            languages: getSupportedLanguages(`/index/${slug}`),
           },
         });
       }
     }
   } catch (error) {
-    logger.error('Error generating Sanity news sitemap: ', error);
+    logger.error('Error generating Sanity article sitemap:', error);
   }
 
   return sitemapEntries;
-}
-
-/**
- * Parses article dates with fallback handling for various formats
- * Supports formats like "Apr 15, 2025" and ISO strings
- * @param {string} dateString - The date string to parse
- * @returns {string} ISO date string or current date as fallback
- */
-function parseArticleDate(dateString: string): string {
-  try {
-    // Try parsing the date string directly first
-    let articleDate = new Date(dateString);
-
-    // If that fails, try parsing common formats
-    if (isNaN(articleDate.getTime())) {
-      // Try parsing formats like "Apr 15, 2025", "Mar 30, 2025"
-      const monthNames = [
-        'Jan',
-        'Feb',
-        'Mar',
-        'Apr',
-        'May',
-        'Jun',
-        'Jul',
-        'Aug',
-        'Sep',
-        'Oct',
-        'Nov',
-        'Dec',
-      ];
-
-      for (let i = 0; i < monthNames.length; i++) {
-        if (dateString.includes(monthNames[i])) {
-          articleDate = new Date(dateString);
-          break;
-        }
-      }
-    }
-
-    // Return ISO string if valid, otherwise use current date
-    return isNaN(articleDate.getTime())
-      ? new Date().toISOString()
-      : articleDate.toISOString();
-  } catch (error) {
-    logger.warn(`Failed to parse date "${dateString}":`, error);
-    return new Date().toISOString();
-  }
 }
 
 /**

--- a/apps/site/src/components/common/news/featured-news-carousel.test.tsx
+++ b/apps/site/src/components/common/news/featured-news-carousel.test.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom';
 import { FeaturedNewsCarousel } from './featured-news-carousel';
 import { render } from '@testing-library/react';
 import { vi, beforeEach, describe, it, expect } from 'vitest';
-import { SanityDocument } from 'next-sanity';
+import type { SanityArticle } from '@/lib/sanity/article-types';
 
 // Mock embla-carousel-react
 vi.mock('embla-carousel-react', () => {
@@ -129,7 +129,7 @@ describe('FeaturedNewsCarousel', () => {
   });
   it('renders without imploding', () => {
     render(
-      <FeaturedNewsCarousel items={items as unknown as SanityDocument[]} />
+      <FeaturedNewsCarousel items={items as unknown as SanityArticle[]} />
     );
 
     // Should only show the first three articles (assuming we're rendering this on a reasonably sized 16:9 screen)

--- a/apps/site/src/components/common/news/featured-news-carousel.tsx
+++ b/apps/site/src/components/common/news/featured-news-carousel.tsx
@@ -3,11 +3,26 @@
 'use client';
 
 import { Carousel, NewsCard } from '@/components/common';
+import type { SanityArticle } from '@/lib/sanity/article-types';
+import { getArticleCardHref } from '@/lib/sanity/article-urls';
 import { urlFor } from '@/lib/sanity/utils';
 import { useLocale } from 'next-intl';
-import { SanityDocument } from 'next-sanity';
 
 const articlePlaceholderRoute = '/article-placeholder.webp';
+
+/** Formats listing dates with a safe fallback when `date` is missing. */
+function formatArticleListingDate(
+  dateValue: string | undefined,
+  locale: string
+): string {
+  const safe = dateValue !== undefined && dateValue.length > 0 ? dateValue : '';
+  if (safe.length === 0) return '';
+  return new Date(safe).toLocaleDateString(locale, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
 
 /*
  * A carousel for featured news.
@@ -16,7 +31,7 @@ const articlePlaceholderRoute = '/article-placeholder.webp';
 export function FeaturedNewsCarousel({
   items = [],
 }: {
-  items: SanityDocument[];
+  items: SanityArticle[];
 }) {
   const locale = useLocale();
 
@@ -32,26 +47,19 @@ export function FeaturedNewsCarousel({
           image={
             article.thumbnail && article.thumbnail.asset
               ? {
-                  url: urlFor(article.thumbnail)?.url(),
-                  alt: article.thumbnail.alt,
+                  url:
+                    urlFor(article.thumbnail)?.url() ?? articlePlaceholderRoute,
+                  alt: article.thumbnail.alt ?? '',
                 }
               : {
                   url: articlePlaceholderRoute,
                   alt: '',
                 }
           }
-          source={article.source}
-          date={new Date(article.date).toLocaleDateString(locale, {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          })}
-          excerpt={article.summary}
-          link={
-            article.offSiteUrl && article.offSiteUrl.length > 0
-              ? article.offSiteUrl
-              : `/news/${article.slug.current}`
-          }
+          source={article.source ?? ''}
+          date={formatArticleListingDate(article.date, locale)}
+          excerpt={article.summary ?? ''}
+          link={getArticleCardHref(article)}
         />
       ))}
     </Carousel>

--- a/apps/site/src/components/common/news/latest-news-table.test.tsx
+++ b/apps/site/src/components/common/news/latest-news-table.test.tsx
@@ -4,7 +4,7 @@ import { screen, renderWithNextIntl } from '@/test/test-utils';
 import { LatestNewsTable } from './latest-news-table';
 import '@testing-library/jest-dom';
 import { act } from 'react';
-import { SanityDocument } from 'next-sanity';
+import type { SanityArticle } from '@/lib/sanity/article-types';
 import { describe, it, expect } from 'vitest';
 
 const items = [

--- a/apps/site/src/components/common/news/latest-news-table.tsx
+++ b/apps/site/src/components/common/news/latest-news-table.tsx
@@ -4,10 +4,10 @@
 
 import type { SanityArticle } from '@/lib/sanity/article-types';
 import { getArticleCardHref } from '@/lib/sanity/article-urls';
+import { Link } from '@/i18n/config';
 import clsx from 'clsx';
 import { ExternalLink } from 'lucide-react';
 import { useLocale } from 'next-intl';
-import Link from 'next/link';
 import { useState } from 'react';
 import { HiArrowLongDown } from 'react-icons/hi2';
 

--- a/apps/site/src/components/common/news/latest-news-table.tsx
+++ b/apps/site/src/components/common/news/latest-news-table.tsx
@@ -2,17 +2,31 @@
 
 'use client';
 
-import useCurrentUrl from '@/lib/hooks/useCurrentUrl';
+import type { SanityArticle } from '@/lib/sanity/article-types';
+import { getArticleCardHref } from '@/lib/sanity/article-urls';
 import clsx from 'clsx';
 import { ExternalLink } from 'lucide-react';
 import { useLocale } from 'next-intl';
-import { SanityDocument } from 'next-sanity';
 import Link from 'next/link';
 import { useState } from 'react';
 import { HiArrowLongDown } from 'react-icons/hi2';
 
 interface LatestNewsTableProps {
-  items: SanityDocument[];
+  items: SanityArticle[];
+}
+
+/** Formats listing dates with a safe fallback when `date` is missing. */
+function formatArticleListingDate(
+  dateValue: string | undefined,
+  locale: string
+): string {
+  const safe = dateValue !== undefined && dateValue.length > 0 ? dateValue : '';
+  if (safe.length === 0) return '';
+  return new Date(safe).toLocaleDateString(locale, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
 }
 
 export function LatestNewsTable({ items }: LatestNewsTableProps) {
@@ -24,7 +38,6 @@ export function LatestNewsTable({ items }: LatestNewsTableProps) {
   };
 
   const locale = useLocale();
-  const windowHref = useCurrentUrl();
 
   return (
     <div className="rounded-md text-[#555555] mx-auto px-2 md:px-6 flex flex-col justify-center">
@@ -47,11 +60,7 @@ export function LatestNewsTable({ items }: LatestNewsTableProps) {
           <div>{item.title}</div>
 
           <Link
-            href={
-              item.offSiteUrl
-                ? item.offSiteUrl
-                : windowHref + '/' + item.slug.current
-            }
+            href={getArticleCardHref(item)}
             rel="noopener noreferrer"
             aria-label={`Open ${item.title} in this tab`}
           >
@@ -62,11 +71,7 @@ export function LatestNewsTable({ items }: LatestNewsTableProps) {
           </Link>
 
           <div className="text-right">
-            {new Date(item.date).toLocaleDateString(locale, {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
+            {formatArticleListingDate(item.date, locale)}
           </div>
         </div>
       ))}

--- a/apps/site/src/lib/sanity/article-actions.ts
+++ b/apps/site/src/lib/sanity/article-actions.ts
@@ -1,0 +1,19 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+'use server';
+
+import { getArticlesByCollection } from '@/lib/sanity/articles';
+import type { ArticleCollection } from '@/lib/sanity/article-types';
+import type { SanityArticle } from '@/lib/sanity/article-types';
+
+/**
+ * Loads articles for the home/news highlights carousel (client-invoked server action).
+ *
+ * @param collection - Preferred collection slice (defaults to `news`)
+ * @returns Article documents
+ */
+export async function loadArticlesForHighlights(
+  collection: ArticleCollection = 'news'
+): Promise<SanityArticle[]> {
+  return getArticlesByCollection(collection);
+}

--- a/apps/site/src/lib/sanity/article-types.ts
+++ b/apps/site/src/lib/sanity/article-types.ts
@@ -1,0 +1,70 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import type { PortableTextBlock } from '@portabletext/types';
+
+/** Primary article classifications used across the site and Sanity. */
+export const ARTICLE_CONTENT_TYPES = [
+  'news',
+  'research',
+  'story',
+  'product-release',
+  'press',
+] as const;
+
+/** Type for `news.contentType`. */
+export type ArticleContentType = (typeof ARTICLE_CONTENT_TYPES)[number];
+
+/** Allowed collection keys for Discover / parent pages (`/news`, future `/research`, etc.). */
+export const ARTICLE_COLLECTIONS = ARTICLE_CONTENT_TYPES;
+
+export type ArticleCollection = (typeof ARTICLE_COLLECTIONS)[number];
+
+/** Image field shape reused from Sanity for articles. */
+export interface SanityArticleImageField {
+  _type?: string;
+  alt?: string;
+  asset?: { _ref?: string; _type?: string };
+}
+
+/** Portable Text block typed loosely for Sanity `news.content`. */
+export type SanityArticlePortableText = PortableTextBlock[] | undefined;
+
+/** Subscript entry on a news/article document. */
+export interface SanityArticleSubscript {
+  label?: string;
+  text: string;
+  url?: string;
+}
+
+/**
+ * Article document fetched from Sanity (`_type`: `news`).
+ * Editorial fields overlap with Portable Text previews and listing cards.
+ */
+export interface SanityArticle {
+  _id: string;
+  _type: 'news';
+  _updatedAt?: string;
+  title: string;
+  subtitle?: string;
+  slug: { current: string };
+  date?: string;
+  author?: string;
+  company?: string;
+  content?: SanityArticlePortableText;
+  summary?: string;
+  thumbnail?: SanityArticleImageField;
+  headerImage?: SanityArticleImageField & { _key?: string };
+  /** When set, the article is external and must not expose a canonical on-site detail page. */
+  offSiteUrl?: string;
+  isFeatured?: boolean;
+  source?: string;
+  subscripts?: SanityArticleSubscript[];
+  /** Primary category for routing (defaults to `news` when missing). */
+  contentType?: ArticleContentType;
+  /** Secondary parent pages where this article may appear. */
+  collections?: ArticleCollection[];
+  /** Preferred parent for breadcrumbs or analytics. */
+  canonicalParent?: ArticleCollection | string;
+  /** When true, omit from dynamic sitemap (internal articles only). */
+  excludeFromSitemap?: boolean;
+}

--- a/apps/site/src/lib/sanity/article-urls.test.ts
+++ b/apps/site/src/lib/sanity/article-urls.test.ts
@@ -1,0 +1,33 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import {
+  getArticleCardHref,
+  getInternalArticlePath,
+} from '@/lib/sanity/article-urls';
+import { describe, expect, it } from 'vitest';
+
+describe('getInternalArticlePath', () => {
+  it('returns `/index/{slug}` path', () => {
+    expect(getInternalArticlePath('my-article')).toBe('/index/my-article');
+  });
+});
+
+describe('getArticleCardHref', () => {
+  it('prefers off-site URL when defined', () => {
+    expect(
+      getArticleCardHref({
+        offSiteUrl: 'https://example.com/story',
+        slug: { current: 'ignored' },
+      })
+    ).toBe('https://example.com/story');
+  });
+
+  it('uses internal path when off-site URL is empty', () => {
+    expect(
+      getArticleCardHref({
+        offSiteUrl: '',
+        slug: { current: 'local-article' },
+      })
+    ).toBe('/index/local-article');
+  });
+});

--- a/apps/site/src/lib/sanity/article-urls.ts
+++ b/apps/site/src/lib/sanity/article-urls.ts
@@ -1,0 +1,32 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * Builds the locale-relative path for an on-site CMS article (`/index/[slug]`).
+ *
+ * @param slug - Article slug `current`
+ * @returns Path without locale prefix (`next-intl` adds locale)
+ */
+export function getInternalArticlePath(slug: string): string {
+  return `/index/${slug}`;
+}
+
+/**
+ * Destination for listing cards: external URL when set, otherwise the internal article path.
+ *
+ * @param article - Article-shaped object (`slug.current` required)
+ * @returns Absolute external URL or internal path for `Link`
+ */
+export function getArticleCardHref(article: {
+  offSiteUrl?: string | null;
+  slug: { current: string };
+}): string {
+  const external = article.offSiteUrl;
+  if (
+    external !== undefined &&
+    external !== null &&
+    String(external).trim() !== ''
+  ) {
+    return external;
+  }
+  return getInternalArticlePath(article.slug.current);
+}

--- a/apps/site/src/lib/sanity/articles.ts
+++ b/apps/site/src/lib/sanity/articles.ts
@@ -1,0 +1,199 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { client } from '@/lib/sanity/client';
+import { logger } from '@/lib/logger';
+import type { ArticleCollection } from '@/lib/sanity/article-types';
+import type { SanityArticle } from '@/lib/sanity/article-types';
+import { FilteredResponseQueryOptions } from 'next-sanity';
+
+const ARTICLE_DOCUMENT_TYPE = 'news';
+
+/** One hour ISR for marketing article surfaces. */
+const LISTING_REVALIDATE = 60 * 60;
+
+/** Default groq fragments for reusable article payloads. */
+const ARTICLE_PROJECTION = `{
+  _id,
+  _type,
+  _updatedAt,
+  title,
+  subtitle,
+  slug,
+  date,
+  author,
+  company,
+  content,
+  summary,
+  thumbnail,
+  headerImage,
+  offSiteUrl,
+  isFeatured,
+  source,
+  subscripts,
+  contentType,
+  collections,
+  canonicalParent,
+  excludeFromSitemap
+}`;
+
+/** Query options reused for article fetch surfaces. */
+const defaultListingOptions: FilteredResponseQueryOptions = {
+  next: { revalidate: LISTING_REVALIDATE },
+};
+
+/**
+ * Whether this article is intended to be read on-site (has no off-site URL).
+ *
+ * @param article - Sanity article document
+ * @returns True when the article should use `/index/[slug]`
+ */
+export function isInternalArticle(
+  article: Pick<SanityArticle, 'offSiteUrl'>
+): boolean {
+  const url = article.offSiteUrl;
+  return url === undefined || url === null || String(url).trim() === '';
+}
+
+/**
+ * Whether the article should appear in the dynamic XML sitemap.
+ *
+ * @param article - Sanity article document
+ * @returns True when the URL may be indexed
+ */
+export function isSitemapArticle(article: SanityArticle): boolean {
+  if (!isInternalArticle(article)) return false;
+  return article.excludeFromSitemap !== true;
+}
+
+/**
+ * Lowercase collection key used in GROQ filters.
+ *
+ * @param collection - Marketing collection key
+ * @returns Normalized string
+ */
+function collectionParam(collection: ArticleCollection): string {
+  return collection;
+}
+
+/**
+ * Fetch a single article by slug.
+ *
+ * @param slug - Slug `current` value
+ * @param options - Optional Sanity fetch options
+ * @returns Article or null
+ */
+export async function getArticleBySlug(
+  slug: string,
+  options?: FilteredResponseQueryOptions
+): Promise<SanityArticle | null> {
+  try {
+    const query = `*[_type == "${ARTICLE_DOCUMENT_TYPE}" && slug.current == $slug][0] ${ARTICLE_PROJECTION}`;
+    const article = await client.fetch<SanityArticle | null>(
+      query,
+      { slug },
+      options
+    );
+    return article ?? null;
+  } catch (error) {
+    logger.error('Sanity getArticleBySlug failed', error);
+    return null;
+  }
+}
+
+/**
+ * Articles that belong to a collection: primary `contentType` or optional `collections` membership.
+ * Missing `contentType` in CMS is treated as `news`. Sorted by `date` descending.
+ *
+ * @param collection - e.g. `news`, `research`
+ * @param options - Optional Sanity fetch options
+ * @returns Article list
+ */
+export async function getArticlesByCollection(
+  collection: ArticleCollection,
+  options?: FilteredResponseQueryOptions
+): Promise<SanityArticle[]> {
+  const c = collectionParam(collection);
+  try {
+    const query = `*[_type == "${ARTICLE_DOCUMENT_TYPE}" && (
+        coalesce(contentType, "news") == $collection ||
+        $collection in coalesce(collections, [])
+      )] | order(date desc) ${ARTICLE_PROJECTION}`;
+    const articles = await client.fetch<SanityArticle[]>(
+      query,
+      { collection: c },
+      options ?? defaultListingOptions
+    );
+    return Array.isArray(articles) ? articles : [];
+  } catch (error) {
+    logger.error('Sanity getArticlesByCollection failed', error);
+    return [];
+  }
+}
+
+/**
+ * Featured articles optionally scoped to a collection (primary type or `collections` array).
+ *
+ * @param collection - When set, restricts to articles in this collection
+ * @param options - Optional Sanity fetch options
+ * @returns Article list sorted by date descending
+ */
+export async function getFeaturedArticles(
+  collection?: ArticleCollection,
+  options?: FilteredResponseQueryOptions
+): Promise<SanityArticle[]> {
+  if (collection === undefined) {
+    try {
+      const query = `*[_type == "${ARTICLE_DOCUMENT_TYPE}" && isFeatured == true] | order(date desc) ${ARTICLE_PROJECTION}`;
+      const articles = await client.fetch<SanityArticle[]>(
+        query,
+        {},
+        options ?? defaultListingOptions
+      );
+      return Array.isArray(articles) ? articles : [];
+    } catch (error) {
+      logger.error('Sanity getFeaturedArticles (global) failed', error);
+      return [];
+    }
+  }
+
+  try {
+    const c = collectionParam(collection);
+    const query = `*[_type == "${ARTICLE_DOCUMENT_TYPE}" && isFeatured == true && (
+      coalesce(contentType, "news") == $collection ||
+      $collection in coalesce(collections, [])
+    )] | order(date desc) ${ARTICLE_PROJECTION}`;
+    const articles = await client.fetch<SanityArticle[]>(
+      query,
+      { collection: c },
+      options ?? defaultListingOptions
+    );
+    return Array.isArray(articles) ? articles : [];
+  } catch (error) {
+    logger.error('Sanity getFeaturedArticles (collection) failed', error);
+    return [];
+  }
+}
+
+/**
+ * Articles eligible for the dynamic sitemap: internal URLs only, respecting `excludeFromSitemap`.
+ *
+ * @param options - Optional Sanity fetch options (`revalidate` defaults to sitemap cadence externally)
+ * @returns Article list sorted by `_updatedAt` descending when present
+ */
+export async function getSitemapArticles(
+  options?: FilteredResponseQueryOptions
+): Promise<SanityArticle[]> {
+  try {
+    const query = `*[_type == "${ARTICLE_DOCUMENT_TYPE}" && (!defined(offSiteUrl) || offSiteUrl == "")] | order(_updatedAt desc) ${ARTICLE_PROJECTION}`;
+    const articles = await client.fetch<SanityArticle[]>(
+      query,
+      {},
+      options ?? {}
+    );
+    if (!Array.isArray(articles)) return [];
+    return articles.filter(isSitemapArticle);
+  } catch (error) {
+    logger.error('Sanity getSitemapArticles failed', error);
+    return [];
+  }
+}


### PR DESCRIPTION
## Description

Fixes #842 

This change implements the single shared article surface at `/{locale}/index/[slug]` so press, stories, product notes, research, and similar content types can share one template while listings under `/news`, `/research`, and future hubs can deep-link consistently.

Summary of what shipped:
- Sanity CMS: Schema and types extended for categorization and metadata (contentType, collections, related fields as designed) so the frontend can distinguish article kinds and assemble listings.`
- Routing: Canonical article route under `index/[slug]`; `/news/[slug]` kept as redirects toward the canonical URL so bookmarks and inbound links stay valid while URLs converge on `/index/` for the template.
- External articles: Readers hit a Todd URL such as `/news/[slug]` that immediately sends them to the real article elsewhere. The sitemap only includes real on-site articles (e.g. under `/index/…`), not these shortcut/redirect URLs.
- Frontend: Listing components, URL helpers, and server actions/query paths updated so cards and links resolve to `/…/index/{slug}`; article shell/metadata adjusted for the unified template where needed.

## Out of Scope
**Note** that this does not close #290, #842 stays on routes, CMS fields, and frontend wiring; Sanity TypeGen (typed schemas + GROQ, and eventual `useDocument` / `useDocuments` instead of hand-written `sanityQuery`) is still tracked on #290.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
