### PR TITLE
feat(careers): replace exposed accommodation email with inquiry link

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/components/careers-externship.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/components/careers-externship.tsx
@@ -115,6 +115,7 @@ export function CareersExternship() {
             <Disclaimer
               translationLoc="careers.disclaimers"
               disclaimerCount={5}
+              linkHref="/contact"
             />
           </div>
         </main>

--- a/apps/site/src/components/common/disclaimer/disclaimer.tsx
+++ b/apps/site/src/components/common/disclaimer/disclaimer.tsx
@@ -1,21 +1,31 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { Link } from '@/i18n/config';
 import { useTranslations } from 'next-intl';
 
 /**
  * Disclaimer component. Renders legal disclaimers via next-intl. Having to manually add the # of disclaimers to each instance of this component is a pain, but Vitest was having issues with using the `.raw()` function from next-intl, so for sake of time I'm avoiding fixing this.
  *
+ * When `linkHref` is provided, disclaimer strings may contain a `<link>...</link>`
+ * tag that is rendered as a locale-aware link to that destination. This lets a
+ * disclaimer route users to an inquiry form instead of exposing a raw email
+ * address. Strings without the tag are unaffected, so callers that omit
+ * `linkHref` keep the original plain-text rendering.
+ *
  * @param {string} translationLoc - The name of the translation. Ex. `common` or `careers`
- * @param {numer} disclaimerCount - The number of separate disclaimers (paragarphs)
+ * @param {number} disclaimerCount - The number of separate disclaimers (paragarphs)
+ * @param {string} [linkHref] - Optional destination for a `<link>` tag inside any disclaimer string
  *
  * @returns {JSX.Element} - The disclaimer component
  * */
 export function Disclaimer({
   translationLoc,
   disclaimerCount,
+  linkHref,
 }: {
   translationLoc: string;
   disclaimerCount: number;
+  linkHref?: string;
 }) {
   const t = useTranslations(translationLoc);
 
@@ -23,7 +33,16 @@ export function Disclaimer({
     <section className="mb-32 max-w-[1200px] w-[80vw] mx-auto space-y-1 text-sm leading-relaxed font-light pl-8 indent-[-1rem]">
       {Array.from({ length: disclaimerCount }).map((_, i) => (
         <p key={i}>
-          {i + 1}. {t(String(i))}
+          {i + 1}.{' '}
+          {linkHref
+            ? t.rich(String(i), {
+                link: (chunks) => (
+                  <Link href={linkHref} className="underline">
+                    {chunks}
+                  </Link>
+                ),
+              })
+            : t(String(i))}
         </p>
       ))}
     </section>

--- a/apps/site/src/messages/careers/en.json
+++ b/apps/site/src/messages/careers/en.json
@@ -104,7 +104,7 @@
     "disclaimers": {
       "0": "Todd is an equal opportunity employer in the regions where we operate.",
       "1": "Todd Agriscience, Inc. and our business entities are committed to offering an equal opportunity for all applicants. We do not discriminate based on race, color, religion, national origin, age, sex, marital status, ancestry, neurotype, disability, veteran status, gender identity, sexual orientation or any other category protected by local law.",
-      "2": "If you need additional assistance throughout the hiring process related to a health condition or there is something our team can do to enable a more accessible experience, please notify our team at support@toddagriscience.com",
+      "2": "If you need additional assistance throughout the hiring process related to a health condition or there is something our team can do to enable a more accessible experience, please <link>submit an accommodation request</link>.",
       "3": "Under the U.S. Transparency in Coverage act, Todd is required to provide U.S. pricing information to U.S. consumers before they receive care under our insurance plans. To review Todd’s U.S. medical insurance pricing structure, please click here: https://transparency-in-coverage.collectivehealth.com/index.html.",
       "4": "To learn more about how we process your personal information and your rights in regards to your personal information as a Todd Applicant, please visit our Privacy Policy."
     }

--- a/apps/site/src/messages/careers/es.json
+++ b/apps/site/src/messages/careers/es.json
@@ -104,7 +104,7 @@
     "disclaimers": {
       "0": "Todd es un empleador de igualdad de oportunidades en las regiones donde operamos.",
       "1": "Todd Agriscience, Inc. y nuestras entidades comerciales están comprometidas con ofrecer una oportunidad igual para todos los candidatos. No discriminamos basados en raza, color, religión, origen nacional, edad, sexo, estado civil, ascendencia, neurotipo, discapacidad, estado de veterano, identidad de género, orientación sexual o cualquier otra categoría protegida por la ley local.",
-      "2": "Si necesitas asistencia adicional durante el proceso de contratación relacionada con una condición de salud o hay algo que nuestro equipo puede hacer para habilitar una experiencia más accesible, por favor infórmanos a nuestro equipo en support@toddagriscience.com",
+      "2": "Si necesitas asistencia adicional durante el proceso de contratación relacionada con una condición de salud o hay algo que nuestro equipo puede hacer para habilitar una experiencia más accesible, por favor <link>envía una solicitud de adaptación</link>.",
       "3": "Bajo la Ley de Transparencia en Cobertura de EE. UU., Todd está obligado a proporcionar información de precios de EE. UU. a consumidores de EE. UU. antes de que reciban atención bajo nuestros planes de seguro. Para revisar la estructura de precios de seguros médicos de EE. UU. de Todd, por favor haz clic aquí: https://transparency-in-coverage.collectivehealth.com/index.html.",
       "4": "Para aprender más sobre cómo procesamos tu información personal y tus derechos en relación a tu información personal como candidato de Todd, por favor visita nuestra Política de Privacidad."
     }


### PR DESCRIPTION
## Description

Fixes #590

### What
The careers disclosure footer (disclaimer item #2) listed `support@toddagriscience.com` in plain text as the channel for disability accommodation requests. This replaces it with a locale-aware link to the existing `/contact` public inquiry form.

### Why
- A live email address in page copy is exposed to scrapers and offers applicants no structured way to open a request.
- The issue asks for "an inquiry link ... so an applicant can open an inquiry ticket." `/contact` already creates a public inquiry ticket, so we route there instead of exposing the mailbox.

### How
- Added an optional `linkHref` prop to the shared `Disclaimer` component. When provided, disclaimer strings may use a `<link>...</link>` tag rendered via next-intl's `t.rich`; the careers page passes `linkHref="/contact"`.
- Callers that omit `linkHref` (terms, research) keep the original plain-text rendering, so the change is fully backwards compatible.
- Updated both `en` and `es` accommodation strings to use the `<link>` tag.

### Testing
- `careers` + `disclaimer` suites pass (11 tests); type-check, lint, and build all green.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable. _(covered by existing careers/disclaimer suites; behavior is backwards compatible)_
- [x] You've included inline docs for your change, where applicable. _(JSDoc on the new `linkHref` prop)_
- [x] Any components that you've modified are accessible. _(link has descriptive visible text + underline; no raw email)_
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate