### PR TITLE
fix: navbar reload site, redirect with locale correctly

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/desktop-menu-item.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/desktop-menu-item.tsx
@@ -1,17 +1,23 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+'use client';
+
 import {
   NavigationMenuContent,
   NavigationMenuItem,
-  NavigationMenuLink,
   NavigationMenuTrigger,
 } from '@/components/ui/navigation-menu';
+import NavMenuLink from './nav-menu-link';
 import { DesktopMenuItemProps } from './types';
 
 /**
  * Renders a single top-level desktop menu entry. When the entry has children,
  * a NavigationMenu trigger reveals a full-width hover dropdown; otherwise the
  * entry is rendered as a plain navigation link.
+ *
+ * Uses `NavMenuLink` (which wraps Radix `NavigationMenuLink` directly with an
+ * intercepting onClick) so that internal navigation stays client-side and
+ * preserves the active locale prefix (e.g. `/es/about` instead of `/about`).
  *
  * @param props - The menu item to render.
  * @returns A `NavigationMenuItem` with optional dropdown content.
@@ -33,14 +39,12 @@ export default function DesktopMenuItem({ item }: DesktopMenuItemProps) {
           <ul className="relative grid w-full grid-flow-col grid-rows-3 gap-x-10 gap-y-1 py-4 pl-4">
             {item.items.map((subItem) => (
               <li key={subItem.title}>
-                <NavigationMenuLink asChild>
-                  <a
-                    href={subItem.url}
-                    className="block whitespace-nowrap py-1 text-[18px] font-normal transition-opacity duration-200 hover:opacity-70"
-                  >
-                    {subItem.title}
-                  </a>
-                </NavigationMenuLink>
+                <NavMenuLink
+                  href={subItem.url}
+                  className="block whitespace-nowrap py-1 text-[18px] font-normal transition-opacity duration-200 hover:opacity-70"
+                >
+                  {subItem.title}
+                </NavMenuLink>
               </li>
             ))}
           </ul>
@@ -51,12 +55,12 @@ export default function DesktopMenuItem({ item }: DesktopMenuItemProps) {
 
   return (
     <NavigationMenuItem>
-      <NavigationMenuLink
+      <NavMenuLink
         href={item.url}
         className="inline-flex h-10 w-max items-center justify-center px-4 py-2 text-sm font-normal transition-opacity hover:opacity-70"
       >
         {item.title}
-      </NavigationMenuLink>
+      </NavMenuLink>
     </NavigationMenuItem>
   );
 }

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/desktop-nav.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/desktop-nav.tsx
@@ -1,16 +1,25 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+'use client';
+
 import ToddHeader from '@/components/common/wordmark/todd-wordmark';
-import { Button } from '@/components/ui/button';
+import { buttonVariants } from '@/components/ui/button';
 import {
   NavigationMenu,
   NavigationMenuList,
 } from '@/components/ui/navigation-menu';
+import { Link } from '@/i18n/config';
+import { cn } from '@/lib/utils';
 import DesktopMenuItem from './desktop-menu-item';
 import { NavLayoutProps } from './types';
 
 /**
  * Desktop layout for the marketing header. Hidden below the `lg` breakpoint.
+ *
+ * Auth links are rendered as locale-aware `Link` elements styled with
+ * `buttonVariants` (rather than `Button asChild + Link`) to avoid the Radix
+ * Slot + `next/link` composition issue (see shadcn-ui/ui#8378) that can cause
+ * full page reloads in Next.js 16 + React 19.
  *
  * @param props - Resolved menu items and auth links to display.
  * @returns The desktop navigation row with logo, menu list, and auth buttons.
@@ -27,19 +36,24 @@ export default function DesktopNav({ menuItems, authLinks }: NavLayoutProps) {
             ))}
           </NavigationMenuList>
           <div className="flex items-center gap-5 px-5 justify-self-end">
-            <Button
-              className="text-sm font-normal"
-              asChild
-              variant="ghost"
-              size="sm"
+            <Link
+              href={authLinks.login.url}
+              className={cn(
+                buttonVariants({ variant: 'ghost', size: 'sm' }),
+                'text-sm font-normal'
+              )}
             >
-              <a href={authLinks.login.url}>{authLinks.login.title}</a>
-            </Button>
-            <Button className="text-sm font-normal" asChild size="sm">
-              <a className="text-sm font-normal" href={authLinks.signup.url}>
-                {authLinks.signup.title}
-              </a>
-            </Button>
+              {authLinks.login.title}
+            </Link>
+            <Link
+              href={authLinks.signup.url}
+              className={cn(
+                buttonVariants({ size: 'sm' }),
+                'text-sm font-normal'
+              )}
+            >
+              {authLinks.signup.title}
+            </Link>
           </div>
         </div>
       </NavigationMenu>

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/mobile-menu-item.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/mobile-menu-item.tsx
@@ -2,6 +2,7 @@
 
 'use client';
 
+import { Link } from '@/i18n/config';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
 import { MobileMenuItemProps } from './types';
@@ -9,6 +10,9 @@ import { MobileMenuItemProps } from './types';
 /**
  * Renders a single mobile menu entry. Items with children expand inline to
  * reveal sub-links; leaf items navigate directly and close the parent sheet.
+ *
+ * Uses the locale-aware `Link` from `@/i18n/config` so that internal navigation
+ * preserves the active locale prefix (e.g. `/es/about` instead of `/about`).
  *
  * @param props - The menu item and a callback invoked after navigation.
  * @returns A bordered list entry with optional expandable sub-links.
@@ -41,13 +45,23 @@ export default function MobileMenuItem({
           <ul className="flex flex-col gap-2 pb-3 pl-4">
             {item.items.map((subItem) => (
               <li key={subItem.title}>
-                <a
-                  href={subItem.url}
-                  className="block py-1 text-lg font-thin hover:opacity-70"
-                  onClick={onNavigate}
-                >
-                  {subItem.title}
-                </a>
+                {isExternalOrHash(subItem.url) ? (
+                  <a
+                    href={subItem.url}
+                    className="block py-1 text-lg font-thin hover:opacity-70"
+                    onClick={onNavigate}
+                  >
+                    {subItem.title}
+                  </a>
+                ) : (
+                  <Link
+                    href={subItem.url}
+                    className="block py-1 text-lg font-thin hover:opacity-70"
+                    onClick={onNavigate}
+                  >
+                    {subItem.title}
+                  </Link>
+                )}
               </li>
             ))}
           </ul>
@@ -56,13 +70,33 @@ export default function MobileMenuItem({
     );
   }
 
+  if (isExternalOrHash(item.url)) {
+    return (
+      <a
+        href={item.url}
+        className="block border-b border-[#E0E0E0] border-border/30 py-3 gap-4 text-[22px] font-normal"
+        onClick={onNavigate}
+      >
+        {item.title}
+      </a>
+    );
+  }
+
   return (
-    <a
+    <Link
       href={item.url}
       className="block border-b border-[#E0E0E0] border-border/30 py-3 gap-4 text-[22px] font-normal"
       onClick={onNavigate}
     >
       {item.title}
-    </a>
+    </Link>
   );
+}
+
+/**
+ * Treat hashes and absolute URLs as opaque hrefs so we don't run them through
+ * next-intl's locale-aware `Link`, which expects internal pathnames.
+ */
+function isExternalOrHash(url: string): boolean {
+  return url.startsWith('#') || /^[a-z][a-z0-9+.-]*:/i.test(url);
 }

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/mobile-nav.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/mobile-nav.tsx
@@ -3,13 +3,15 @@
 'use client';
 
 import ToddHeader from '@/components/common/wordmark/todd-wordmark';
-import { Button } from '@/components/ui/button';
+import { buttonVariants } from '@/components/ui/button';
 import {
   Sheet,
   SheetContent,
   SheetDescription,
   SheetTitle,
 } from '@/components/ui/sheet';
+import { Link } from '@/i18n/config';
+import { cn } from '@/lib/utils';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import HamburgerButton from './hamburger-button';
@@ -19,6 +21,11 @@ import { NavLayoutProps } from './types';
 /**
  * Mobile layout for the marketing header. Visible below the `lg` breakpoint
  * with a fullscreen sheet menu triggered from a fixed bottom bar.
+ *
+ * Auth links are rendered as locale-aware `Link` elements styled with
+ * `buttonVariants` (rather than `Button asChild + Link`) to avoid the Radix
+ * Slot + `next/link` composition issue (see shadcn-ui/ui#8378) that can cause
+ * full page reloads in Next.js 16 + React 19.
  *
  * @param props - Resolved menu items and auth links to display.
  * @returns The mobile navigation chrome and its sheet menu.
@@ -63,18 +70,16 @@ export default function MobileNav({ menuItems, authLinks }: NavLayoutProps) {
               ))}
             </nav>
             <div className="flex flex-col gap-3 px-6 pb-10">
-              <Button
-                className="w-auto justify-start text-lg hover:opacity-70"
-                asChild
-                variant="ghost"
+              <Link
+                href={authLinks.signup.url}
+                onClick={() => setIsMobileOpen(false)}
+                className={cn(
+                  buttonVariants({ variant: 'ghost' }),
+                  'w-auto justify-start text-lg hover:opacity-70'
+                )}
               >
-                <a
-                  href={authLinks.signup.url}
-                  onClick={() => setIsMobileOpen(false)}
-                >
-                  {authLinks.signup.title}
-                </a>
-              </Button>
+                {authLinks.signup.title}
+              </Link>
             </div>
           </SheetContent>
         </Sheet>
@@ -84,14 +89,15 @@ export default function MobileNav({ menuItems, authLinks }: NavLayoutProps) {
             label={t('menu.open')}
             onClick={() => setIsMobileOpen(true)}
           />
-          <Button
-            className="text-lg font-normal"
-            asChild
-            variant="ghost"
-            size="sm"
+          <Link
+            href={authLinks.login.url}
+            className={cn(
+              buttonVariants({ variant: 'ghost', size: 'sm' }),
+              'text-lg font-normal'
+            )}
           >
-            <a href={authLinks.login.url}>{authLinks.login.title}</a>
-          </Button>
+            {authLinks.login.title}
+          </Link>
         </div>
       </div>
     </div>

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/nav-menu-link.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/new-header/nav-menu-link.tsx
@@ -1,0 +1,103 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+'use client';
+
+import { NavigationMenuLink } from '@/components/ui/navigation-menu';
+import { useRouter } from '@/i18n/config';
+import { useLocale } from 'next-intl';
+import type { ComponentProps, MouseEvent, ReactNode } from 'react';
+
+/**
+ * Props for the `NavMenuLink` helper.
+ */
+export interface NavMenuLinkProps {
+  /** Pathname to navigate to. Internal paths are prefixed with the active locale. */
+  href: string;
+  /** Optional class names forwarded to the rendered anchor. */
+  className?: string;
+  /** Link contents. */
+  children: ReactNode;
+  /** Optional callback invoked before client-side navigation. */
+  onSelect?: () => void;
+}
+
+/**
+ * Returns true when an href should be treated as an opaque external/hash link
+ * (e.g. `#`, `mailto:`, `https://...`).
+ */
+function isExternalOrHash(url: string): boolean {
+  return url.startsWith('#') || /^[a-z][a-z0-9+.-]*:/i.test(url);
+}
+
+/**
+ * Navigation-menu link that performs locale-aware client-side navigation
+ * without relying on the Radix `asChild` + Slot composition with `next/link`.
+ *
+ * That composition has a known issue in Next.js 16 + React 19 where the
+ * slotted anchor can fail to materialize, breaking dropdown items and falling
+ * back to full page reloads (see shadcn-ui/ui#8378). Here we render
+ * `NavigationMenuLink` directly so the DOM always contains a real
+ * `<a href="/{locale}/path">` (good for SEO and Cmd-click "Open in new tab"),
+ * and intercept the click to push through next-intl's router for client-side
+ * navigation. External links and `#` hrefs render as standard anchors.
+ *
+ * @param props - {@link NavMenuLinkProps}
+ * @returns An accessible NavigationMenuLink wired for SPA navigation.
+ */
+export default function NavMenuLink({
+  href,
+  className,
+  children,
+  onSelect,
+  ...rest
+}: NavMenuLinkProps &
+  Omit<
+    ComponentProps<typeof NavigationMenuLink>,
+    'href' | 'className' | 'children' | 'onClick'
+  >) {
+  const router = useRouter();
+  const locale = useLocale();
+
+  if (isExternalOrHash(href)) {
+    return (
+      <NavigationMenuLink
+        href={href}
+        className={className}
+        onClick={onSelect}
+        {...rest}
+      >
+        {children}
+      </NavigationMenuLink>
+    );
+  }
+
+  const localizedHref = `/${locale}${href.startsWith('/') ? href : `/${href}`}`;
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    // Respect modifier clicks so users can still open links in a new tab.
+    if (
+      event.defaultPrevented ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      event.button !== 0
+    ) {
+      return;
+    }
+    event.preventDefault();
+    onSelect?.();
+    router.push(href);
+  };
+
+  return (
+    <NavigationMenuLink
+      href={localizedHref}
+      className={className}
+      onClick={handleClick}
+      {...rest}
+    >
+      {children}
+    </NavigationMenuLink>
+  );
+}


### PR DESCRIPTION
## Description

Fixes the marketing header so that:

- Clicking nav items on `/es` (or any non-default locale) stays on that locale instead of bouncing back to `/en`.
- Navigation uses client-side RSC routing - avoiding full page reloads.
- The "Company" dropdown actually renders its sub-items (About / Careers / News).
- The "Company" dropdown only opens on click now, not on hover (close-on-leave is unchanged).
- The "Company" trigger has the same pointer cursor and opacity-on-hover as the other nav items.
- The dropdown no longer gets clipped behind page content on `/news`.

The first issue was plain `<a href="/about">` tags in the new header - they're locale-less, so the middleware fell back to the `NEXT_LOCALE` cookie (which is `en` from the initial `/` -> `/en` redirect) and bounced you out of `/es`. Swapped them for the locale-aware `Link` from `@/i18n/config`, matching the footer.

The dropdown rendering + full reloads were both caused by an `asChild` + `next/link` incompatibility in Next.js 16 + React 19 ([shadcn-ui/ui#8378](https://github.com/shadcn-ui/ui/issues/8378)). Replaced those with a small `NavMenuLink` helper that uses `next-intl`'s router directly, and styled the auth buttons with `buttonVariants` on a plain `Link`.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
