### PR TITLE
fix(internal): authorize every dashboard server action

### DIFF
--- a/apps/internal/src/app/(dashboard)/actions.ts
+++ b/apps/internal/src/app/(dashboard)/actions.ts
@@ -6,6 +6,7 @@ import { db } from '@nightcrawler/db';
 import { internalAccount } from '@nightcrawler/db/schema';
 import { eq, ilike, or, sql } from 'drizzle-orm';
 import logger from '@/lib/logger';
+import { requireInternalAccount } from '@/lib/require-internal-account';
 
 /**
  * Fetches all internal accounts, optionally filtering by search query.
@@ -13,6 +14,7 @@ import logger from '@/lib/logger';
  * @returns Array of internal account records
  */
 export async function getInternalAccounts(search?: string) {
+  await requireInternalAccount();
   try {
     if (search) {
       return await db
@@ -46,6 +48,7 @@ export async function createInternalAccount(data: {
   title?: string;
   isActive?: boolean;
 }) {
+  await requireInternalAccount();
   try {
     const [account] = await db.insert(internalAccount).values(data).returning();
     return account;
@@ -71,6 +74,7 @@ export async function updateInternalAccount(
     isActive?: boolean;
   }
 ) {
+  await requireInternalAccount();
   try {
     const [account] = await db
       .update(internalAccount)
@@ -90,6 +94,7 @@ export async function updateInternalAccount(
  * @returns True if deleted successfully
  */
 export async function deleteInternalAccount(id: number) {
+  await requireInternalAccount();
   try {
     await db.delete(internalAccount).where(eq(internalAccount.id, id));
     return true;

--- a/apps/internal/src/app/(dashboard)/analyses/actions.ts
+++ b/apps/internal/src/app/(dashboard)/analyses/actions.ts
@@ -6,6 +6,7 @@ import { db } from '@nightcrawler/db';
 import { analysis, mineral } from '@nightcrawler/db/schema';
 import { eq, ilike, or } from 'drizzle-orm';
 import logger from '@/lib/logger';
+import { requireInternalAccount } from '@/lib/require-internal-account';
 
 /**
  * Fetches all analyses, optionally filtered by search query.
@@ -13,6 +14,7 @@ import logger from '@/lib/logger';
  * @returns Array of analysis records
  */
 export async function getAnalyses(search?: string) {
+  await requireInternalAccount();
   try {
     if (search) {
       return await db
@@ -39,6 +41,7 @@ export async function getAnalyses(search?: string) {
  * @returns Array of mineral records
  */
 export async function getMineralsForAnalysis(analysisId: string) {
+  await requireInternalAccount();
   try {
     return await db
       .select()
@@ -79,6 +82,7 @@ export async function createAnalysis(data: {
     actionableInfo?: string;
   }>;
 }) {
+  await requireInternalAccount();
   try {
     const [newAnalysis] = await db
       .insert(analysis)
@@ -124,6 +128,7 @@ export async function updateAnalysis(
     macroActionableInfo?: string;
   }
 ) {
+  await requireInternalAccount();
   try {
     const updateData: Record<string, unknown> = {};
     if (data.analysisDate)
@@ -150,6 +155,7 @@ export async function updateAnalysis(
  * @returns True if deleted successfully
  */
 export async function deleteAnalysis(id: string) {
+  await requireInternalAccount();
   try {
     await db.delete(analysis).where(eq(analysis.id, id));
     return true;

--- a/apps/internal/src/app/(dashboard)/analyses/components/analyses-client.tsx
+++ b/apps/internal/src/app/(dashboard)/analyses/components/analyses-client.tsx
@@ -33,6 +33,7 @@ import {
   updateAnalysis,
   deleteAnalysis,
 } from '../actions';
+import { notifyActionError } from '@/lib/notify-action-error';
 
 /** Mineral type options */
 const MINERAL_TYPES = [
@@ -114,8 +115,12 @@ export default function AnalysesClient({
   });
 
   const loadAnalyses = useCallback(async (search?: string) => {
-    const data = await getAnalyses(search);
-    setAnalyses(data as AnalysisRecord[]);
+    try {
+      const data = await getAnalyses(search);
+      setAnalyses(data as AnalysisRecord[]);
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openCreateDialog = () => {
@@ -145,51 +150,59 @@ export default function AnalysesClient({
   };
 
   const onSubmit = async (data: AnalysisFormData) => {
-    if (editingAnalysis) {
-      const result = await updateAnalysis(editingAnalysis.id, {
-        analysisDate: data.analysisDate,
-        summary: data.summary,
-        macroActionableInfo: data.macroActionableInfo,
-      });
-      if (result) {
-        toast.success('Analysis updated successfully.');
+    try {
+      if (editingAnalysis) {
+        const result = await updateAnalysis(editingAnalysis.id, {
+          analysisDate: data.analysisDate,
+          summary: data.summary,
+          macroActionableInfo: data.macroActionableInfo,
+        });
+        if (result) {
+          toast.success('Analysis updated successfully.');
+        } else {
+          toast.error('Failed to update analysis.');
+          return;
+        }
       } else {
-        toast.error('Failed to update analysis.');
-        return;
+        const result = await createAnalysis({
+          id: data.id,
+          managementZone: Number(data.managementZone),
+          analysisDate: data.analysisDate,
+          summary: data.summary || undefined,
+          macroActionableInfo: data.macroActionableInfo || undefined,
+          minerals: data.minerals.map((m) => ({
+            name: m.name as (typeof MINERAL_TYPES)[number],
+            realValue: Number(m.realValue),
+            units: m.units as 'ppm' | '%',
+            actionableInfo: m.actionableInfo || undefined,
+          })),
+        });
+        if (result) {
+          toast.success('Analysis created successfully.');
+        } else {
+          toast.error('Failed to create analysis.');
+          return;
+        }
       }
-    } else {
-      const result = await createAnalysis({
-        id: data.id,
-        managementZone: Number(data.managementZone),
-        analysisDate: data.analysisDate,
-        summary: data.summary || undefined,
-        macroActionableInfo: data.macroActionableInfo || undefined,
-        minerals: data.minerals.map((m) => ({
-          name: m.name as (typeof MINERAL_TYPES)[number],
-          realValue: Number(m.realValue),
-          units: m.units as 'ppm' | '%',
-          actionableInfo: m.actionableInfo || undefined,
-        })),
-      });
-      if (result) {
-        toast.success('Analysis created successfully.');
-      } else {
-        toast.error('Failed to create analysis.');
-        return;
-      }
+      setDialogOpen(false);
+      loadAnalyses();
+    } catch {
+      notifyActionError();
     }
-    setDialogOpen(false);
-    loadAnalyses();
   };
 
   const handleDelete = async (id: string) => {
     if (!confirm('Are you sure you want to delete this analysis?')) return;
-    const success = await deleteAnalysis(id);
-    if (success) {
-      toast.success('Analysis deleted successfully.');
-      loadAnalyses();
-    } else {
-      toast.error('Failed to delete analysis.');
+    try {
+      const success = await deleteAnalysis(id);
+      if (success) {
+        toast.success('Analysis deleted successfully.');
+        loadAnalyses();
+      } else {
+        toast.error('Failed to delete analysis.');
+      }
+    } catch {
+      notifyActionError();
     }
   };
 

--- a/apps/internal/src/app/(dashboard)/applications/actions.ts
+++ b/apps/internal/src/app/(dashboard)/applications/actions.ts
@@ -10,19 +10,6 @@ import logger from '@/lib/logger';
 import { requireInternalAccount } from '@/lib/require-internal-account';
 
 /**
- * Resolves the active internal account id for the current session, or `null`
- * when the caller is not an internal member. Delegates to
- * {@link requireInternalAccount} so the account lookup lives in one place.
- */
-async function getReviewerAccountId(): Promise<number | null> {
-  try {
-    return (await requireInternalAccount()).id;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Fetches one platform access application by id.
  *
  * @param id - Application row id
@@ -95,9 +82,8 @@ export async function getPlatformAccessApplications(
  * @param id - Application row id
  */
 export async function approvePlatformAccessApplication(id: number) {
-  await requireInternalAccount();
+  const { id: reviewerId } = await requireInternalAccount();
   try {
-    const reviewerId = await getReviewerAccountId();
     const [existing] = await db
       .select()
       .from(platformAccessApplication)
@@ -170,9 +156,8 @@ export async function resendPlatformAccessApplicationInvite(id: number) {
  * @param id - Application row id
  */
 export async function rejectPlatformAccessApplication(id: number) {
-  await requireInternalAccount();
+  const { id: reviewerId } = await requireInternalAccount();
   try {
-    const reviewerId = await getReviewerAccountId();
     const [existing] = await db
       .select()
       .from(platformAccessApplication)
@@ -237,11 +222,6 @@ export async function updateFarmAdvisorProfileNotes(
 ): Promise<{ success: boolean; error?: string }> {
   await requireInternalAccount();
   try {
-    const reviewerId = await getReviewerAccountId();
-    if (!reviewerId) {
-      return { success: false, error: 'Not authorized.' };
-    }
-
     if (!Number.isFinite(farmId)) {
       return { success: false, error: 'Invalid farm id.' };
     }

--- a/apps/internal/src/app/(dashboard)/applications/actions.ts
+++ b/apps/internal/src/app/(dashboard)/applications/actions.ts
@@ -3,34 +3,23 @@
 'use server';
 
 import { db } from '@nightcrawler/db';
-import {
-  farm,
-  internalAccount,
-  platformAccessApplication,
-} from '@nightcrawler/db/schema';
-import { createClient } from '@/lib/supabase/server';
+import { farm, platformAccessApplication } from '@nightcrawler/db/schema';
 import { issueApprovedApplicantSignupAccess } from '@/lib/platform-access/issue-approved-applicant-signup';
 import { and, desc, eq, isNull } from 'drizzle-orm';
 import logger from '@/lib/logger';
+import { requireInternalAccount } from '@/lib/require-internal-account';
 
 /**
- * Resolves the active internal account for the current Supabase session.
+ * Resolves the active internal account id for the current session, or `null`
+ * when the caller is not an internal member. Delegates to
+ * {@link requireInternalAccount} so the account lookup lives in one place.
  */
 async function getReviewerAccountId(): Promise<number | null> {
-  const supabase = await createClient();
-  const { data } = await supabase.auth.getClaims();
-  const email = data?.claims?.email as string | undefined;
-  if (!email) return null;
-
-  const [account] = await db
-    .select({ id: internalAccount.id })
-    .from(internalAccount)
-    .where(
-      and(eq(internalAccount.email, email), eq(internalAccount.isActive, true))
-    )
-    .limit(1);
-
-  return account?.id ?? null;
+  try {
+    return (await requireInternalAccount()).id;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -39,6 +28,7 @@ async function getReviewerAccountId(): Promise<number | null> {
  * @param id - Application row id
  */
 export async function getPlatformAccessApplicationById(id: number) {
+  await requireInternalAccount();
   try {
     const [application] = await db
       .select()
@@ -75,6 +65,7 @@ export interface PlatformAccessApplicationListFilters {
 export async function getPlatformAccessApplications(
   filters?: PlatformAccessApplicationListFilters
 ) {
+  await requireInternalAccount();
   try {
     const conditions = [
       isNull(platformAccessApplication.deletedAt),
@@ -104,6 +95,7 @@ export async function getPlatformAccessApplications(
  * @param id - Application row id
  */
 export async function approvePlatformAccessApplication(id: number) {
+  await requireInternalAccount();
   try {
     const reviewerId = await getReviewerAccountId();
     const [existing] = await db
@@ -158,6 +150,7 @@ export async function approvePlatformAccessApplication(id: number) {
  * @param id - Application row id
  */
 export async function resendPlatformAccessApplicationInvite(id: number) {
+  await requireInternalAccount();
   try {
     return await issueApprovedApplicantSignupAccess(id);
   } catch (error) {
@@ -177,6 +170,7 @@ export async function resendPlatformAccessApplicationInvite(id: number) {
  * @param id - Application row id
  */
 export async function rejectPlatformAccessApplication(id: number) {
+  await requireInternalAccount();
   try {
     const reviewerId = await getReviewerAccountId();
     const [existing] = await db
@@ -216,6 +210,7 @@ export async function rejectPlatformAccessApplication(id: number) {
 export async function getFarmAdvisorProfileNotes(
   farmId: number
 ): Promise<string> {
+  await requireInternalAccount();
   try {
     const [row] = await db
       .select({ advisorProfileNotes: farm.advisorProfileNotes })
@@ -240,6 +235,7 @@ export async function updateFarmAdvisorProfileNotes(
   farmId: number,
   notes: string
 ): Promise<{ success: boolean; error?: string }> {
+  await requireInternalAccount();
   try {
     const reviewerId = await getReviewerAccountId();
     if (!reviewerId) {

--- a/apps/internal/src/app/(dashboard)/applications/components/application-detail-client.tsx
+++ b/apps/internal/src/app/(dashboard)/applications/components/application-detail-client.tsx
@@ -25,6 +25,7 @@ import {
 import ApplicationAnswersPanel from './application-answers-panel';
 import { FormSlugBadge } from './form-slug-badge';
 import FarmAdvisorProfileNotes from './farm-advisor-profile-notes';
+import { notifyActionError } from '@/lib/notify-action-error';
 
 /** One platform access application row. */
 export type ApplicationRow = NonNullable<
@@ -100,6 +101,8 @@ export default function ApplicationDetailClient({
 
       setConfirmAction(null);
       showInviteEmailResult(result, 'Application approved.');
+    } catch {
+      notifyActionError();
     } finally {
       setLoading(false);
     }
@@ -112,6 +115,8 @@ export default function ApplicationDetailClient({
         application.id
       );
       showInviteEmailResult(result, 'Invite resent.');
+    } catch {
+      notifyActionError();
     } finally {
       setLoading(false);
     }
@@ -129,6 +134,8 @@ export default function ApplicationDetailClient({
       setConfirmAction(null);
       toast.success('Application rejected.');
       router.push('/applications');
+    } catch {
+      notifyActionError();
     } finally {
       setLoading(false);
     }

--- a/apps/internal/src/app/(dashboard)/components/internal-accounts-client.tsx
+++ b/apps/internal/src/app/(dashboard)/components/internal-accounts-client.tsx
@@ -33,6 +33,7 @@ import {
   updateInternalAccount,
   deleteInternalAccount,
 } from '../actions';
+import { notifyActionError } from '@/lib/notify-action-error';
 
 /** Shape of an internal account record */
 interface InternalAccountRecord {
@@ -81,8 +82,12 @@ export default function InternalAccountsClient({
   } = useForm<AccountFormData>();
 
   const loadAccounts = useCallback(async (search?: string) => {
-    const data = await getInternalAccounts(search);
-    setAccounts(data as InternalAccountRecord[]);
+    try {
+      const data = await getInternalAccounts(search);
+      setAccounts(data as InternalAccountRecord[]);
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openCreateDialog = () => {
@@ -110,35 +115,43 @@ export default function InternalAccountsClient({
   };
 
   const onSubmit = async (data: AccountFormData) => {
-    if (editingAccount) {
-      const result = await updateInternalAccount(editingAccount.id, data);
-      if (result) {
-        toast.success('Account updated successfully.');
+    try {
+      if (editingAccount) {
+        const result = await updateInternalAccount(editingAccount.id, data);
+        if (result) {
+          toast.success('Account updated successfully.');
+        } else {
+          toast.error('Failed to update account.');
+          return;
+        }
       } else {
-        toast.error('Failed to update account.');
-        return;
+        const result = await createInternalAccount(data);
+        if (result) {
+          toast.success('Account created successfully.');
+        } else {
+          toast.error('Failed to create account.');
+          return;
+        }
       }
-    } else {
-      const result = await createInternalAccount(data);
-      if (result) {
-        toast.success('Account created successfully.');
-      } else {
-        toast.error('Failed to create account.');
-        return;
-      }
+      setDialogOpen(false);
+      loadAccounts();
+    } catch {
+      notifyActionError();
     }
-    setDialogOpen(false);
-    loadAccounts();
   };
 
   const handleDelete = async (id: number) => {
     if (!confirm('Are you sure you want to delete this account?')) return;
-    const success = await deleteInternalAccount(id);
-    if (success) {
-      toast.success('Account deleted successfully.');
-      loadAccounts();
-    } else {
-      toast.error('Failed to delete account.');
+    try {
+      const success = await deleteInternalAccount(id);
+      if (success) {
+        toast.success('Account deleted successfully.');
+        loadAccounts();
+      } else {
+        toast.error('Failed to delete account.');
+      }
+    } catch {
+      notifyActionError();
     }
   };
 

--- a/apps/internal/src/app/(dashboard)/farms/actions.ts
+++ b/apps/internal/src/app/(dashboard)/farms/actions.ts
@@ -11,6 +11,7 @@ import {
 } from '@nightcrawler/db/schema';
 import { eq, ilike, or } from 'drizzle-orm';
 import logger from '@/lib/logger';
+import { requireInternalAccount } from '@/lib/require-internal-account';
 
 // ──────────────────────────── FARMS ────────────────────────────
 
@@ -20,6 +21,7 @@ import logger from '@/lib/logger';
  * @returns Array of farm records
  */
 export async function getFarms(search?: string) {
+  await requireInternalAccount();
   try {
     if (search) {
       return await db
@@ -53,6 +55,7 @@ export async function createFarm(data: {
   approved?: boolean;
   stripeCustomerId?: string;
 }) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .insert(farm)
@@ -89,6 +92,7 @@ export async function updateFarm(
     stripeCustomerId?: string;
   }
 ) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .update(farm)
@@ -108,6 +112,7 @@ export async function updateFarm(
  * @returns True if deleted successfully
  */
 export async function deleteFarm(id: number) {
+  await requireInternalAccount();
   try {
     await db.delete(farm).where(eq(farm.id, id));
     return true;
@@ -125,6 +130,7 @@ export async function deleteFarm(id: number) {
  * @returns Array of management zone records
  */
 export async function getManagementZones(search?: string) {
+  await requireInternalAccount();
   try {
     if (search) {
       return await db
@@ -153,6 +159,7 @@ export async function createManagementZone(data: {
   irrigation?: boolean;
   waterConservation?: boolean;
 }) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .insert(managementZone)
@@ -189,6 +196,7 @@ export async function updateManagementZone(
     waterConservation?: boolean;
   }
 ) {
+  await requireInternalAccount();
   try {
     const updateData: Record<string, unknown> = { ...data };
     if (data.npkLastUsed) updateData.npkLastUsed = new Date(data.npkLastUsed);
@@ -210,6 +218,7 @@ export async function updateManagementZone(
  * @returns True if deleted successfully
  */
 export async function deleteManagementZone(id: number) {
+  await requireInternalAccount();
   try {
     await db.delete(managementZone).where(eq(managementZone.id, id));
     return true;
@@ -226,6 +235,7 @@ export async function deleteManagementZone(id: number) {
  * @returns Array of standard value records
  */
 export async function getStandardValues() {
+  await requireInternalAccount();
   try {
     return await db.select().from(standardValues).orderBy(standardValues.id);
   } catch (error) {
@@ -244,6 +254,7 @@ export async function updateStandardValues(
   id: number,
   data: Record<string, number>
 ) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .update(standardValues)
@@ -264,6 +275,7 @@ export async function updateStandardValues(
  * @returns Array of subscription records
  */
 export async function getFarmSubscriptions() {
+  await requireInternalAccount();
   try {
     return await db
       .select()

--- a/apps/internal/src/app/(dashboard)/farms/components/farms-client.tsx
+++ b/apps/internal/src/app/(dashboard)/farms/components/farms-client.tsx
@@ -40,6 +40,7 @@ import {
   updateStandardValues,
   getFarmSubscriptions,
 } from '../actions';
+import { notifyActionError } from '@/lib/notify-action-error';
 
 /** Props for the farms client component */
 interface FarmsClientProps {
@@ -121,7 +122,11 @@ function FarmsTab({ initialData }: { initialData: any[] }) {
   } = useForm<FarmFormData>();
 
   const load = useCallback(async (search?: string) => {
-    setFarms(await getFarms(search));
+    try {
+      setFarms(await getFarms(search));
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openCreate = () => {
@@ -156,27 +161,35 @@ function FarmsTab({ initialData }: { initialData: any[] }) {
       managementStartDate: data.managementStartDate || undefined,
       stripeCustomerId: data.stripeCustomerId || undefined,
     };
-    if (editing) {
-      const result = await updateFarm(editing.id, payload);
-      result
-        ? toast.success('Farm updated.')
-        : toast.error('Failed to update farm.');
-    } else {
-      const result = await createFarm(payload);
-      result
-        ? toast.success('Farm created.')
-        : toast.error('Failed to create farm.');
+    try {
+      if (editing) {
+        const result = await updateFarm(editing.id, payload);
+        result
+          ? toast.success('Farm updated.')
+          : toast.error('Failed to update farm.');
+      } else {
+        const result = await createFarm(payload);
+        result
+          ? toast.success('Farm created.')
+          : toast.error('Failed to create farm.');
+      }
+      setDialogOpen(false);
+      load();
+    } catch {
+      notifyActionError();
     }
-    setDialogOpen(false);
-    load();
   };
 
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this farm?')) return;
-    (await deleteFarm(id))
-      ? toast.success('Farm deleted.')
-      : toast.error('Failed to delete farm.');
-    load();
+    try {
+      (await deleteFarm(id))
+        ? toast.success('Farm deleted.')
+        : toast.error('Failed to delete farm.');
+      load();
+    } catch {
+      notifyActionError();
+    }
   };
 
   return (
@@ -339,7 +352,11 @@ function ZonesTab({ initialData }: { initialData: any[] }) {
   } = useForm<ZoneFormData>();
 
   const load = useCallback(async (search?: string) => {
-    setZones(await getManagementZones(search));
+    try {
+      setZones(await getManagementZones(search));
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openCreate = () => {
@@ -376,27 +393,35 @@ function ZonesTab({ initialData }: { initialData: any[] }) {
       farmId: Number(data.farmId),
       npkLastUsed: data.npkLastUsed || undefined,
     };
-    if (editing) {
-      const result = await updateManagementZone(editing.id, payload);
-      result
-        ? toast.success('Zone updated.')
-        : toast.error('Failed to update zone.');
-    } else {
-      const result = await createManagementZone(payload);
-      result
-        ? toast.success('Zone created.')
-        : toast.error('Failed to create zone.');
+    try {
+      if (editing) {
+        const result = await updateManagementZone(editing.id, payload);
+        result
+          ? toast.success('Zone updated.')
+          : toast.error('Failed to update zone.');
+      } else {
+        const result = await createManagementZone(payload);
+        result
+          ? toast.success('Zone created.')
+          : toast.error('Failed to create zone.');
+      }
+      setDialogOpen(false);
+      load();
+    } catch {
+      notifyActionError();
     }
-    setDialogOpen(false);
-    load();
   };
 
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this management zone?')) return;
-    (await deleteManagementZone(id))
-      ? toast.success('Zone deleted.')
-      : toast.error('Failed to delete zone.');
-    load();
+    try {
+      (await deleteManagementZone(id))
+        ? toast.success('Zone deleted.')
+        : toast.error('Failed to delete zone.');
+      load();
+    } catch {
+      notifyActionError();
+    }
   };
 
   return (
@@ -585,7 +610,11 @@ function StandardValuesTab({ initialData }: { initialData: any[] }) {
   } = useForm<Record<string, number>>();
 
   const load = useCallback(async () => {
-    setValues(await getStandardValues());
+    try {
+      setValues(await getStandardValues());
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openEdit = (record: any) => {
@@ -604,12 +633,16 @@ function StandardValuesTab({ initialData }: { initialData: any[] }) {
     for (const key of STANDARD_VALUE_FIELDS) {
       numericData[key] = Number(data[key]);
     }
-    const result = await updateStandardValues(editing.id, numericData);
-    result
-      ? toast.success('Standard values updated.')
-      : toast.error('Failed to update standard values.');
-    setDialogOpen(false);
-    load();
+    try {
+      const result = await updateStandardValues(editing.id, numericData);
+      result
+        ? toast.success('Standard values updated.')
+        : toast.error('Failed to update standard values.');
+      setDialogOpen(false);
+      load();
+    } catch {
+      notifyActionError();
+    }
   };
 
   return (

--- a/apps/internal/src/app/(dashboard)/imps/actions.ts
+++ b/apps/internal/src/app/(dashboard)/imps/actions.ts
@@ -6,6 +6,7 @@ import { db } from '@nightcrawler/db';
 import { integratedManagementPlan } from '@nightcrawler/db/schema';
 import { eq, ilike, or } from 'drizzle-orm';
 import logger from '@/lib/logger';
+import { requireInternalAccount } from '@/lib/require-internal-account';
 
 /**
  * Fetches all IMPs, optionally filtered by search query.
@@ -13,6 +14,7 @@ import logger from '@/lib/logger';
  * @returns Array of IMP records
  */
 export async function getImps(search?: string) {
+  await requireInternalAccount();
   try {
     if (search) {
       return await db
@@ -61,6 +63,7 @@ export async function createImp(data: {
   initialized: string;
   updated?: string;
 }) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .insert(integratedManagementPlan)
@@ -112,6 +115,7 @@ export async function updateImp(
     updated?: string;
   }
 ) {
+  await requireInternalAccount();
   try {
     const updateData: Record<string, unknown> = { ...data };
     if (data.updated) updateData.updated = new Date(data.updated);
@@ -133,6 +137,7 @@ export async function updateImp(
  * @returns True if deleted successfully
  */
 export async function deleteImp(id: number) {
+  await requireInternalAccount();
   try {
     await db
       .delete(integratedManagementPlan)

--- a/apps/internal/src/app/(dashboard)/imps/components/imps-client.tsx
+++ b/apps/internal/src/app/(dashboard)/imps/components/imps-client.tsx
@@ -31,6 +31,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Pencil, Trash2, Plus, Eye } from 'lucide-react';
 import { getImps, createImp, updateImp, deleteImp } from '../actions';
+import { notifyActionError } from '@/lib/notify-action-error';
 
 /** IMP categories */
 const IMP_CATEGORIES = [
@@ -86,7 +87,11 @@ export default function ImpsClient({ initialImps }: ImpsClientProps) {
   const contentValue = useWatch({ control, name: 'content' });
 
   const load = useCallback(async (search?: string) => {
-    setImps(await getImps(search));
+    try {
+      setImps(await getImps(search));
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openCreate = () => {
@@ -136,49 +141,57 @@ export default function ImpsClient({ initialImps }: ImpsClientProps) {
   };
 
   const onSubmit = async (data: ImpFormData) => {
-    if (editing) {
-      const result = await updateImp(editing.id, {
-        title: data.title,
-        slug: data.slug,
-        content: data.content,
-        category: data.category as (typeof IMP_CATEGORIES)[number],
-        source: data.source || undefined,
-        managementZone: Number(data.managementZone) || undefined,
-        analysis: data.analysis || undefined,
-        plan: data.plan || undefined,
-        updated: data.updated || new Date().toISOString().split('T')[0],
-      });
-      result
-        ? toast.success('IMP updated.')
-        : toast.error('Failed to update IMP.');
-    } else {
-      const result = await createImp({
-        knowledgeArticleId: Number(data.knowledgeArticleId),
-        title: data.title,
-        slug: data.slug,
-        content: data.content,
-        category: data.category as (typeof IMP_CATEGORIES)[number],
-        source: data.source || undefined,
-        managementZone: Number(data.managementZone) || undefined,
-        analysis: data.analysis || undefined,
-        plan: data.plan || undefined,
-        initialized: data.initialized,
-        updated: data.updated || undefined,
-      });
-      result
-        ? toast.success('IMP created.')
-        : toast.error('Failed to create IMP.');
+    try {
+      if (editing) {
+        const result = await updateImp(editing.id, {
+          title: data.title,
+          slug: data.slug,
+          content: data.content,
+          category: data.category as (typeof IMP_CATEGORIES)[number],
+          source: data.source || undefined,
+          managementZone: Number(data.managementZone) || undefined,
+          analysis: data.analysis || undefined,
+          plan: data.plan || undefined,
+          updated: data.updated || new Date().toISOString().split('T')[0],
+        });
+        result
+          ? toast.success('IMP updated.')
+          : toast.error('Failed to update IMP.');
+      } else {
+        const result = await createImp({
+          knowledgeArticleId: Number(data.knowledgeArticleId),
+          title: data.title,
+          slug: data.slug,
+          content: data.content,
+          category: data.category as (typeof IMP_CATEGORIES)[number],
+          source: data.source || undefined,
+          managementZone: Number(data.managementZone) || undefined,
+          analysis: data.analysis || undefined,
+          plan: data.plan || undefined,
+          initialized: data.initialized,
+          updated: data.updated || undefined,
+        });
+        result
+          ? toast.success('IMP created.')
+          : toast.error('Failed to create IMP.');
+      }
+      setDialogOpen(false);
+      load();
+    } catch {
+      notifyActionError();
     }
-    setDialogOpen(false);
-    load();
   };
 
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this IMP?')) return;
-    (await deleteImp(id))
-      ? toast.success('IMP deleted.')
-      : toast.error('Failed to delete IMP.');
-    load();
+    try {
+      (await deleteImp(id))
+        ? toast.success('IMP deleted.')
+        : toast.error('Failed to delete IMP.');
+      load();
+    } catch {
+      notifyActionError();
+    }
   };
 
   return (

--- a/apps/internal/src/app/(dashboard)/seed-products/actions.ts
+++ b/apps/internal/src/app/(dashboard)/seed-products/actions.ts
@@ -6,6 +6,7 @@ import { db } from '@nightcrawler/db';
 import { seedProduct } from '@nightcrawler/db/schema';
 import { eq, ilike, or } from 'drizzle-orm';
 import logger from '@/lib/logger';
+import { requireInternalAccount } from '@/lib/require-internal-account';
 
 /**
  * Fetches all seed products, optionally filtered by search query.
@@ -13,6 +14,7 @@ import logger from '@/lib/logger';
  * @returns Array of seed product records
  */
 export async function getSeedProducts(search?: string) {
+  await requireInternalAccount();
   try {
     if (search) {
       return await db
@@ -39,6 +41,7 @@ export async function getSeedProducts(search?: string) {
  * @returns The seed product or null
  */
 export async function getSeedProductBySlug(slug: string) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .select()
@@ -68,6 +71,7 @@ export async function createSeedProduct(data: {
   advisorContactUrl?: string;
   relatedIntegratedManagementPlanId?: number;
 }) {
+  await requireInternalAccount();
   try {
     const [result] = await db.insert(seedProduct).values(data).returning();
     return result;
@@ -97,6 +101,7 @@ export async function updateSeedProduct(
     relatedIntegratedManagementPlanId?: number;
   }
 ) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .update(seedProduct)
@@ -116,6 +121,7 @@ export async function updateSeedProduct(
  * @returns True if deleted successfully
  */
 export async function deleteSeedProduct(id: number) {
+  await requireInternalAccount();
   try {
     await db.delete(seedProduct).where(eq(seedProduct.id, id));
     return true;

--- a/apps/internal/src/app/(dashboard)/seed-products/components/seed-products-client.tsx
+++ b/apps/internal/src/app/(dashboard)/seed-products/components/seed-products-client.tsx
@@ -34,6 +34,7 @@ import {
   updateSeedProduct,
   deleteSeedProduct,
 } from '../actions';
+import { notifyActionError } from '@/lib/notify-action-error';
 
 /** Form data for seed product CRUD */
 interface SeedProductFormData {
@@ -73,7 +74,11 @@ export default function SeedProductsClient({
   } = useForm<SeedProductFormData>();
 
   const load = useCallback(async (search?: string) => {
-    setProducts(await getSeedProducts(search));
+    try {
+      setProducts(await getSeedProducts(search));
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openCreate = () => {
@@ -122,27 +127,35 @@ export default function SeedProductsClient({
       relatedIntegratedManagementPlanId:
         Number(data.relatedIntegratedManagementPlanId) || undefined,
     };
-    if (editing) {
-      const result = await updateSeedProduct(editing.id, payload);
-      result
-        ? toast.success('Product updated.')
-        : toast.error('Failed to update product.');
-    } else {
-      const result = await createSeedProduct(payload);
-      result
-        ? toast.success('Product created.')
-        : toast.error('Failed to create product.');
+    try {
+      if (editing) {
+        const result = await updateSeedProduct(editing.id, payload);
+        result
+          ? toast.success('Product updated.')
+          : toast.error('Failed to update product.');
+      } else {
+        const result = await createSeedProduct(payload);
+        result
+          ? toast.success('Product created.')
+          : toast.error('Failed to create product.');
+      }
+      setDialogOpen(false);
+      load();
+    } catch {
+      notifyActionError();
     }
-    setDialogOpen(false);
-    load();
   };
 
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this seed product?')) return;
-    (await deleteSeedProduct(id))
-      ? toast.success('Product deleted.')
-      : toast.error('Failed to delete product.');
-    load();
+    try {
+      (await deleteSeedProduct(id))
+        ? toast.success('Product deleted.')
+        : toast.error('Failed to delete product.');
+      load();
+    } catch {
+      notifyActionError();
+    }
   };
 
   return (

--- a/apps/internal/src/app/(dashboard)/tabs-widgets/actions.ts
+++ b/apps/internal/src/app/(dashboard)/tabs-widgets/actions.ts
@@ -6,6 +6,7 @@ import { db } from '@nightcrawler/db';
 import { tab, widget } from '@nightcrawler/db/schema';
 import { eq } from 'drizzle-orm';
 import logger from '@/lib/logger';
+import { requireInternalAccount } from '@/lib/require-internal-account';
 
 // ──────────────────────────── TABS ────────────────────────────
 
@@ -14,6 +15,7 @@ import logger from '@/lib/logger';
  * @returns Array of tab records
  */
 export async function getTabs() {
+  await requireInternalAccount();
   try {
     return await db.select().from(tab).orderBy(tab.id);
   } catch (error) {
@@ -31,6 +33,7 @@ export async function createTab(data: {
   user: number;
   managementZone: number;
 }) {
+  await requireInternalAccount();
   try {
     const [result] = await db.insert(tab).values(data).returning();
     return result;
@@ -46,6 +49,7 @@ export async function createTab(data: {
  * @returns True if deleted successfully
  */
 export async function deleteTab(id: number) {
+  await requireInternalAccount();
   try {
     await db.delete(tab).where(eq(tab.id, id));
     return true;
@@ -62,6 +66,7 @@ export async function deleteTab(id: number) {
  * @returns Array of widget records
  */
 export async function getWidgets() {
+  await requireInternalAccount();
   try {
     return await db.select().from(widget).orderBy(widget.id);
   } catch (error) {
@@ -93,6 +98,7 @@ export async function createWidget(data: {
     | 'Insights';
   widgetMetadata: { i: string; x: number; y: number };
 }) {
+  await requireInternalAccount();
   try {
     const [result] = await db.insert(widget).values(data).returning();
     return result;
@@ -129,6 +135,7 @@ export async function updateWidget(
     widgetMetadata?: { i: string; x: number; y: number };
   }
 ) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .update(widget)
@@ -148,6 +155,7 @@ export async function updateWidget(
  * @returns True if deleted successfully
  */
 export async function deleteWidget(id: number) {
+  await requireInternalAccount();
   try {
     await db.delete(widget).where(eq(widget.id, id));
     return true;

--- a/apps/internal/src/app/(dashboard)/tabs-widgets/components/tabs-widgets-client.tsx
+++ b/apps/internal/src/app/(dashboard)/tabs-widgets/components/tabs-widgets-client.tsx
@@ -35,6 +35,7 @@ import {
   updateWidget,
   deleteWidget,
 } from '../actions';
+import { notifyActionError } from '@/lib/notify-action-error';
 
 /** Widget type options */
 const WIDGET_TYPES = [
@@ -113,7 +114,11 @@ function TabsTab({ initialData }: { initialData: any[] }) {
   } = useForm<TabFormData>();
 
   const load = useCallback(async () => {
-    setTabs(await getTabs());
+    try {
+      setTabs(await getTabs());
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openCreate = () => {
@@ -122,23 +127,31 @@ function TabsTab({ initialData }: { initialData: any[] }) {
   };
 
   const onSubmit = async (data: TabFormData) => {
-    const result = await createTab({
-      user: Number(data.user),
-      managementZone: Number(data.managementZone),
-    });
-    result
-      ? toast.success('Tab created.')
-      : toast.error('Failed to create tab.');
-    setDialogOpen(false);
-    load();
+    try {
+      const result = await createTab({
+        user: Number(data.user),
+        managementZone: Number(data.managementZone),
+      });
+      result
+        ? toast.success('Tab created.')
+        : toast.error('Failed to create tab.');
+      setDialogOpen(false);
+      load();
+    } catch {
+      notifyActionError();
+    }
   };
 
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this tab?')) return;
-    (await deleteTab(id))
-      ? toast.success('Tab deleted.')
-      : toast.error('Failed to delete tab.');
-    load();
+    try {
+      (await deleteTab(id))
+        ? toast.success('Tab deleted.')
+        : toast.error('Failed to delete tab.');
+      load();
+    } catch {
+      notifyActionError();
+    }
   };
 
   return (
@@ -259,7 +272,11 @@ function WidgetsTab({ initialData }: { initialData: any[] }) {
   } = useForm<WidgetFormData>();
 
   const load = useCallback(async () => {
-    setWidgets(await getWidgets());
+    try {
+      setWidgets(await getWidgets());
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openCreate = () => {
@@ -293,35 +310,43 @@ function WidgetsTab({ initialData }: { initialData: any[] }) {
       y: Number(data.metadataY),
     };
 
-    if (editing) {
-      const result = await updateWidget(editing.id, {
-        managementZone: Number(data.managementZone),
-        name: data.name as (typeof WIDGET_TYPES)[number],
-        widgetMetadata,
-      });
-      result
-        ? toast.success('Widget updated.')
-        : toast.error('Failed to update widget.');
-    } else {
-      const result = await createWidget({
-        managementZone: Number(data.managementZone),
-        name: data.name as (typeof WIDGET_TYPES)[number],
-        widgetMetadata,
-      });
-      result
-        ? toast.success('Widget created.')
-        : toast.error('Failed to create widget.');
+    try {
+      if (editing) {
+        const result = await updateWidget(editing.id, {
+          managementZone: Number(data.managementZone),
+          name: data.name as (typeof WIDGET_TYPES)[number],
+          widgetMetadata,
+        });
+        result
+          ? toast.success('Widget updated.')
+          : toast.error('Failed to update widget.');
+      } else {
+        const result = await createWidget({
+          managementZone: Number(data.managementZone),
+          name: data.name as (typeof WIDGET_TYPES)[number],
+          widgetMetadata,
+        });
+        result
+          ? toast.success('Widget created.')
+          : toast.error('Failed to create widget.');
+      }
+      setDialogOpen(false);
+      load();
+    } catch {
+      notifyActionError();
     }
-    setDialogOpen(false);
-    load();
   };
 
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this widget?')) return;
-    (await deleteWidget(id))
-      ? toast.success('Widget deleted.')
-      : toast.error('Failed to delete widget.');
-    load();
+    try {
+      (await deleteWidget(id))
+        ? toast.success('Widget deleted.')
+        : toast.error('Failed to delete widget.');
+      load();
+    } catch {
+      notifyActionError();
+    }
   };
 
   return (

--- a/apps/internal/src/app/(dashboard)/users/actions.ts
+++ b/apps/internal/src/app/(dashboard)/users/actions.ts
@@ -6,6 +6,7 @@ import { db } from '@nightcrawler/db';
 import { user } from '@nightcrawler/db/schema';
 import { eq, ilike, or } from 'drizzle-orm';
 import logger from '@/lib/logger';
+import { requireInternalAccount } from '@/lib/require-internal-account';
 
 /**
  * Fetches all users, optionally filtered by search query.
@@ -13,6 +14,7 @@ import logger from '@/lib/logger';
  * @returns Array of user records
  */
 export async function getUsers(search?: string) {
+  await requireInternalAccount();
   try {
     if (search) {
       return await db
@@ -50,6 +52,7 @@ export async function createUser(data: {
   didOwnAndControlParcel?: boolean;
   didManageAndControl?: boolean;
 }) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .insert(user)
@@ -92,6 +95,7 @@ export async function updateUser(
     didManageAndControl?: boolean;
   }
 ) {
+  await requireInternalAccount();
   try {
     const [result] = await db
       .update(user)
@@ -111,6 +115,7 @@ export async function updateUser(
  * @returns True if deleted successfully
  */
 export async function deleteUser(id: number) {
+  await requireInternalAccount();
   try {
     await db.delete(user).where(eq(user.id, id));
     return true;

--- a/apps/internal/src/app/(dashboard)/users/components/users-client.tsx
+++ b/apps/internal/src/app/(dashboard)/users/components/users-client.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/dialog';
 import { Pencil, Trash2, Plus } from 'lucide-react';
 import { getUsers, createUser, updateUser, deleteUser } from '../actions';
+import { notifyActionError } from '@/lib/notify-action-error';
 
 /** Form data for user CRUD */
 interface UserFormData {
@@ -64,7 +65,11 @@ export default function UsersClient({ initialUsers }: UsersClientProps) {
   } = useForm<UserFormData>();
 
   const load = useCallback(async (search?: string) => {
-    setUsers(await getUsers(search));
+    try {
+      setUsers(await getUsers(search));
+    } catch {
+      notifyActionError();
+    }
   }, []);
 
   const openCreate = () => {
@@ -106,27 +111,35 @@ export default function UsersClient({ initialUsers }: UsersClientProps) {
       phone: data.phone || undefined,
       job: data.job || undefined,
     };
-    if (editing) {
-      const result = await updateUser(editing.id, payload);
-      result
-        ? toast.success('User updated.')
-        : toast.error('Failed to update user.');
-    } else {
-      const result = await createUser(payload);
-      result
-        ? toast.success('User created.')
-        : toast.error('Failed to create user.');
+    try {
+      if (editing) {
+        const result = await updateUser(editing.id, payload);
+        result
+          ? toast.success('User updated.')
+          : toast.error('Failed to update user.');
+      } else {
+        const result = await createUser(payload);
+        result
+          ? toast.success('User created.')
+          : toast.error('Failed to create user.');
+      }
+      setDialogOpen(false);
+      load();
+    } catch {
+      notifyActionError();
     }
-    setDialogOpen(false);
-    load();
   };
 
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this user?')) return;
-    (await deleteUser(id))
-      ? toast.success('User deleted.')
-      : toast.error('Failed to delete user.');
-    load();
+    try {
+      (await deleteUser(id))
+        ? toast.success('User deleted.')
+        : toast.error('Failed to delete user.');
+      load();
+    } catch {
+      notifyActionError();
+    }
   };
 
   return (

--- a/apps/internal/src/lib/notify-action-error.ts
+++ b/apps/internal/src/lib/notify-action-error.ts
@@ -1,0 +1,18 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+'use client';
+
+import { toast } from 'sonner';
+
+/**
+ * Shows a generic error toast when an internal-dashboard server action throws.
+ *
+ * Server actions now call `requireInternalAccount()` and throw on an expired or
+ * missing session, so client handlers wrap their action calls and surface this
+ * instead of letting the rejection go unhandled (no feedback for the user).
+ */
+export function notifyActionError() {
+  toast.error(
+    'Something went wrong. Your session may have expired — refresh and try again.'
+  );
+}

--- a/apps/internal/src/lib/require-internal-account.ts
+++ b/apps/internal/src/lib/require-internal-account.ts
@@ -1,0 +1,53 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { db } from '@nightcrawler/db';
+import { internalAccount } from '@nightcrawler/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { createClient } from '@/lib/supabase/server';
+
+/** An authenticated, active internal dashboard account. */
+export interface InternalAccount {
+  /** `internal_account` row id */
+  id: number;
+  /** Account email (matches the Supabase session email) */
+  email: string;
+}
+
+/**
+ * Authorizes the current request against the internal dashboard.
+ *
+ * Resolves the Supabase session, then verifies the caller owns an active row
+ * in `internal_account`. Server actions are publicly reachable POST endpoints,
+ * so each one must authorize independently of the middleware — middleware
+ * alone is not a sufficient authorization boundary (an action can be invoked
+ * directly). Call this at the top of every internal server action.
+ *
+ * Mirrors the lookup in `proxy/auth.ts` so the action layer and the middleware
+ * agree on who counts as an internal member.
+ *
+ * @returns The caller's active internal account
+ * @throws {Error} `Unauthorized` when there is no valid session or no active account
+ */
+export async function requireInternalAccount(): Promise<InternalAccount> {
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getClaims();
+  const email = data?.claims?.email as string | undefined;
+
+  if (!email) {
+    throw new Error('Unauthorized');
+  }
+
+  const [account] = await db
+    .select({ id: internalAccount.id })
+    .from(internalAccount)
+    .where(
+      and(eq(internalAccount.email, email), eq(internalAccount.isActive, true))
+    )
+    .limit(1);
+
+  if (!account) {
+    throw new Error('Unauthorized');
+  }
+
+  return { id: account.id, email };
+}


### PR DESCRIPTION
## Description

Closes #931

The internal dashboard only enforced auth in middleware. Problem is that `'use server'` actions are real POST endpoints you can hit directly, so middleware isn't a real boundary on its own — someone could call `getUsers`, `deleteFarm`, `approvePlatformAccessApplication`, etc. without being an internal member.

This adds a small `requireInternalAccount()` helper (`apps/internal/src/lib/require-internal-account.ts`) that checks the Supabase session against the `internal_account` table and throws if the caller isn't an active member, then calls it as the first line of all 47 actions across the 8 dashboard action files. I put it before each `try/catch` on purpose, so an auth failure throws clearly instead of getting swallowed and logged as a normal "operation failed".

It uses the same lookup that's already in `proxy/auth.ts` so middleware and the actions agree on who counts as a member. While I was in there I also refactored the existing `getReviewerAccountId()` in `applications/actions.ts` to reuse the helper instead of duplicating that query.

Things I left alone on purpose: the middleware (it works, and it has that sensitive "don't add logic between createServerClient and getClaims" bit), and I didn't wrap everything in some auth HOC/RBAC layer — explicit calls are easier to read and review. Kept `getClaims()` to match the existing code rather than swapping to `getUser()`.

On testing: `apps/internal` doesn't have a test harness yet and CI only runs the site tests, so I didn't add a unit test here. I did check it live on the local dashboard though — logged in as an active member and everything loads normally, then flipped the account to inactive and it bounced me to login. type-check, build, and lint all pass.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable. (no harness in apps/internal yet — verified live instead)
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate