### PR TITLE
feat(site): add help link to account side menu

### DIFF
--- a/apps/site/src/app/(authenticated)/(shell)/(accounts)/account/components/account-side-menu/account-side-menu.stories.tsx
+++ b/apps/site/src/app/(authenticated)/(shell)/(accounts)/account/components/account-side-menu/account-side-menu.stories.tsx
@@ -1,0 +1,40 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import AccountSideMenu from './account-side-menu';
+
+const meta: Meta<typeof AccountSideMenu> = {
+  title: 'Account/AccountSideMenu',
+  component: AccountSideMenu,
+  parameters: {
+    layout: 'padded',
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/account',
+      },
+    },
+    docs: {
+      description: {
+        component:
+          'Left-hand navigation for the account area. Lists the account sections and, in the bottom utility group, a Help link to the support page (/contact) above the Log out action.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AccountSideMenu>;
+
+export const Default: Story = {};
+
+export const PrivacyActive: Story = {
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/account/privacy',
+      },
+    },
+  },
+};

--- a/apps/site/src/app/(authenticated)/(shell)/(accounts)/account/components/account-side-menu/account-side-menu.test.tsx
+++ b/apps/site/src/app/(authenticated)/(shell)/(accounts)/account/components/account-side-menu/account-side-menu.test.tsx
@@ -40,6 +40,15 @@ describe('AccountSideMenu', () => {
     );
   });
 
+  it('renders a help link pointing to the support page', () => {
+    render(<AccountSideMenu />);
+
+    expect(screen.getByRole('link', { name: 'Help' })).toHaveAttribute(
+      'href',
+      '/contact'
+    );
+  });
+
   it('calls logout flow when clicking log out', async () => {
     const user = userEvent.setup();
     render(<AccountSideMenu />);

--- a/apps/site/src/app/(authenticated)/(shell)/(accounts)/account/components/account-side-menu/account-side-menu.tsx
+++ b/apps/site/src/app/(authenticated)/(shell)/(accounts)/account/components/account-side-menu/account-side-menu.tsx
@@ -58,7 +58,7 @@ export default function AccountSideMenu() {
           href="/contact"
           className="flex w-fit items-center gap-2 text-sm font-normal text-foreground/70 hover:text-foreground"
         >
-          <span className="text-sm font-normal">Help</span>
+          Help
           <BiHelpCircle className="size-5" />
         </Link>
 
@@ -67,7 +67,7 @@ export default function AccountSideMenu() {
           onClick={handleLogout}
           className="text-foreground text-sm font-normal hover:cursor-pointer hover:opacity-70 translate-x-[-13px]"
         >
-          <span className="text-sm font-normal">Log out</span>
+          Log out
           <BiLogOut className="size-5" />
         </Button>
       </div>

--- a/apps/site/src/app/(authenticated)/(shell)/(accounts)/account/components/account-side-menu/account-side-menu.tsx
+++ b/apps/site/src/app/(authenticated)/(shell)/(accounts)/account/components/account-side-menu/account-side-menu.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { logout } from '@/lib/auth-client';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { BiLogOut } from 'react-icons/bi';
+import { BiHelpCircle, BiLogOut } from 'react-icons/bi';
 
 const sideMenuItems = [
   { href: '/account', label: 'Farm information' },
@@ -53,7 +53,15 @@ export default function AccountSideMenu() {
         </nav>
       </div>
 
-      <div className="mt-17.5 border-t border-[#D9D9D9] pt-4">
+      <div className="mt-17.5 space-y-3 border-t border-[#D9D9D9] pt-4">
+        <Link
+          href="/contact"
+          className="flex w-fit items-center gap-2 text-sm font-normal text-foreground/70 hover:text-foreground"
+        >
+          <span className="text-sm font-normal">Help</span>
+          <BiHelpCircle className="size-5" />
+        </Link>
+
         <Button
           type="button"
           onClick={handleLogout}


### PR DESCRIPTION
## Description

Fixes #734

There was no easy way to reach support from the account pages. This adds a **"Help"** link to the account side menu (the left-hand page selector), in the same bottom utility group as "Log out", pointing to the existing authenticated `/contact` ("Support Tools") page — so users land on the email/contact options already built there.

**What changed**
- `account-side-menu.tsx`: new "Help" link to `/contact`, with a `BiHelpCircle` icon trailing the label (mirroring the "Log out" treatment) and the label aligned flush-left with the section nav items.
- A unit test asserting the Help link renders and targets `/contact`.
- A Storybook story (`Default` and `PrivacyActive`) so the menu can be viewed in isolation.

**Notes / decisions**
- Reuses the existing `/contact` Support Tools page rather than introducing a new help destination — smallest, most consistent fix.
- The issue suggested the left page selector *or* the top-right; I went with the left side menu as the lower-risk, cleaner spot. Easy to move to the header if preferred.
- Follows this component's existing conventions: plain text label (the authenticated account area is not under `[locale]`, so it is not internationalized) and the same typography/hover styling as the section nav links.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate