### PR TITLE
fix(site): prevent SSRF in Google Sheets submission

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(contact)/contact/actions.test.ts
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(contact)/contact/actions.test.ts
@@ -3,12 +3,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  submitToGoogleSheets: vi.fn(),
+  submitContactToSheets: vi.fn(),
   loggerError: vi.fn(),
 }));
 
 vi.mock('@/lib/actions/googleSheets', () => ({
-  submitToGoogleSheets: mocks.submitToGoogleSheets,
+  submitContactToSheets: mocks.submitContactToSheets,
 }));
 
 vi.mock('@/lib/logger', () => ({
@@ -33,13 +33,11 @@ function makeFormData(fields: Record<string, string | undefined>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  delete process.env.CONTACT_GOOGLE_SCRIPT_URL;
 });
 
 describe('submitPublicInquiry', () => {
-  it('returns success and submits to Google Sheets when inputs are valid', async () => {
-    process.env.CONTACT_GOOGLE_SCRIPT_URL = 'https://example.com/script';
-    mocks.submitToGoogleSheets.mockResolvedValueOnce(undefined);
+  it('returns success and submits to the contact sheet when inputs are valid', async () => {
+    mocks.submitContactToSheets.mockResolvedValueOnce(undefined);
 
     const fd = makeFormData({
       name: 'Inban',
@@ -50,29 +48,25 @@ describe('submitPublicInquiry', () => {
     const result = await submitPublicInquiry(fd);
 
     expect(result).toEqual({ data: null });
-    expect(mocks.submitToGoogleSheets).toHaveBeenCalledTimes(1);
+    expect(mocks.submitContactToSheets).toHaveBeenCalledTimes(1);
 
-    const [submittedFormData, url] = mocks.submitToGoogleSheets.mock.calls[0];
-    expect(url).toBe('https://example.com/script');
+    // The action forwards only the form data — never a URL (URL is bound
+    // server-side in the wrapper, so the caller can't control the target).
+    const [submittedFormData] = mocks.submitContactToSheets.mock.calls[0];
     expect(submittedFormData).toBeInstanceOf(FormData);
-
     expect(submittedFormData.get('name')).toBe('Inban');
     expect(submittedFormData.get('lastKnownEmail')).toBe('inban@example.com');
     expect(submittedFormData.get('response')).toBe('Hello!');
   });
 
   it('throws an error when required fields are missing', async () => {
-    process.env.CONTACT_GOOGLE_SCRIPT_URL = 'https://example.com/script';
-
     const fd = makeFormData({});
     await expect(submitPublicInquiry(fd)).rejects.toThrow('Name is required.');
 
-    expect(mocks.submitToGoogleSheets).not.toHaveBeenCalled();
+    expect(mocks.submitContactToSheets).not.toHaveBeenCalled();
   });
 
   it('throws validation error if email is provided but invalid', async () => {
-    process.env.CONTACT_GOOGLE_SCRIPT_URL = 'https://example.com/script';
-
     const fd = makeFormData({
       name: 'Inban',
       lastKnownEmail: 'not-an-email',
@@ -83,12 +77,10 @@ describe('submitPublicInquiry', () => {
       'Please enter a valid email.'
     );
 
-    expect(mocks.submitToGoogleSheets).not.toHaveBeenCalled();
+    expect(mocks.submitContactToSheets).not.toHaveBeenCalled();
   });
 
   it('throws validation error if response is over 1500 chars', async () => {
-    process.env.CONTACT_GOOGLE_SCRIPT_URL = 'https://example.com/script';
-
     const fd = makeFormData({
       name: 'Inban',
       lastKnownEmail: 'inban@example.com',
@@ -99,25 +91,11 @@ describe('submitPublicInquiry', () => {
       'Response is too long (max 1500 characters).'
     );
 
-    expect(mocks.submitToGoogleSheets).not.toHaveBeenCalled();
+    expect(mocks.submitContactToSheets).not.toHaveBeenCalled();
   });
 
-  it('throws config error if CONTACT_GOOGLE_SCRIPT_URL is missing', async () => {
-    const fd = makeFormData({
-      name: 'Inban',
-      lastKnownEmail: 'inban@example.com',
-      response: 'Hello!',
-    });
-
-    await expect(submitPublicInquiry(fd)).rejects.toThrow(
-      'Server configuration error: Missing CONTACT_GOOGLE_SCRIPT_URL'
-    );
-    expect(mocks.submitToGoogleSheets).not.toHaveBeenCalled();
-  });
-
-  it('throws error when submitToGoogleSheets throws, and logs it', async () => {
-    process.env.CONTACT_GOOGLE_SCRIPT_URL = 'https://example.com/script';
-    mocks.submitToGoogleSheets.mockRejectedValueOnce(
+  it('surfaces and logs an error when the submission fails', async () => {
+    mocks.submitContactToSheets.mockRejectedValueOnce(
       new Error('Sheets is down')
     );
 

--- a/apps/site/src/app/(unauthenticated)/[locale]/(contact)/contact/actions.ts
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(contact)/contact/actions.ts
@@ -2,7 +2,7 @@
 
 'use server';
 
-import { submitToGoogleSheets } from '@/lib/actions/googleSheets';
+import { submitContactToSheets } from '@/lib/actions/googleSheets';
 import logger from '@/lib/logger';
 import type { ActionResponse } from '@/lib/types/action-response';
 import { throwActionError } from '@/lib/utils/actions';
@@ -41,15 +41,8 @@ export async function submitPublicInquiry(
     throwActionError(z.treeifyError(validated.error));
   }
 
-  const scriptUrl = process.env.CONTACT_GOOGLE_SCRIPT_URL;
-  if (!scriptUrl) {
-    throwActionError(
-      'Server configuration error: Missing CONTACT_GOOGLE_SCRIPT_URL'
-    );
-  }
-
   try {
-    await submitToGoogleSheets(formData, scriptUrl);
+    await submitContactToSheets(formData);
     return { data: null };
   } catch (err) {
     logger.error('Public inquiry submission error:', err);

--- a/apps/site/src/lib/actions/googleSheets.test.ts
+++ b/apps/site/src/lib/actions/googleSheets.test.ts
@@ -1,0 +1,40 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { submitContactToSheets } from './googleSheets';
+
+const ORIGINAL_URL = process.env.CONTACT_GOOGLE_SCRIPT_URL;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  process.env.CONTACT_GOOGLE_SCRIPT_URL = ORIGINAL_URL;
+});
+
+describe('submitContactToSheets', () => {
+  it('throws a config error when CONTACT_GOOGLE_SCRIPT_URL is not set', async () => {
+    delete process.env.CONTACT_GOOGLE_SCRIPT_URL;
+
+    await expect(submitContactToSheets({ email: 'a@b.com' })).rejects.toThrow(
+      'Server configuration error: Missing CONTACT_GOOGLE_SCRIPT_URL'
+    );
+  });
+
+  it('posts to the server-configured URL, not a caller-supplied one', async () => {
+    process.env.CONTACT_GOOGLE_SCRIPT_URL = 'https://script.example.com/exec';
+
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ status: 'success' }), { status: 200 })
+      );
+
+    await submitContactToSheets({ email: 'a@b.com' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledUrl = String(fetchMock.mock.calls[0][0]);
+    expect(calledUrl).toContain('https://script.example.com/exec');
+  });
+});

--- a/apps/site/src/lib/actions/googleSheets.ts
+++ b/apps/site/src/lib/actions/googleSheets.ts
@@ -2,13 +2,17 @@
 
 'use server';
 
-/** Submits data to a Google Sheets URL via a `FormData` object. For context, any Google Sheet will be expecting a POST request (handled by this action) with JSON-ified data like so:
+/**
+ * Posts form data to a Google Apps Script endpoint as JSON, e.g.
+ * `{"email": "test@example.com"}`.
  *
- * {"email": "test@example.com"}
- *
- * The `FormData` interface can handle this appropriately.
- * */
-export async function submitToGoogleSheets(
+ * Intentionally NOT exported: in a `'use server'` module every export becomes a
+ * directly-callable server action, so exporting a function that takes a
+ * caller-supplied URL would let any client drive a server-side `fetch()` to an
+ * arbitrary destination (SSRF). The target URL must therefore come from a
+ * trusted, env-bound wrapper below — never from the caller.
+ */
+async function submitToGoogleSheets(
   formData: FormData | Object,
   googleScriptUrl: string
 ) {
@@ -64,9 +68,22 @@ export async function submitToGoogleSheets(
   }
 }
 
+/**
+ * Server action: submits a contact-page inquiry to the contact Google Sheet.
+ *
+ * The destination is bound to `CONTACT_GOOGLE_SCRIPT_URL` on the server, so the
+ * caller cannot control where the request is sent (prevents SSRF). Throws if
+ * the environment variable is not configured.
+ *
+ * @param formData - Submitted contact form payload
+ */
 export async function submitContactToSheets(formData: FormData | Object) {
-  return submitToGoogleSheets(
-    formData,
-    process.env.CONTACT_GOOGLE_SCRIPT_URL || ''
-  );
+  const googleScriptUrl = process.env.CONTACT_GOOGLE_SCRIPT_URL;
+  if (!googleScriptUrl) {
+    throw new Error(
+      'Server configuration error: Missing CONTACT_GOOGLE_SCRIPT_URL'
+    );
+  }
+
+  return submitToGoogleSheets(formData, googleScriptUrl);
 }

--- a/apps/site/src/lib/actions/googleSheets.ts
+++ b/apps/site/src/lib/actions/googleSheets.ts
@@ -2,6 +2,8 @@
 
 'use server';
 
+import logger from '@/lib/logger';
+
 /**
  * Posts form data to a Google Apps Script endpoint as JSON, e.g.
  * `{"email": "test@example.com"}`.
@@ -61,7 +63,7 @@ async function submitToGoogleSheets(
 
     return { success: true };
   } catch (error) {
-    console.error('Submission error:', error);
+    logger.error('Submission error:', error);
     throw new Error(
       error instanceof Error ? error.message : 'An unknown error occurred'
     );


### PR DESCRIPTION
## Description

Closes #935

`submitToGoogleSheets` was exported from a `'use server'` module while taking a caller-supplied URL. Because every export in a `'use server'` file becomes a directly-invokable server action, that meant any client could call it as an endpoint and make the server `fetch()` an arbitrary URL — a classic SSRF vector.

The fix is the one the issue recommends: stop exporting the generic URL-taking function and make it a private helper, so the destination can only come from a trusted, server-side source. The only exported entry point now is `submitContactToSheets`, which binds the target to `CONTACT_GOOGLE_SCRIPT_URL` on the server (and throws if it isn't configured), so a caller can't control where the request goes. I updated the one live caller (the contact form's `submitPublicInquiry`) to use the wrapper and dropped its now-redundant URL handling.

`apply` only referenced the function in a vestigial test mock (its action code doesn't import googleSheets), so nothing else needed touching.

### Testing
- Updated the contact action tests to the wrapper (forwards form data, never a URL).
- Added `googleSheets.test.ts` covering the security-relevant behavior: throws when `CONTACT_GOOGLE_SCRIPT_URL` is unset (fails closed) and posts only to the server-configured URL.
- Site tests for both files pass (7), lint clean.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate