### PR TITLE
Title: fix(site): resolve chunk error and logout navigation

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/news/page.tsx
@@ -1,7 +1,5 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-'use server';
-
 import { FeaturedNewsCarousel } from '@/components/common/news/featured-news-carousel';
 import { LatestNewsTable } from '@/components/common/news/latest-news-table';
 import {

--- a/apps/site/src/app/error.tsx
+++ b/apps/site/src/app/error.tsx
@@ -18,6 +18,25 @@ export default function Error({
   error: Error;
   reset: () => void;
 }) {
+  // ChunkLoadError fires when the browser fetches a JS chunk that no longer
+  // exists after a new deployment. Reload once to pick up fresh chunks.
+  // The sessionStorage flag prevents an infinite reload loop if the error persists.
+  if (
+    error.name === 'ChunkLoadError' ||
+    error.message?.includes('Loading chunk')
+  ) {
+    try {
+      if (!sessionStorage.getItem('chunk-reload-attempted')) {
+        sessionStorage.setItem('chunk-reload-attempted', '1');
+        window.location.reload();
+        return null;
+      }
+      sessionStorage.removeItem('chunk-reload-attempted');
+    } catch {
+      // sessionStorage unavailable — fall through to error UI
+    }
+  }
+
   return (
     <div className="mx-auto flex min-h-[calc(100vh-64px)] w-[90vw] max-w-[500px] flex-col items-center justify-center gap-4">
       <h1 className="text-3xl">There was an error with authentication</h1>

--- a/apps/site/src/lib/auth-client.ts
+++ b/apps/site/src/lib/auth-client.ts
@@ -3,7 +3,6 @@
 'use client';
 
 import { AuthError } from '@supabase/supabase-js';
-import { redirect } from 'next/navigation';
 import logger from './logger';
 import { createClient as createBrowserClient } from './supabase/client';
 import { AuthResponse, AuthResponseTypes } from './types/auth';
@@ -90,7 +89,8 @@ export async function logout(): Promise<AuthResponse> {
     };
   }
 
-  redirect('/');
+  window.location.replace('/');
+  return { data: {}, responseType: AuthResponseTypes.Logout };
 }
 
 /**

--- a/apps/site/src/lib/auth.test.ts
+++ b/apps/site/src/lib/auth.test.ts
@@ -50,10 +50,12 @@ vitest.mock('./supabase/server', async (importActual) => {
   };
 });
 
-const mockRedirect = vitest.fn();
-vitest.mock('next/navigation', () => ({
-  redirect: (path: string) => mockRedirect(path),
-}));
+const mockLocationReplace = vitest.fn();
+Object.defineProperty(window, 'location', {
+  value: { replace: mockLocationReplace },
+  writable: true,
+  configurable: true,
+});
 
 describe('login', () => {
   beforeEach(() => {
@@ -104,16 +106,16 @@ describe('logout', () => {
     });
   });
 
-  it('logs out when authenticated and redirects', async () => {
+  it('logs out when authenticated and navigates to root', async () => {
     mockSignOut.mockResolvedValue({ error: null });
 
     await logout();
 
     expect(mockSignOut).toHaveBeenCalledTimes(1);
-    expect(mockRedirect).toHaveBeenCalledWith('/');
+    expect(mockLocationReplace).toHaveBeenCalledWith('/');
   });
 
-  it('does not log out when not authenticated, but still redirects', async () => {
+  it('does not call signOut when not authenticated, but still navigates to root', async () => {
     mockGetUser.mockResolvedValue({
       data: { user: null },
     });
@@ -121,23 +123,26 @@ describe('logout', () => {
     await logout();
 
     expect(mockSignOut).not.toHaveBeenCalled();
+    expect(mockLocationReplace).toHaveBeenCalledWith('/');
   });
 
-  it('logs warning on Supabase signOut error but still redirects', async () => {
+  it('returns AuthError on Supabase signOut error and does not navigate', async () => {
     const fakeError = new AuthError('signout failed');
 
     mockSignOut.mockResolvedValue({ error: fakeError });
 
-    await logout();
+    const result = await logout();
 
     expect(mockSignOut).toHaveBeenCalled();
+    expect(result?.error).toBeInstanceOf(AuthError);
+    expect(mockLocationReplace).not.toHaveBeenCalled();
   });
 
-  it('returns AuthError when an exception is thrown and does not redirect', async () => {
+  it('returns AuthError when an exception is thrown and does not navigate', async () => {
     const result = await logout();
 
     expect(result?.error).toBeInstanceOf(AuthError);
-    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(mockLocationReplace).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #848

Resolves two related issues reported on the `/news` page and after logout:

- **Logout error**: `auth-client.ts` was calling `redirect('/')` from `next/navigation`, which is server-only. Calling it from a client context throws an unhandled error that triggers the React error boundary. Replaced with `window.location.replace('/')` which works correctly in the browser and is more appropriate for logout since it clears all client state.
- **Incorrect page directive**: `news/page.tsx` had a `'use server'` directive which marks exports as Server Actions rather than a Server Component. Removed — pages are Server Components by Next.js convention.
- **ChunkLoadError**: After a new deployment, chunk filenames change. Clients with cached HTML fetch stale chunk URLs that 404, triggering React error #418. Added a ChunkLoadError check in `app/error.tsx` that reloads the page once when detected. A `sessionStorage` flag prevents an infinite reload loop if the error persists.

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
