### PR TITLE
fix: add logout link to apply page

### DIFF
--- a/apps/site/src/components/common/authenticated-header/components/apply-logout-link.tsx
+++ b/apps/site/src/components/common/authenticated-header/components/apply-logout-link.tsx
@@ -1,0 +1,23 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+'use client';
+
+import LogoutLink from '@/components/common/utils/logout-link/logout-link';
+import { usePathname } from 'next/navigation';
+
+/**
+ * only renders on the /apply route
+ * @returns The apply logout link, or null outside `/apply`
+ */
+
+export function ApplyLogoutLink() {
+  const pathname = usePathname();
+
+  if (pathname !== '/apply') {
+    return null;
+  }
+
+  return (
+    <LogoutLink className="text-foreground flex items-center gap-1 text-sm transition-opacity hover:opacity-70" />
+  );
+}

--- a/apps/site/src/components/common/authenticated-header/nav-links.tsx
+++ b/apps/site/src/components/common/authenticated-header/nav-links.tsx
@@ -1,6 +1,7 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import Link from 'next/link';
+import { ApplyLogoutLink } from './components/apply-logout-link';
 import { OrderNavLink } from './components/order-nav-link';
 
 /** Reusable navigation links component.
@@ -27,6 +28,7 @@ export async function NavLinks() {
             {link.label}
           </Link>
         ))}
+        <ApplyLogoutLink />
       </div>
     </nav>
   );


### PR DESCRIPTION
## Description

Fixes #957 

Adds a logout link in the header for the /apply route, so the user doesn't get stuck on that page.

## Checklist

- [X ] You've included unit or integration tests for your change, where applicable.
- [X ] You've included inline docs for your change, where applicable.
- [X ] Any components that you've modified are accessible.
- [X ] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
