### PR TITLE
feat: serve English at root path, drop /en/ prefix

### DIFF
--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -160,17 +160,6 @@ const nextConfig: NextConfig = {
 
   redirects() {
     return [
-      // Redirect legacy /en/* URLs — English is now served without a locale prefix
-      {
-        source: '/en',
-        destination: '/',
-        permanent: true,
-      },
-      {
-        source: '/en/:path*',
-        destination: '/:path*',
-        permanent: true,
-      },
       // Legacy slug redirects for English
       {
         source: '/who-we-are/:path*',

--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -160,24 +160,52 @@ const nextConfig: NextConfig = {
 
   redirects() {
     return [
+      // Redirect legacy /en/* URLs — English is now served without a locale prefix
       {
-        source: '/:locale(en|es)/who-we-are/:path*',
-        destination: '/:locale/about/:path*',
+        source: '/en',
+        destination: '/',
         permanent: true,
       },
       {
-        source: '/:locale(en|es)/who-we-are',
-        destination: '/:locale/about',
+        source: '/en/:path*',
+        destination: '/:path*',
+        permanent: true,
+      },
+      // Legacy slug redirects for English
+      {
+        source: '/who-we-are/:path*',
+        destination: '/about/:path*',
         permanent: true,
       },
       {
-        source: '/:locale(en|es)/what-we-do',
-        destination: '/:locale/research',
+        source: '/who-we-are',
+        destination: '/about',
         permanent: true,
       },
       {
-        source: '/:locale(en|es)/support',
-        destination: '/:locale/contact',
+        source: '/what-we-do',
+        destination: '/research',
+        permanent: true,
+      },
+      // Legacy slug redirects for Spanish
+      {
+        source: '/es/who-we-are/:path*',
+        destination: '/es/about/:path*',
+        permanent: true,
+      },
+      {
+        source: '/es/who-we-are',
+        destination: '/es/about',
+        permanent: true,
+      },
+      {
+        source: '/es/what-we-do',
+        destination: '/es/research',
+        permanent: true,
+      },
+      {
+        source: '/es/support',
+        destination: '/es/contact',
         permanent: true,
       },
       {

--- a/apps/site/src/app/(authenticated)/(accounts)/account/(with-shell)/privacy/page.test.tsx
+++ b/apps/site/src/app/(authenticated)/(accounts)/account/(with-shell)/privacy/page.test.tsx
@@ -16,6 +16,6 @@ describe('AccountPrivacyPage', () => {
     ).toHaveAttribute('href', '/contact');
     expect(
       screen.getByRole('link', { name: /Privacy Policy/i })
-    ).toHaveAttribute('href', '/en/privacy');
+    ).toHaveAttribute('href', '/privacy');
   });
 });

--- a/apps/site/src/app/(authenticated)/(accounts)/account/(with-shell)/privacy/page.tsx
+++ b/apps/site/src/app/(authenticated)/(accounts)/account/(with-shell)/privacy/page.tsx
@@ -26,7 +26,7 @@ export default function AccountPrivacyPage() {
           label="Privacy Policy"
           value={<BiChevronRight className="size-6" />}
           valueClassName="text-foreground"
-          href="/en/privacy"
+          href="/privacy"
         />
       </div>
     </AccountInfo>

--- a/apps/site/src/app/(authenticated)/(accounts)/account/components/account-side-menu/account-side-menu.test.tsx
+++ b/apps/site/src/app/(authenticated)/(accounts)/account/components/account-side-menu/account-side-menu.test.tsx
@@ -47,6 +47,6 @@ describe('AccountSideMenu', () => {
     await user.click(screen.getByRole('button', { name: 'Log out' }));
 
     expect(mockLogout).toHaveBeenCalledTimes(1);
-    expect(mockPush).toHaveBeenCalledWith('/en');
+    expect(mockPush).toHaveBeenCalledWith('/');
   });
 });

--- a/apps/site/src/app/(authenticated)/(accounts)/account/components/account-side-menu/account-side-menu.tsx
+++ b/apps/site/src/app/(authenticated)/(accounts)/account/components/account-side-menu/account-side-menu.tsx
@@ -24,7 +24,7 @@ export default function AccountSideMenu() {
     const result = await logout();
 
     if (!result?.error) {
-      router.push('/en');
+      router.push('/');
     }
   };
 

--- a/apps/site/src/app/(authenticated)/(misc)/contact/components/contact-links-section.tsx
+++ b/apps/site/src/app/(authenticated)/(misc)/contact/components/contact-links-section.tsx
@@ -23,7 +23,7 @@ const contactLinkItems: ContactLinkItem[] = [
   },
   {
     label: 'Recent Updates',
-    href: '/en/news',
+    href: '/news',
     icon: <BiSolidInfoSquare className="size-6" />,
   },
   {
@@ -33,7 +33,7 @@ const contactLinkItems: ContactLinkItem[] = [
   },
   {
     label: 'Disclosures',
-    href: '/en/disclosures',
+    href: '/disclosures',
     icon: <BiSolidInfoCircle className="size-6" />,
   },
 ];

--- a/apps/site/src/app/(authenticated)/components/account-agreement/account-agreement-content.tsx
+++ b/apps/site/src/app/(authenticated)/components/account-agreement/account-agreement-content.tsx
@@ -21,10 +21,10 @@ export default function AccountAgreementContent() {
           </Link>
         </li>
         <li className="underline">
-          <Link href={'/en/terms'}>Terms of Use</Link>
+          <Link href={'/terms'}>Terms of Use</Link>
         </li>
         <li className="underline">
-          <Link href={'/en/privacy'}>Privacy Policy</Link>
+          <Link href={'/privacy'}>Privacy Policy</Link>
         </li>
       </ul>
 

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/footer/footer.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/footer/footer.tsx
@@ -74,7 +74,7 @@ const Footer = () => {
 
   const currentYear = new Date().getFullYear();
 
-  const pathname = usePathname() || '/en';
+  const pathname = usePathname() || '/';
   const [langOpen, setLangOpen] = useState(false);
   const [pendingLocale, setPendingLocale] = useState<string | null>(null);
 

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/page.tsx
@@ -15,13 +15,13 @@ export const metadata: Metadata = {
   description:
     'Todd combines deep experience in regenerative agriculture, farm management and engaging consumers.',
   alternates: {
-    canonical: 'https://toddagriscience.com/en/',
+    canonical: 'https://toddagriscience.com/',
   },
   openGraph: {
     title: 'Todd | Global Leader in Sustainable Agriculture',
     description:
       'Todd combines deep experience in regenerative agriculture, farm management and engaging consumers.',
-    url: 'https://toddagriscience.com/en/',
+    url: 'https://toddagriscience.com/',
     siteName: siteConfig.name,
     locale: 'en',
     type: 'website',

--- a/apps/site/src/app/sitemap.ts
+++ b/apps/site/src/app/sitemap.ts
@@ -74,7 +74,10 @@ function getStaticSitemap(): MetadataRoute.Sitemap {
         continue;
       }
 
-      const url = `${baseUrl}/${locale}${page}`;
+      const url =
+        locale === routing.defaultLocale
+          ? `${baseUrl}${page}`
+          : `${baseUrl}/${locale}${page}`;
 
       sitemapEntries.push({
         url,
@@ -111,7 +114,10 @@ function articleListToIndexSitemapEntries(
 
       const lastModified =
         article._updatedAt !== undefined ? article._updatedAt : new Date();
-      const url = `${baseUrl}/${locale}/index/${slug}`;
+      const url =
+        locale === routing.defaultLocale
+          ? `${baseUrl}/index/${slug}`
+          : `${baseUrl}/${locale}/index/${slug}`;
 
       sitemapEntries.push({
         url,
@@ -147,7 +153,10 @@ function articleListToCareersPostingSitemapEntries(
 
       const lastModified =
         article._updatedAt !== undefined ? article._updatedAt : new Date();
-      const url = `${baseUrl}/${locale}/careers/${slug}`;
+      const url =
+        locale === routing.defaultLocale
+          ? `${baseUrl}/careers/${slug}`
+          : `${baseUrl}/${locale}/careers/${slug}`;
 
       sitemapEntries.push({
         url,
@@ -198,14 +207,16 @@ async function getSanityCareersArticleCareersRouteSitemap(): Promise<MetadataRou
 function getSupportedLanguages(page: string): Languages<string> {
   const languages: { [key: string]: string } = {};
   routing.locales.forEach((loc) => {
-    // Ensure proper path separator - page might already start with '/' or be empty
     const cleanPage = page.startsWith('/') ? page : `/${page}`;
-    languages[loc] = `${baseUrl}/${loc}${cleanPage}`;
+    languages[loc] =
+      loc === routing.defaultLocale
+        ? `${baseUrl}${cleanPage}`
+        : `${baseUrl}/${loc}${cleanPage}`;
   });
 
   // Add x-default for better international SEO
-  languages['x-default'] =
-    `${baseUrl}/${routing.defaultLocale}${page.startsWith('/') ? page : `/${page}`}`;
+  const cleanPage = page.startsWith('/') ? page : `/${page}`;
+  languages['x-default'] = `${baseUrl}${cleanPage}`;
 
   return languages;
 }

--- a/apps/site/src/components/common/desktop-gate/desktop-gate.tsx
+++ b/apps/site/src/components/common/desktop-gate/desktop-gate.tsx
@@ -44,7 +44,7 @@ export default function DesktopGate({
     const result = await logout();
 
     if (!result?.error) {
-      router.push('/en');
+      router.push('/');
     }
   };
 

--- a/apps/site/src/components/common/legal-subtext/legal-subtext.tsx
+++ b/apps/site/src/components/common/legal-subtext/legal-subtext.tsx
@@ -20,7 +20,7 @@ export function LegalSubtext() {
           Todd Account Agreement
         </NextLink>{' '}
         and{' '}
-        <NextLink href="/en/privacy" className="underline font-normal">
+        <NextLink href="/privacy" className="underline font-normal">
           Privacy Policy
         </NextLink>
         .

--- a/apps/site/src/components/common/utils/logout-link/logout-link.test.tsx
+++ b/apps/site/src/components/common/utils/logout-link/logout-link.test.tsx
@@ -35,6 +35,6 @@ describe('LogoutLink', () => {
     await user.click(screen.getByRole('button', { name: 'Log out' }));
 
     expect(mockLogout).toHaveBeenCalledTimes(1);
-    expect(mockPush).toHaveBeenCalledWith('/en');
+    expect(mockPush).toHaveBeenCalledWith('/');
   });
 });

--- a/apps/site/src/components/common/utils/logout-link/logout-link.tsx
+++ b/apps/site/src/components/common/utils/logout-link/logout-link.tsx
@@ -25,7 +25,7 @@ export default function LogoutLink({
     const result = await logout();
     // If logout doesn't redirect automatically, manually redirect
     if (!result?.error) {
-      router.push('/en');
+      router.push('/');
     }
   };
 

--- a/apps/site/src/i18n/config.ts
+++ b/apps/site/src/i18n/config.ts
@@ -20,8 +20,8 @@ export const routing = defineRouting({
   // Used when no locale matches
   defaultLocale: 'en',
 
-  // Always show locale prefix
-  localePrefix: 'always',
+  // Only prefix non-default locales (en served at /, es at /es/)
+  localePrefix: 'as-needed',
 
   // Enable locale detection in production, disable in development for easier testing
   localeDetection: process.env.NODE_ENV === 'production',

--- a/apps/site/src/proxy/all-users-page.test.ts
+++ b/apps/site/src/proxy/all-users-page.test.ts
@@ -49,8 +49,20 @@ describe('isAllUserRoute', () => {
     expect(result).toBe(true);
   });
 
-  it('returns false for non-internationalized /signup', async () => {
+  it('returns true for unprefixed /signup (default locale)', async () => {
     const req = mockNextRequest('/signup');
+    const result = await isAllUserRoute(req as NextRequest);
+    expect(result).toBe(true);
+  });
+
+  it('returns true for unprefixed /privacy (default locale)', async () => {
+    const req = mockNextRequest('/privacy');
+    const result = await isAllUserRoute(req as NextRequest);
+    expect(result).toBe(true);
+  });
+
+  it('returns false for unprefixed unrelated routes', async () => {
+    const req = mockNextRequest('/other-page');
     const result = await isAllUserRoute(req as NextRequest);
     expect(result).toBe(false);
   });

--- a/apps/site/src/proxy/all-users-page.ts
+++ b/apps/site/src/proxy/all-users-page.ts
@@ -21,5 +21,7 @@ export default async function isAllUserRoute(request: NextRequest) {
     return allUserRoutesIntl.includes(unIntlRoute);
   }
 
-  return false;
+  // Unprefixed paths serve the default locale (en) under localePrefix: 'as-needed'
+  const unIntlRoute = pathname.split('/')[1];
+  return allUserRoutesIntl.includes(unIntlRoute);
 }

--- a/apps/site/src/proxy/auth.test.ts
+++ b/apps/site/src/proxy/auth.test.ts
@@ -147,7 +147,7 @@ describe('handleAuthRouting', () => {
     expect(result?.headers.get('location')).toBe('https://example.com/');
   });
 
-  it('redirects unauthenticated users from a protected route to "/en"', async () => {
+  it('allows unauthenticated users through at "/" so marketing homepage is served', async () => {
     const mockRequest = makeMockRequest('https://example.com/');
 
     (createServerClient as Mock).mockReturnValue(
@@ -156,8 +156,20 @@ describe('handleAuthRouting', () => {
 
     const result = await handleAuthRouting(mockRequest);
 
+    expect(result).toBeNull();
+  });
+
+  it('redirects unauthenticated users from other protected routes to "/"', async () => {
+    const mockRequest = makeMockRequest('https://example.com/account/settings');
+
+    (createServerClient as Mock).mockReturnValue(
+      mockSupabase({ authenticated: false })
+    );
+
+    const result = await handleAuthRouting(mockRequest);
+
     expect(result).toBeInstanceOf(NextResponse);
-    expect(result?.headers.get('location')).toBe('https://example.com/en');
+    expect(result?.headers.get('location')).toBe('https://example.com/');
   });
 
   it('allows unauthenticated users on a non-protected marketing route', async () => {

--- a/apps/site/src/proxy/auth.ts
+++ b/apps/site/src/proxy/auth.ts
@@ -65,7 +65,15 @@ export async function handleAuthRouting(
       return supabaseResponse;
     }
 
-    return NextResponse.redirect(new URL('/en', request.url));
+    // With localePrefix: 'as-needed', the marketing homepage lives at /.
+    // Returning null lets unauthenticated users fall through to the intl
+    // middleware which serves the marketing page. Any other protected route
+    // (e.g. /account/*) redirects to / where they'll see the marketing page.
+    if (pathname === '/') {
+      return null;
+    }
+
+    return NextResponse.redirect(new URL('/', request.url));
   } else {
     if (isAuthenticated) {
       if (isRouteInternationalized(pathname)) {

--- a/apps/site/src/proxy/i18n.test.ts
+++ b/apps/site/src/proxy/i18n.test.ts
@@ -20,8 +20,22 @@ vi.mock('next-intl/middleware', () => {
 const { MockNextResponse } = vi.hoisted(() => {
   class MockNextResponse {
     private headers = new Headers();
-    private cookies: string[] = [];
+    private _rawSetCookies: string[] = [];
+    private _cookieMap = new Map<string, string>();
     status?: number;
+
+    // Mirrors the ResponseCookies interface used in Next.js middleware
+    cookies = {
+      set: (name: string, value: string, options?: { path?: string }) => {
+        this._cookieMap.set(name, value);
+        const pathStr = options?.path ? `; Path=${options.path}` : '';
+        this._rawSetCookies.push(`${name}=${value}${pathStr}`);
+      },
+      get: (name: string) => {
+        const val = this._cookieMap.get(name);
+        return val !== undefined ? { name, value: val } : undefined;
+      },
+    };
 
     constructor(body?: object, init?: ResponseInit) {
       this.status = init?.status;
@@ -47,12 +61,12 @@ const { MockNextResponse } = vi.hoisted(() => {
 
     /** required by Next middleware */
     getSetCookie(): string[] {
-      return this.cookies;
+      return this._rawSetCookies;
     }
 
     /** test helper */
     _pushSetCookie(value: string) {
-      this.cookies.push(value);
+      this._rawSetCookies.push(value);
     }
   }
 
@@ -183,6 +197,30 @@ describe('I18n Middleware', () => {
       expect(result).toBeDefined();
       expect(result).toBeInstanceOf(NextResponse);
       expect(result.headers.get('x-intl-processed')).toBe('1');
+    });
+
+    it('should set NEXT_LOCALE=en cookie on /en/* redirect to prevent Accept-Language override', () => {
+      const mockRequest = {
+        nextUrl: { pathname: '/en/about' },
+      } as NextRequest;
+
+      const result = handleI18nMiddleware(mockRequest, false);
+
+      // @ts-expect-error getSetCookie is a mock-only method not on NextResponse
+      const setCookies: string[] = result.getSetCookie();
+      expect(setCookies.some((c) => c.startsWith('NEXT_LOCALE=en'))).toBe(true);
+    });
+
+    it('should not set NEXT_LOCALE cookie for non-default locale paths like /es/*', () => {
+      const mockRequest = {
+        nextUrl: { pathname: '/es/about' },
+      } as NextRequest;
+
+      const result = handleI18nMiddleware(mockRequest, false);
+
+      // @ts-expect-error getSetCookie is a mock-only method not on NextResponse
+      const setCookies: string[] = result.getSetCookie();
+      expect(setCookies.every((c) => !c.startsWith('NEXT_LOCALE='))).toBe(true);
     });
   });
 

--- a/apps/site/src/proxy/i18n.test.ts
+++ b/apps/site/src/proxy/i18n.test.ts
@@ -7,13 +7,14 @@ import { NextResponse, NextRequest } from 'next/server.js';
 
 // Dear reader: to be frank with you, I have no idea why or how this file works. Best of luck.
 // Mock next-intl/middleware
+// createMiddleware is a factory — it must return the middleware function, not be the middleware itself.
 vi.mock('next-intl/middleware', () => {
   const mockIntlMiddleware = vi.fn(() => {
     const response = NextResponse.next();
     response.headers.set('x-intl-processed', '1');
     return response;
   });
-  return { default: mockIntlMiddleware };
+  return { default: vi.fn(() => mockIntlMiddleware) };
 });
 
 const { MockNextResponse } = vi.hoisted(() => {
@@ -115,25 +116,21 @@ describe('I18n Middleware', () => {
       expect(result).toBeInstanceOf(NextResponse);
     });
 
-    it('should redirect non-locale routes to /en/{path} when unauthenticated', () => {
+    it('should delegate to intl middleware for default locale (en) unprefixed paths', () => {
       const mockRequest = {
         nextUrl: {
           pathname: '/about',
-          clone: vi.fn().mockReturnValue({
-            pathname: '/about',
-          }),
+          clone: vi.fn().mockReturnValue({ pathname: '/about' }),
         },
+        cookies: { get: vi.fn().mockReturnValue(undefined) },
+        headers: { get: vi.fn().mockReturnValue(null) },
       } as unknown as NextRequest;
 
       const result = handleI18nMiddleware(mockRequest, false);
 
-      // @ts-expect-error Caused by the Object.assign in MockNextResponse. See top of file for more info.
-      expect(vi.mocked(MockNextResponse.redirect)).toHaveBeenCalled();
       expect(result).toBeDefined();
       expect(result).toBeInstanceOf(NextResponse);
-      expect(result.headers.get('location')).toStrictEqual({
-        pathname: '/en/about',
-      });
+      expect(result.headers.get('x-intl-processed')).toBe('1');
     });
 
     it('should not redirect unauth uninternationalized routes', async () => {
@@ -176,17 +173,16 @@ describe('I18n Middleware', () => {
       expect(result.headers.get('location').pathname).toBe('/incoming');
     });
 
-    it('should return next() for locale routes when unauthenticated', () => {
+    it('should delegate to intl middleware for locale-prefixed routes when unauthenticated', () => {
       const mockRequest = {
         nextUrl: { pathname: '/en/about' },
       } as NextRequest;
 
       const result = handleI18nMiddleware(mockRequest, false);
 
-      // @ts-expect-error Caused by the Object.assign in MockNextResponse. See top of file for more info.
-      expect(MockNextResponse.next).toHaveBeenCalled();
       expect(result).toBeDefined();
       expect(result).toBeInstanceOf(NextResponse);
+      expect(result.headers.get('x-intl-processed')).toBe('1');
     });
   });
 

--- a/apps/site/src/proxy/i18n.ts
+++ b/apps/site/src/proxy/i18n.ts
@@ -34,7 +34,7 @@ export function handleI18nMiddleware(
   const { pathname } = request.nextUrl;
 
   if (!isAuthenticated) {
-    // For root path, use intl middleware (it will redirect / to /en)
+    // For root path, let intl middleware serve it as the default locale
     if (pathname === '/') {
       return intlMiddleware(request);
     }
@@ -51,9 +51,11 @@ export function handleI18nMiddleware(
       );
     }
 
-    // For paths that already have locale, let them through normally
+    // For paths that already have a locale prefix, let intl middleware handle
+    // them — it will redirect /en/... to /... (default locale needs no prefix)
+    // and pass /es/... through unchanged.
     if (SUPPORTED_LOCALES.includes(splitPathnames[1] as Locale)) {
-      return NextResponse.next();
+      return intlMiddleware(request);
     }
 
     // Unauth routes, such as `/login`
@@ -63,8 +65,10 @@ export function handleI18nMiddleware(
       return response;
     }
 
-    // For paths without locale (like /about, /no-page-here),
-    // redirect using NEXT_LOCALE cookie if set, else default to en
+    // For paths without locale (like /about), detect preferred locale and
+    // redirect non-default locales to /{locale}/path. For the default locale
+    // (en), delegate to intl middleware which rewrites internally without
+    // adding a /en/ prefix to the URL.
     const preferredLocale =
       request.cookies?.get('NEXT_LOCALE')?.value ||
       request.headers?.get('accept-language')?.split(',')[0]?.slice(0, 2) ||
@@ -72,6 +76,9 @@ export function handleI18nMiddleware(
     const locale = SUPPORTED_LOCALES.includes(preferredLocale as Locale)
       ? preferredLocale
       : 'en';
+    if (locale === 'en') {
+      return intlMiddleware(request);
+    }
     const url = request.nextUrl.clone();
     url.pathname = `/${locale}${pathname}`;
     return NextResponse.redirect(url);

--- a/apps/site/src/proxy/i18n.ts
+++ b/apps/site/src/proxy/i18n.ts
@@ -52,10 +52,18 @@ export function handleI18nMiddleware(
     }
 
     // For paths that already have a locale prefix, let intl middleware handle
-    // them — it will redirect /en/... to /... (default locale needs no prefix)
-    // and pass /es/... through unchanged.
+    // them. /es/... is passed through unchanged. For /en/... (default locale
+    // with an unnecessary prefix), intl middleware redirects to /... but does
+    // not persist the locale via cookie — so we pin NEXT_LOCALE=en on the
+    // redirect response to prevent the subsequent locale-detection pass from
+    // re-routing the user to /es/... based on Accept-Language.
     if (SUPPORTED_LOCALES.includes(splitPathnames[1] as Locale)) {
-      return intlMiddleware(request);
+      const explicitLocale = splitPathnames[1] as Locale;
+      const response = intlMiddleware(request) as NextResponse;
+      if (explicitLocale === routing.defaultLocale) {
+        response.cookies.set('NEXT_LOCALE', explicitLocale, { path: '/' });
+      }
+      return response;
     }
 
     // Unauth routes, such as `/login`

--- a/apps/site/src/proxy/special-redirect.test.ts
+++ b/apps/site/src/proxy/special-redirect.test.ts
@@ -24,8 +24,16 @@ describe('specialRedirect', () => {
     );
   });
 
-  it('redirects locale externship route to Google form', () => {
+  it('redirects locale-prefixed externship route to Google form', () => {
     const response = specialRedirect(makeRequest('/en/careers/externship'));
+    expect(response).not.toBeNull();
+    expect(response?.headers.get('location')).toContain(
+      'docs.google.com/forms'
+    );
+  });
+
+  it('redirects unprefixed /careers/externship to Google form', () => {
+    const response = specialRedirect(makeRequest('/careers/externship'));
     expect(response).not.toBeNull();
     expect(response?.headers.get('location')).toContain(
       'docs.google.com/forms'

--- a/apps/site/src/proxy/special-redirect.ts
+++ b/apps/site/src/proxy/special-redirect.ts
@@ -28,12 +28,18 @@ export default function specialRedirect(
   const isLocale =
     locale0 !== undefined && SUPPORTED_LOCALES.includes(locale0 as Locale);
 
-  if (
+  const isPrefixedExternship =
     segments.length === 3 &&
     isLocale &&
     segments[1] === 'careers' &&
-    segments[2] === 'externship'
-  ) {
+    segments[2] === 'externship';
+
+  const isUnprefixedExternship =
+    segments.length === 2 &&
+    segments[0] === 'careers' &&
+    segments[1] === 'externship';
+
+  if (isPrefixedExternship || isUnprefixedExternship) {
     return NextResponse.redirect(
       // eslint-disable-next-line no-secrets/no-secrets
       'https://docs.google.com/forms/d/e/1FAIpQLSfi8yeNdjHuJCrO1sPSUhh8uCICsA6KGevRM-Mk9iND-aYkBQ/viewform'


### PR DESCRIPTION
Description

Fixes #852

## Serve English at `/` instead of `/en/`

Changes `localePrefix` from `'always'` to `'as-needed'` in the next-intl config so English is served at the root path while Spanish stays at `/es/`.

### What changed

- Added permanent redirects for all legacy `/en/*` URLs so existing links and bookmarks don't break
- Fixed a redirect loop in auth middleware where `/` was simultaneously a protected route and the new marketing homepage, unauthenticated requests to `/` now fall through to the intl middleware instead of redirecting
- Updated all internal hardcoded `/en/` links (privacy, terms, logout redirects, canonical URLs, etc.)
- Extended `specialRedirect` to handle both prefixed (`/en/careers/externship`) and unprefixed (`/careers/externship`) externship routes
- Updated proxy tests (`auth`, `i18n`, `all-users-page`, `special-redirect`) to cover the new routing behavior

Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used conventional commits 
