### PR TITLE
fix: safari flash, scroll-back, and self-referential redirects

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/[slug]/page.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/[slug]/page.test.tsx
@@ -24,6 +24,10 @@ vi.mock('@/lib/sanity/articles', () => ({
   isCareerArticle: isCareerArticleMock,
 }));
 
+vi.mock('@/lib/env', () => ({
+  env: { baseUrl: 'https://toddagriscience.com' },
+}));
+
 describe('Legacy /careers/[slug] redirect handler', () => {
   beforeEach(() => {
     vi.mocked(redirect).mockClear();
@@ -32,6 +36,28 @@ describe('Legacy /careers/[slug] redirect handler', () => {
     getArticleBySlugMock.mockReset();
     isInternalArticleMock.mockReset();
     isCareerArticleMock.mockReset();
+  });
+
+  it('permanent-redirects to /index when off-site URL points at the same legacy careers path', async () => {
+    const article = {
+      _id: '1b',
+      _type: 'news',
+      title: 'Loop role',
+      slug: { current: 'loop-role' },
+      offSiteUrl: 'https://toddagriscience.com/en/careers/loop-role',
+      summary: '',
+      contentType: 'careers' as const,
+    };
+    getArticleBySlugMock.mockResolvedValueOnce(article);
+    isCareerArticleMock.mockReturnValueOnce(true);
+    isInternalArticleMock.mockReturnValueOnce(false);
+
+    await LegacyCareersArticleRedirect({
+      params: Promise.resolve({ locale: 'en', slug: 'loop-role' }),
+    });
+
+    expect(redirect).not.toHaveBeenCalled();
+    expect(permanentRedirect).toHaveBeenCalledWith('/en/index/loop-role');
   });
 
   it('redirects externally when off-site URL is set', async () => {

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/[slug]/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/[slug]/page.tsx
@@ -1,5 +1,7 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { env } from '@/lib/env';
+import { isSelfReferentialArticleUrl } from '@/lib/sanity/article-urls';
 import {
   getArticleBySlug,
   isCareerArticle,
@@ -31,6 +33,17 @@ export default async function LegacyCareersArticleRedirect({
     return;
   }
   if (!isInternalArticle(article)) {
+    if (
+      isSelfReferentialArticleUrl(
+        String(article.offSiteUrl),
+        locale,
+        slug,
+        env.baseUrl
+      )
+    ) {
+      permanentRedirect(`/${locale}/index/${slug}`);
+      return;
+    }
     redirect(String(article.offSiteUrl));
     return;
   }

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/footer/footer.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/footer/footer.tsx
@@ -78,8 +78,16 @@ const Footer = () => {
   const [langOpen, setLangOpen] = useState(false);
   const [pendingLocale, setPendingLocale] = useState<string | null>(null);
 
+  const trimPath = (p: string) => p.replace(/\/+$/, '') || '/';
+
   const handleLocaleChange = (newLocale: string) => {
     setLangOpen(false);
+    const segments = pathname.split('/');
+    segments[1] = newLocale;
+    const newPath = segments.join('/') || `/${newLocale}`;
+    if (trimPath(newPath) === trimPath(pathname)) {
+      return;
+    }
     setPendingLocale(newLocale);
   };
 

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/index/[slug]/page.tsx
@@ -2,6 +2,8 @@
 
 import SanityNormal from '@/components/sanity/news/sanity-normal';
 import SanityLink from '@/components/sanity/sanity-link';
+import { env } from '@/lib/env';
+import { isSelfReferentialArticleUrl } from '@/lib/sanity/article-urls';
 import { getArticleBySlug, isInternalArticle } from '@/lib/sanity/articles';
 import { urlFor } from '@/lib/sanity/utils';
 import { PortableTextReactComponents } from 'next-sanity';
@@ -22,7 +24,7 @@ export default async function ArticleIndexPage({
 }: {
   params: Promise<{ locale: string; slug: string }>;
 }) {
-  const { slug } = await params;
+  const { slug, locale } = await params;
   const article = await getArticleBySlug(slug, {
     next: { revalidate: 60 * 60 },
   });
@@ -32,7 +34,16 @@ export default async function ArticleIndexPage({
     return;
   }
 
-  if (!isInternalArticle(article)) {
+  const outbound =
+    !isInternalArticle(article) &&
+    !isSelfReferentialArticleUrl(
+      String(article.offSiteUrl),
+      locale,
+      slug,
+      env.baseUrl
+    );
+
+  if (outbound) {
     redirect(article.offSiteUrl as string);
     return;
   }

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/[slug]/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/[slug]/page.tsx
@@ -1,5 +1,7 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { env } from '@/lib/env';
+import { isSelfReferentialArticleUrl } from '@/lib/sanity/article-urls';
 import { getArticleBySlug, isInternalArticle } from '@/lib/sanity/articles';
 import { notFound, permanentRedirect, redirect } from 'next/navigation';
 
@@ -22,6 +24,17 @@ export default async function LegacyNewsArticleRedirect({
     return;
   }
   if (!isInternalArticle(article)) {
+    if (
+      isSelfReferentialArticleUrl(
+        String(article.offSiteUrl),
+        locale,
+        slug,
+        env.baseUrl
+      )
+    ) {
+      permanentRedirect(`/${locale}/index/${slug}`);
+      return;
+    }
     redirect(String(article.offSiteUrl));
     return;
   }

--- a/apps/site/src/components/common/utils/fade-in/fade-in.tsx
+++ b/apps/site/src/components/common/utils/fade-in/fade-in.tsx
@@ -9,11 +9,10 @@ import React from 'react';
 import type FadeInProps from './types/fade-in';
 
 /**
- * Inner component that accesses `usePathname()` (uncached request data)
- * and applies a fade-in animation keyed to the current route.
+ * Inner component keyed by `usePathname()`; opacity remains solid to avoid transition flashes.
  *
  * @param props - {@link FadeInProps}
- * @returns Animated wrapper around children
+ * @returns Wrapper around children
  */
 function FadeInInner({
   children,
@@ -25,9 +24,8 @@ function FadeInInner({
   return (
     <motion.div
       key={pathname}
-      initial={{ opacity: 0.1 }}
+      initial={{ opacity: 1 }}
       animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
       transition={{ duration, type: 'tween' }}
       className={className}
     >
@@ -37,15 +35,13 @@ function FadeInInner({
 }
 
 /**
- * FadeIn component that fades the entire page content on navigation.
- * Wraps the pathname-dependent animation in a Suspense boundary so
- * it does not block prerendering when `cacheComponents` is enabled.
- * The fallback renders children immediately without animation.
+ * Layout wrapper keyed by pathname inside `Suspense` (for `cacheComponents` compatibility).
+ * Uses full opacity so route changes do not show a semi-transparent loading frame.
  *
  * @param {React.ReactNode} children - The content to animate
- * @param {number} duration - Animation duration in seconds (default: 0.73)
+ * @param {number} duration - Kept for API compatibility with Framer Motion transition
  * @param {string} className - Additional CSS classes
- * @returns {JSX.Element} - The animated fade-in component
+ * @returns {JSX.Element} - The fade-in shell component
  */
 const FadeIn: React.FC<FadeInProps> = ({
   children,

--- a/apps/site/src/components/common/utils/smooth-scroll/smooth-scroll.tsx
+++ b/apps/site/src/components/common/utils/smooth-scroll/smooth-scroll.tsx
@@ -3,8 +3,9 @@
 'use client';
 
 import Lenis from '@studio-freight/lenis';
-import { usePathname, useRouter } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import { logger } from '@/lib/logger';
+import { usePathname } from 'next/navigation';
+import React, { useEffect, useRef, useState } from 'react';
 
 /**
  * Global Window interface extension to include Lenis instance
@@ -27,9 +28,18 @@ export default function SmoothScroll({
 }: {
   children: React.ReactNode;
 }) {
-  const router = useRouter();
   const pathname = usePathname();
   const [isLenisReady, setIsLenisReady] = useState(false);
+  /** When true, the latest navigation came from the history stack (back/forward); skip scroll-to-top. */
+  const skipScrollFromHistory = useRef(false);
+
+  useEffect(() => {
+    const onPopState = () => {
+      skipScrollFromHistory.current = true;
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
 
   useEffect(() => {
     let lenis: Lenis | null = null;
@@ -51,7 +61,7 @@ export default function SmoothScroll({
         window.lenis = lenis;
         setIsLenisReady(true);
       } catch (e) {
-        console.error('Lenis Initialization Error', e);
+        logger.error('Lenis initialization failed', e);
         return;
       }
 
@@ -89,13 +99,16 @@ export default function SmoothScroll({
         delete window.lenis;
       }
     };
-  }, [router]);
+  }, []);
 
   // Handle scroll to top on navigation - only when Lenis is ready
   useEffect(() => {
-    if (isLenisReady && window.lenis) {
-      window.lenis.scrollTo(0, { immediate: true });
+    if (!isLenisReady || !window.lenis) return;
+    if (skipScrollFromHistory.current) {
+      skipScrollFromHistory.current = false;
+      return;
     }
+    window.lenis.scrollTo(0, { immediate: true });
   }, [pathname, isLenisReady]);
 
   return <>{children}</>;

--- a/apps/site/src/lib/sanity/article-urls.test.ts
+++ b/apps/site/src/lib/sanity/article-urls.test.ts
@@ -3,6 +3,7 @@
 import {
   getArticleCardHref,
   getInternalArticlePath,
+  isSelfReferentialArticleUrl,
 } from '@/lib/sanity/article-urls';
 import { describe, expect, it } from 'vitest';
 
@@ -29,5 +30,59 @@ describe('getArticleCardHref', () => {
         slug: { current: 'local-article' },
       })
     ).toBe('/index/local-article');
+  });
+});
+
+const base = 'https://toddagriscience.com';
+
+describe('isSelfReferentialArticleUrl', () => {
+  it('returns true for same-origin legacy careers path with matching slug', () => {
+    expect(
+      isSelfReferentialArticleUrl(
+        `${base}/en/careers/my-role`,
+        'en',
+        'my-role',
+        base
+      )
+    ).toBe(true);
+  });
+
+  it('returns true for relative index path', () => {
+    expect(isSelfReferentialArticleUrl('/en/index/x', 'en', 'x', base)).toBe(
+      true
+    );
+  });
+
+  it('returns false for a different slug on careers', () => {
+    expect(
+      isSelfReferentialArticleUrl(
+        `${base}/en/careers/other`,
+        'en',
+        'my-role',
+        base
+      )
+    ).toBe(false);
+  });
+
+  it('returns false for unrelated external origins', () => {
+    expect(
+      isSelfReferentialArticleUrl(
+        'https://example.com/en/careers/my-role',
+        'en',
+        'my-role',
+        base
+      )
+    ).toBe(false);
+  });
+
+  it('matches www vs bare hostname', () => {
+    expect(
+      isSelfReferentialArticleUrl(
+        'https://www.toddagriscience.com/en/index/job',
+        'en',
+        'job',
+        'https://toddagriscience.com'
+      )
+    ).toBe(true);
   });
 });

--- a/apps/site/src/lib/sanity/article-urls.ts
+++ b/apps/site/src/lib/sanity/article-urls.ts
@@ -1,5 +1,64 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+/** Normalizes hostnames so `www.example.com` matches `example.com`. */
+function hostnameWithoutWww(host: string): string {
+  return host.replace(/^www\./i, '');
+}
+
+/**
+ * Whether two absolute URLs refer to the same site (scheme + host, ignoring `www.`).
+ *
+ * @param a - First URL string
+ * @param b - Second URL string
+ */
+function sameRegisteredHostname(a: string, b: string): boolean {
+  try {
+    const ua = new URL(a);
+    const ub = new URL(b);
+    return hostnameWithoutWww(ua.hostname) === hostnameWithoutWww(ub.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detects CMS `offSiteUrl` values that point back to this article’s own marketing URLs.
+ * Those would otherwise cause infinite redirects between `/index/[slug]`, `/news/[slug]`,
+ * and `/careers/[slug]` legacy handlers.
+ *
+ * @param offSiteUrl - Raw value from Sanity (absolute or site-relative)
+ * @param locale - Active locale segment (`en`, `es`, …)
+ * @param slug - Article `slug.current`
+ * @param baseUrl - Site base URL (e.g. `https://toddagriscience.com`)
+ * @returns True when the URL targets this document on-site and should not be used as an external redirect
+ */
+export function isSelfReferentialArticleUrl(
+  offSiteUrl: string,
+  locale: string,
+  slug: string,
+  baseUrl: string
+): boolean {
+  const trimmed = String(offSiteUrl).trim();
+  if (trimmed === '') return false;
+  try {
+    const site = new URL(baseUrl);
+    const target = new URL(trimmed, baseUrl);
+    if (!sameRegisteredHostname(target.href, site.href)) return false;
+    const normalized = target.pathname.replace(/\/+$/, '') || '/';
+    const paths = [
+      `/${locale}/index/${slug}`,
+      `/${locale}/careers/${slug}`,
+      `/${locale}/news/${slug}`,
+      `/index/${slug}`,
+      `/careers/${slug}`,
+      `/news/${slug}`,
+    ].map((p) => p.replace(/\/+$/, '') || '/');
+    return paths.includes(normalized);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Builds the locale-relative path for an on-site CMS article (`/index/[slug]`).
  *


### PR DESCRIPTION
- Keep FadeIn at full opacity to remove semi-transparent route transitions
- Skip Lenis scroll-to-top on popstate; stabilize Lenis init effect deps
- Break redirect loops when Sanity offSiteUrl targets same careers/index/news paths
- Skip footer locale navigation when target path matches current URL

## Description

Fixes #{issue number}

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] Any components that you've modified are accessible.
- [ ] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
