### PR TITLE
refactor: changed the meta data for todd and had updated /index to /s…

### DIFF
--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -175,7 +175,11 @@ const nextConfig: NextConfig = {
         destination: '/:locale/research',
         permanent: true,
       },
-      // `/careers/index` is a real route (`careers/index/page.tsx`); do not add a redirect to `/careers`.
+      {
+        source: '/:locale(en|es)/careers/index',
+        destination: '/:locale/careers/search',
+        permanent: true,
+      },
       // Handles requests to go.toddagriscience.com/invite
       {
         source: '/invite',

--- a/apps/site/src/app/(authenticated)/(misc)/apply/layout.tsx
+++ b/apps/site/src/app/(authenticated)/(misc)/apply/layout.tsx
@@ -1,9 +1,10 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { siteConfig } from '@/lib/metadata';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: { default: 'Apply | Todd', template: '%s | Todd United States' },
+  title: { default: 'Apply | Todd', template: `%s | ${siteConfig.name}` },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/site/src/app/(authenticated)/(misc)/order/layout.tsx
+++ b/apps/site/src/app/(authenticated)/(misc)/order/layout.tsx
@@ -1,9 +1,10 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { siteConfig } from '@/lib/metadata';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: { default: 'Order | Todd', template: '%s | Todd United States' },
+  title: { default: 'Order | Todd', template: `%s | ${siteConfig.name}` },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/site/src/app/(authenticated)/(misc)/welcome/layout.tsx
+++ b/apps/site/src/app/(authenticated)/(misc)/welcome/layout.tsx
@@ -1,9 +1,10 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { siteConfig } from '@/lib/metadata';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: { default: 'Welcome | Todd', template: '%s | Todd United States' },
+  title: { default: 'Welcome | Todd', template: `%s | ${siteConfig.name}` },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/site/src/app/(go)/creators/layout.tsx
+++ b/apps/site/src/app/(go)/creators/layout.tsx
@@ -1,13 +1,14 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import { env } from '@/lib/env';
+import { siteConfig } from '@/lib/metadata';
 import { Metadata } from 'next';
 
 export async function generateMetadata({}: {}): Promise<Metadata> {
   return {
     metadataBase: new URL('https://go.toddagriscience.com'),
     title: {
-      absolute: `Todd Creator Program | Todd United States`,
+      absolute: `Todd Creator Program | ${siteConfig.name}`,
     },
     description: 'Help us make a impact on society.',
     openGraph: {

--- a/apps/site/src/app/(unauthenticated)/[locale]/(contact)/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(contact)/layout.tsx
@@ -1,10 +1,11 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import UnauthenticatedHeader from '@/components/common/unauthenticated-header/unauthenticated-header';
+import { siteConfig } from '@/lib/metadata';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: { default: 'Contact', template: '%s | Todd United States' },
+  title: { default: 'Contact', template: `%s | ${siteConfig.name}` },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/components/careers-landing.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/components/careers-landing.tsx
@@ -168,7 +168,7 @@ export async function CareersLanding({
       title: t('landing.hero.title'),
       subtitle: t('landing.hero.subtitle'),
       valuesLinkLabel: t('landing.hero.viewCareersCta'),
-      valuesAnchorHref: '/careers/index',
+      valuesAnchorHref: '/careers/search',
     },
     bridgeStatement: t('landing.bridgeStatement'),
     valuesBlock: {

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/fixtures/careers-landing-view.fixture.ts
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/fixtures/careers-landing-view.fixture.ts
@@ -9,7 +9,7 @@ export const CAREERS_LANDING_VIEW_FIXTURE: CareersLandingCopy = {
     title: 'Build the future',
     subtitle: 'Team subtitle.',
     valuesLinkLabel: 'View careers',
-    valuesAnchorHref: '/careers/index',
+    valuesAnchorHref: '/careers/search',
   },
   bridgeStatement: 'Bridge line.',
   valuesBlock: {
@@ -44,7 +44,7 @@ export const CAREERS_LANDING_VIEW_FIXTURE: CareersLandingCopy = {
     heading: 'Residency',
     body: 'Body.',
     ctaLabel: 'Learn more →',
-    ctaHref: '/careers/index',
+    ctaHref: '/careers/search',
     imageSrc: '/marketing/careers-1.webp',
     imageAlt: '',
   },
@@ -52,7 +52,7 @@ export const CAREERS_LANDING_VIEW_FIXTURE: CareersLandingCopy = {
     heading: 'Talent',
     body: 'Body.',
     ctaLabel: 'Learn more →',
-    ctaHref: '/careers/index',
+    ctaHref: '/careers/search',
     imageSrc: '/marketing/who-we-are-img.jpg',
     imageAlt: '',
   },
@@ -66,5 +66,5 @@ export const CAREERS_LANDING_VIEW_FIXTURE: CareersLandingCopy = {
   ],
   footerHeading: 'Footer headline',
   footerCtaLabel: 'View careers →',
-  footerCtaHref: '/careers/index',
+  footerCtaHref: '/careers/search',
 };

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/layout.tsx
@@ -1,6 +1,7 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import { env } from '@/lib/env';
+import { siteConfig } from '@/lib/metadata';
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
@@ -16,14 +17,14 @@ export async function generateMetadata({
   return {
     metadataBase: new URL('https://toddagriscience.com'),
     title: {
-      absolute: `${t('shortTitle')} | Todd United States`,
+      absolute: `${t('shortTitle')} | ${siteConfig.name}`,
     },
     description: t('description'),
     openGraph: {
       title: t('title'),
       description: t('description'),
       url: `${env.baseUrl}/${locale}/careers`,
-      siteName: 'Todd United States',
+      siteName: siteConfig.name,
       locale: locale,
       type: 'website',
       images: [

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/page.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/page.test.tsx
@@ -44,12 +44,12 @@ describe('Careers landing view', () => {
     expect(mainLandmark).toContainElement(h1Element);
 
     const valuesLink = screen.getByRole('link', { name: 'View careers' });
-    expect(valuesLink).toHaveAttribute('href', '/careers/index');
+    expect(valuesLink).toHaveAttribute('href', '/careers/search');
 
     const listingLink = screen.getByRole('link', {
       name: 'View careers →',
     });
-    expect(listingLink).toHaveAttribute('href', '/careers/index');
+    expect(listingLink).toHaveAttribute('href', '/careers/search');
 
     screen.getAllByRole('heading', { level: 2 }).forEach((heading) => {
       expect(mainLandmark).toContainElement(heading);

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/page.tsx
@@ -3,7 +3,7 @@
 import { CareersLanding } from './components/careers-landing';
 
 /**
- * Careers hub at `/careers`: company story and values; open roles live at `/careers/index`.
+ * Careers hub at `/careers`: company story and values; open roles live at `/careers/search`.
  *
  * @param params - Route params including locale
  */

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/search/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/search/layout.tsx
@@ -1,11 +1,12 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import { env } from '@/lib/env';
+import { siteConfig } from '@/lib/metadata';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
 /**
- * Metadata for **`/{locale}/careers/index`** (job listings index).
+ * Metadata for **`/{locale}/careers/search`** (job listings).
  *
  * @param params - Route params with locale
  */
@@ -20,14 +21,14 @@ export async function generateMetadata({
   return {
     metadataBase: new URL(env.baseUrl),
     title: {
-      absolute: `${t('shortTitle')} | Todd United States`,
+      absolute: `${t('shortTitle')} | ${siteConfig.name}`,
     },
     description: t('description'),
     openGraph: {
       title: t('title'),
       description: t('description'),
-      url: `${env.baseUrl}/${locale}/careers/index`,
-      siteName: 'Todd United States',
+      url: `${env.baseUrl}/${locale}/careers/search`,
+      siteName: siteConfig.name,
       locale: locale,
       type: 'website',
       images: [
@@ -51,11 +52,11 @@ export async function generateMetadata({
 }
 
 /**
- * Passthrough layout for the careers **`/index`** subtree.
+ * Passthrough layout for the careers **`/search`** subtree.
  *
  * @param props - Layout children slot
  */
-export default function CareersIndexLayout({
+export default function CareersSearchLayout({
   children,
 }: {
   children: React.ReactNode;

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/search/page.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/search/page.test.tsx
@@ -4,7 +4,7 @@ import type { SanityArticle } from '@/lib/sanity/article-types';
 import { renderWithNextIntl, screen } from '@/test/test-utils';
 import '@testing-library/jest-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import CareersIndexPage from './page';
+import CareersSearchPage from './page';
 
 const { getArticlesByCollectionMock } = vi.hoisted(() => ({
   getArticlesByCollectionMock: vi.fn(),
@@ -18,14 +18,14 @@ vi.mock('@/lib/sanity/articles', async (importOriginal) => {
   };
 });
 
-describe('CareersIndexPage', () => {
+describe('CareersSearchPage', () => {
   beforeEach(() => {
     getArticlesByCollectionMock.mockReset();
   });
 
   it('shows empty-state copy when Sanity returns no jobs', async () => {
     getArticlesByCollectionMock.mockResolvedValueOnce([]);
-    const node = await CareersIndexPage({
+    const node = await CareersSearchPage({
       params: Promise.resolve({ locale: 'en' }),
     });
     renderWithNextIntl(node);
@@ -49,7 +49,7 @@ describe('CareersIndexPage', () => {
       summary: '',
     };
     getArticlesByCollectionMock.mockResolvedValueOnce([job]);
-    const node = await CareersIndexPage({
+    const node = await CareersSearchPage({
       params: Promise.resolve({ locale: 'en' }),
     });
     renderWithNextIntl(node);

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/search/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/search/page.tsx
@@ -8,12 +8,12 @@ import { CareersJobList } from '../components/careers-job-list';
 /**
  * Careers job listings from Sanity (links use `/careers/[slug]` or external ATS URLs).
  *
- * Public URL: **`/{locale}/careers/index`** (distinct from the hub at **`/{locale}/careers`**).
+ * Public URL: **`/{locale}/careers/search`** (distinct from the hub at **`/{locale}/careers`**).
  *
  * @param params - Route params with locale
  * @returns Job listings or empty-state message
  */
-export default async function CareersIndexPage({
+export default async function CareersSearchPage({
   params,
 }: {
   params: Promise<{ locale: string }>;

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/types/careers-landing-copy.ts
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/types/careers-landing-copy.ts
@@ -16,7 +16,7 @@ export interface CareersLandingHeroCopy {
   subtitle: string;
   /** Outline pill label (e.g. “View careers” → listings) */
   valuesLinkLabel: string;
-  /** Pill destination (`/careers/index`, etc.) */
+  /** Pill destination (`/careers/search`, etc.) */
   valuesAnchorHref: string;
 }
 

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/layout.tsx
@@ -1,10 +1,11 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { siteConfig } from '@/lib/metadata';
 import { Metadata } from 'next';
 import { Footer, NewHeader } from './components';
 
 export const metadata: Metadata = {
-  title: { default: 'Marketing', template: '%s | Todd United States' },
+  title: { default: 'Marketing', template: `%s | ${siteConfig.name}` },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/layout.tsx
@@ -1,9 +1,10 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { siteConfig } from '@/lib/metadata';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: { default: 'News', template: '%s | Todd United States' },
+  title: { default: 'News', template: `%s | ${siteConfig.name}` },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/page.tsx
@@ -1,6 +1,7 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import LandingPage from './components/page/landing-page';
+import { siteConfig } from '@/lib/metadata';
 import type { Metadata } from 'next';
 
 /**
@@ -21,7 +22,7 @@ export const metadata: Metadata = {
     description:
       'Todd combines deep experience in regenerative agriculture, farm management and engaging consumers.',
     url: 'https://toddagriscience.com/en/',
-    siteName: 'Todd United States',
+    siteName: siteConfig.name,
     locale: 'en',
     type: 'website',
     images: [
@@ -30,7 +31,7 @@ export const metadata: Metadata = {
         width: 1300,
         height: 740,
         type: 'image/png',
-        alt: 'Todd United States',
+        alt: siteConfig.name,
       },
     ],
   },

--- a/apps/site/src/app/(unauthenticated)/[locale]/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/layout.tsx
@@ -3,6 +3,7 @@
 import { FadeIn, SmoothScroll } from '@/components/common';
 import { routing } from '@/i18n/config';
 import { env } from '@/lib/env';
+import { siteConfig } from '@/lib/metadata';
 import type { Metadata, Viewport } from 'next';
 import { Locale, NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations } from 'next-intl/server';
@@ -27,8 +28,8 @@ export async function generateMetadata({
 
   return {
     title: {
-      default: 'Todd United States',
-      template: '%s | Todd United States',
+      default: siteConfig.name,
+      template: `%s | ${siteConfig.name}`,
     },
     description: t('description'),
     metadataBase: new URL('https://toddagriscience.com'),
@@ -43,7 +44,7 @@ export async function generateMetadata({
       title: 'Todd | Global Leader in Sustainable Agriculture',
       description: t('description'),
       url: `${env.baseUrl}/${locale}`,
-      siteName: 'Todd United States',
+      siteName: siteConfig.name,
       locale: ogLocale,
       type: 'website',
       images: [
@@ -52,7 +53,7 @@ export async function generateMetadata({
           width: 1300,
           height: 740,
           type: 'image/png',
-          alt: 'Todd United States',
+          alt: siteConfig.name,
         },
       ],
     },

--- a/apps/site/src/app/(unauthenticated)/externship-terms/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/externship-terms/layout.tsx
@@ -1,9 +1,13 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { siteConfig } from '@/lib/metadata';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: { default: 'Externship Terms', template: '%s | Todd United States' },
+  title: {
+    default: 'Externship Terms',
+    template: `%s | ${siteConfig.name}`,
+  },
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/apps/site/src/app/(unauthenticated)/layout.tsx
+++ b/apps/site/src/app/(unauthenticated)/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeReset } from '@/components/common';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ThemeProvider } from '@/context/theme/ThemeContext';
 import { fontVariables } from '@/lib/fonts';
+import { siteConfig } from '@/lib/metadata';
 import type { Metadata } from 'next';
 import { Organization, WebSite, WithContext } from 'schema-dts';
 import '../globals.css';
@@ -14,8 +15,8 @@ import { PostHogProvider } from '../providers';
  */
 export const metadata: Metadata = {
   title: {
-    default: 'Todd United States',
-    template: '%s | Todd United States',
+    default: siteConfig.name,
+    template: `%s | ${siteConfig.name}`,
   },
 };
 

--- a/apps/site/src/app/manifest.json
+++ b/apps/site/src/app/manifest.json
@@ -48,7 +48,7 @@
   ],
   "shortcuts": [
     {
-      "name": "Who We Are | Todd United States",
+      "name": "Who We Are | Todd",
       "short_name": "Who We Are",
       "description": "We research, explore and innovate deeply",
       "url": "/about",

--- a/apps/site/src/app/sitemap.ts
+++ b/apps/site/src/app/sitemap.ts
@@ -50,7 +50,7 @@ function getStaticSitemap(): MetadataRoute.Sitemap {
   const staticPages = [
     '/',
     '/careers',
-    '/careers/index',
+    '/careers/search',
     '/about',
     '/research',
     '/news',

--- a/apps/site/src/lib/metadata.ts
+++ b/apps/site/src/lib/metadata.ts
@@ -7,8 +7,8 @@ import type { Metadata, Viewport } from 'next';
  * @returns {const} - The site configuration
  */
 const siteConfig = {
-  name: 'Todd United States',
-  title: 'Todd United States',
+  name: 'Todd',
+  title: 'Todd',
   description:
     'Todd Agriscience is a first-generation generative agriculture firm.',
   url: 'https://www.toddagriscience.com',
@@ -49,7 +49,7 @@ export const defaultMetadata: Metadata = {
         url: siteConfig.ogImage,
         width: 1200,
         height: 630,
-        alt: 'Todd United States',
+        alt: siteConfig.name,
       },
     ],
     type: 'website',
@@ -101,7 +101,7 @@ function getTitleSuffix(path: string): string {
   if (path.includes('/investors')) {
     return 'Todd Investors';
   }
-  return 'Todd United States';
+  return siteConfig.name;
 }
 
 /**

--- a/apps/site/src/lib/metadata.ts
+++ b/apps/site/src/lib/metadata.ts
@@ -10,7 +10,7 @@ const siteConfig = {
   name: 'Todd',
   title: 'Todd',
   description:
-    'Todd Agriscience is a first-generation generative agriculture firm.',
+    'Todd is the frontier research lab dedicated to building foundation technology and crop genetics for sustainable agriculture.',
   url: 'https://www.toddagriscience.com',
   ogImage: 'https://www.toddagriscience.com/opengraph-image.png',
   twitterImage: 'https://www.toddagriscience.com/opengraph-image.png',

--- a/apps/site/src/lib/sanity/articles.ts
+++ b/apps/site/src/lib/sanity/articles.ts
@@ -110,7 +110,7 @@ export function isSitemapArticle(article: SanityArticle): boolean {
 }
 
 /**
- * Whether the document counts as careers content for `/careers/index`, `/careers/[slug]`, and the careers sitemap slice.
+ * Whether the document counts as careers content for `/careers/search`, `/careers/[slug]`, and the careers sitemap slice.
  *
  * @param article - Document classification from Sanity (`_type` or legacy tagging)
  * @returns True when the row should behave as a careers article on the marketing site

--- a/apps/site/src/messages/careers/en.json
+++ b/apps/site/src/messages/careers/en.json
@@ -53,14 +53,14 @@
           "heading": "Todd Residency",
           "body": "Our early talent programs offers a chance to make a direct impact at Todd and contribute to Todd's growth journey. We welcome curious, driven people early in their professional journey through.",
           "cta": "Learn more →",
-          "ctaHref": "/careers/index",
+          "ctaHref": "/careers/search",
           "imageAlt": "Two Todd teammates talking in a bright office lounge"
         },
         "talent": {
           "heading": "Early talent",
           "body": "We welcome curious, driven people early in their professional journey to make a direct impact at Todd and contribute to Todd's own growth journey.",
           "cta": "Learn more →",
-          "ctaHref": "/careers/index",
+          "ctaHref": "/careers/search",
           "imageAlt": "Early-career teammates collaborating in a modern office"
         }
       },
@@ -80,7 +80,7 @@
       "footerCta": {
         "heading": "Shape the future of agriculture",
         "cta": "View careers →",
-        "ctaHref": "/careers/index"
+        "ctaHref": "/careers/search"
       }
     },
     "jobPosting": {

--- a/apps/site/src/messages/careers/es.json
+++ b/apps/site/src/messages/careers/es.json
@@ -53,14 +53,14 @@
           "heading": "Residencia Todd",
           "body": "Nuestros programas de talento emergente ofrecen la oportunidad de generar un impacto directo en Todd y contribuir al recorrido de crecimiento de Todd. Damos la bienvenida a personas curiosas y con impulso en una etapa temprana de su trayectoria profesional.",
           "cta": "Saber más →",
-          "ctaHref": "/careers/index",
+          "ctaHref": "/careers/search",
           "imageAlt": "Dos compañeros de Todd conversando en una sala luminosa"
         },
         "talent": {
           "heading": "Talento emergente",
           "body": "Damos la bienvenida a personas curiosas y con impulso, en una etapa temprana de su trayectoria profesional, para generar un impacto directo en Todd y contribuir al propio recorrido de crecimiento de Todd.",
           "cta": "Saber más →",
-          "ctaHref": "/careers/index",
+          "ctaHref": "/careers/search",
           "imageAlt": "Personas en etapa inicial colaborando en una oficina moderna"
         }
       },
@@ -80,7 +80,7 @@
       "footerCta": {
         "heading": "Da forma al futuro de la agricultura",
         "cta": "Ver carreras →",
-        "ctaHref": "/careers/index"
+        "ctaHref": "/careers/search"
       }
     },
     "jobPosting": {

--- a/apps/site/src/proxy/special-redirect.ts
+++ b/apps/site/src/proxy/special-redirect.ts
@@ -8,7 +8,7 @@ import type { Locale } from 'next-intl';
  * Early routing tweaks before auth/i18n.
  *
  * Careers hub and job listings live under `app/(unauthenticated)/[locale]/(marketing)/careers/` as
- * normal routes (`/careers` and `/careers/index`); no rewrite is applied here.
+ * normal routes (`/careers` and `/careers/search`); no rewrite is applied here.
  *
  * @param request - Incoming request
  */


### PR DESCRIPTION
…earch

## Description
This PR renames the site metadata from “Todd United States” to “Todd.” This PR also fixes a Next.js routing bug, Next.js does not reliably handle child pages named index, causing /careers to redirect to the global /index on reload. The /careers/index page has been renamed to /careers/search to prevent route resolution conflicts and ensure stable navigation.

Fixes #{851}

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
