### PR TITLE
hotfix: allow wordmark <img> off-site

### DIFF
--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -115,6 +115,25 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      // Last so CORP wins: allow wordmark <img> off-site (e.g. email templates).
+      {
+        source: '/wordmark.png',
+        headers: [
+          {
+            key: 'Cross-Origin-Resource-Policy',
+            value: 'cross-origin',
+          },
+        ],
+      },
+      {
+        source: '/wordmark.svg',
+        headers: [
+          {
+            key: 'Cross-Origin-Resource-Policy',
+            value: 'cross-origin',
+          },
+        ],
+      },
     ];
   },
 


### PR DESCRIPTION
## Description

Allows wordmark PNG and SVG to be rendered off-site.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x]  You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
