### PR TITLE
fix(security): patch linkify-it high-severity advisory via override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -224,6 +224,7 @@
     "flatted": "^3.4.2",
     "form-data": "^4.0.6",
     "js-yaml": "^4.1.1",
+    "linkify-it": "^5.0.1",
     "lodash": "^4.17.24",
     "lodash-es": "^4.17.24",
     "markdown-it": "^14.1.1",
@@ -2664,7 +2665,7 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+    "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
 
     "lint-staged": ["lint-staged@17.0.7", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA=="],
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "@grpc/grpc-js": "^1.14.4",
     "form-data": "^4.0.6",
     "ws": "^8.21.0",
-    "nodemailer": "^9.0.1"
+    "nodemailer": "^9.0.1",
+    "linkify-it": "^5.0.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
## Description

Fixes GHSA-22p9-wv53-3rq4 — patches `linkify-it <=5.0.0` high-severity vulnerability (quadratic scan loop complexity) by adding a `^5.0.1` override in the root `package.json`. `linkify-it` is a transitive dependency via `markdown-it` → `sanity`, no direct usage in the codebase.

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used conventional commits where appropriate.
