### PR TITLE
fix(security): patch nodemailer + undici high-severity advisories via overrides

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -228,11 +228,12 @@
     "lodash-es": "^4.17.24",
     "markdown-it": "^14.1.1",
     "minimatch": "^10.2.3",
+    "nodemailer": "^9.0.1",
     "picomatch": "^4.0.4",
     "protobufjs": "^7.6.1",
     "rollup": "^4.59.0",
     "tar": "^7.5.11",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "vite": "^7.3.5",
     "ws": "^8.21.0",
   },
@@ -2869,7 +2870,7 @@
 
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
-    "nodemailer": ["nodemailer@8.0.5", "", {}, "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="],
+    "nodemailer": ["nodemailer@9.0.1", "", {}, "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw=="],
 
     "normalize-package-data": ["normalize-package-data@8.0.0", "", { "dependencies": { "hosted-git-info": "^9.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ=="],
 
@@ -3467,7 +3468,7 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
-    "undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/package.json
+++ b/package.json
@@ -79,12 +79,13 @@
     "basic-ftp": "^5.3.1",
     "tar": "^7.5.11",
     "dompurify": "3.3.2",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "vite": "^7.3.5",
     "protobufjs": "^7.6.1",
     "@grpc/grpc-js": "^1.14.4",
     "form-data": "^4.0.6",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "nodemailer": "^9.0.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
## What

Clear the 4 high-severity advisories reported by `bun audit --audit-level=high` via root `package.json` dependency overrides (same mechanism as 990d8b9).

| Package | Was | Now | Advisory |
|---------|-----|-----|----------|
| `nodemailer` | ≤9.0.0 | `^9.0.1` | [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f) — `raw` option bypasses `disableFileAccess`/`disableUrlAccess` → arbitrary file read + full-response SSRF |
| `undici` | `^7.24.0` (in vuln range `>=7.23.0 <7.28.0`) | `^7.28.0` | [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) TLS cert validation bypass (SOCKS5), [GHSA-vxpw-j846-p89q](https://github.com/advisories/GHSA-vxpw-j846-p89q) WS DoS, [GHSA-hm92-r4w5-c3mj](https://github.com/advisories/GHSA-hm92-r4w5-c3mj) cross-origin routing via SOCKS5 pool reuse |

Note: the existing `undici` override was already `^7.24.0` — **inside** the vulnerable range — so it had to be bumped, not just adding `nodemailer`. Existing overrides preserved.

## Verification

- `bun audit --audit-level=high` → **exit 0, 0 high** (was `4 vulnerabilities (4 high)`)
- `bun run type-check` → 4/4 packages pass
- `bun run build` → 3/3 builds pass (site, sanity, internal)

## Compatibility

- **nodemailer 8 → 9 (major):** only call site is `apps/site/src/lib/order/server/order-email.ts` using stable `createTransport`/`sendMail`; the vulnerable `raw` option is not used. Type-check + build pass. Low risk.
- **undici → 7.28.0:** minor within 7.x, API-compatible across newrelic/jsdom/sanity consumers. Deliberately stayed on 7.x to avoid an 8.x cross-major break. Low risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
