### PR TITLE
feat: add soil test parser and content-to-markdown parser scripts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,7 @@
         "next-intl": "^4.8.3",
         "next-sanity": "^12.1.0",
         "openai": "^6.25.0",
+        "pdf-parse": "^2.4.5",
         "pg": "^8.19.0",
         "posthog-js": "^1.354.3",
         "preact": "10.28.4",
@@ -732,6 +733,28 @@
     "@mux/mux-video": ["@mux/mux-video@0.30.3", "", { "dependencies": { "@mux/mux-data-google-ima": "^0.3.4", "@mux/playback-core": "0.33.2", "castable-video": "~1.1.11", "custom-media-element": "~1.4.5", "media-tracks": "~0.3.4" } }, "sha512-EHlv/AjcfQadZeASM7wjjGBlVVXjMa/UP+/cRqbojF6F5JlADfQAHsAtwAisIQ7uCHy3GmdE4EwEIWNv/YZ5kA=="],
 
     "@mux/playback-core": ["@mux/playback-core@0.33.2", "", { "dependencies": { "hls.js": "~1.6.15", "mux-embed": "^5.16.1" } }, "sha512-4g8b92vuiSWXJ+4qEufGZYk6tInmJ8dJStTV4VO6Rub93l7d9vNEDR/nryMuSQ54g2fMHN57F/2fuVaiVdRgSg=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@0.1.80", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "0.1.80", "@napi-rs/canvas-darwin-arm64": "0.1.80", "@napi-rs/canvas-darwin-x64": "0.1.80", "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80", "@napi-rs/canvas-linux-arm64-gnu": "0.1.80", "@napi-rs/canvas-linux-arm64-musl": "0.1.80", "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80", "@napi-rs/canvas-linux-x64-gnu": "0.1.80", "@napi-rs/canvas-linux-x64-musl": "0.1.80", "@napi-rs/canvas-win32-x64-msvc": "0.1.80" } }, "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@0.1.80", "", { "os": "android", "cpu": "arm64" }, "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@0.1.80", "", { "os": "darwin", "cpu": "arm64" }, "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@0.1.80", "", { "os": "darwin", "cpu": "x64" }, "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@0.1.80", "", { "os": "linux", "cpu": "arm" }, "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@0.1.80", "", { "os": "linux", "cpu": "arm64" }, "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@0.1.80", "", { "os": "linux", "cpu": "arm64" }, "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@0.1.80", "", { "os": "linux", "cpu": "none" }, "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@0.1.80", "", { "os": "linux", "cpu": "x64" }, "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.80", "", { "os": "linux", "cpu": "x64" }, "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.80", "", { "os": "win32", "cpu": "x64" }, "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
@@ -2636,6 +2659,10 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "pdf-parse": ["pdf-parse@2.4.5", "", { "dependencies": { "@napi-rs/canvas": "0.1.80", "pdfjs-dist": "5.4.296" }, "bin": { "pdf-parse": "bin/cli.mjs" } }, "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg=="],
+
+    "pdfjs-dist": ["pdfjs-dist@5.4.296", "", { "optionalDependencies": { "@napi-rs/canvas": "^0.1.80" } }, "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q=="],
 
     "peek-stream": ["peek-stream@1.1.3", "", { "dependencies": { "buffer-from": "^1.0.0", "duplexify": "^3.5.0", "through2": "^2.0.3" } }, "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -90,6 +90,7 @@
         "ua-parser-js": "^2.0.9",
         "undici": "^7.24.0",
         "vaul": "^1.1.2",
+        "xlsx": "^0.18.5",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -1466,6 +1467,8 @@
 
     "acorn-loose": ["acorn-loose@8.5.2", "", { "dependencies": { "acorn": "^8.15.0" } }, "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A=="],
 
+    "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
+
     "adm-zip": ["adm-zip@0.5.16", "", {}, "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
@@ -1626,6 +1629,8 @@
 
     "ce-la-react": ["ce-la-react@0.3.2", "", { "peerDependencies": { "react": ">=17.0.0" } }, "sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA=="],
 
+    "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
+
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -1671,6 +1676,8 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "codemirror": ["codemirror@6.0.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw=="],
+
+    "codepage": ["codepage@1.15.0", "", {}, "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -2041,6 +2048,8 @@
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
 
     "framer-motion": ["framer-motion@12.34.3", "", { "dependencies": { "motion-dom": "^12.34.3", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q=="],
 
@@ -2942,6 +2951,8 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "ssf": ["ssf@0.11.2", "", { "dependencies": { "frac": "~1.1.2" } }, "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g=="],
+
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
@@ -3102,7 +3113,7 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
-    "undici": ["undici@7.24.1", "", {}, "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA=="],
+    "undici": ["undici@7.24.3", "", {}, "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -3218,6 +3229,10 @@
 
     "widest-line": ["widest-line@3.1.0", "", { "dependencies": { "string-width": "^4.0.0" } }, "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg=="],
 
+    "wmf": ["wmf@1.0.2", "", {}, "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="],
+
+    "word": ["word@0.3.0", "", {}, "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="],
+
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
@@ -3235,6 +3250,8 @@
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "xdg-basedir": ["xdg-basedir@4.0.0", "", {}, "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="],
+
+    "xlsx": ["xlsx@0.18.5", "", { "dependencies": { "adler-32": "~1.3.0", "cfb": "~1.2.1", "codepage": "~1.15.0", "crc-32": "~1.2.1", "ssf": "~0.11.2", "wmf": "~1.0.1", "word": "~0.3.0" }, "bin": { "xlsx": "bin/xlsx.njs" } }, "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -8,11 +8,39 @@ A modern, production-ready Next.js website for Todd Agriscience with comprehensi
 
 ### Core Framework
 
-- **Next.js 15** with App Router & Turbopack
+- **Next.js 16** with App Router & Turbopack
 - **TypeScript** with strict type checking
 - **Tailwind CSS v4** with custom brand configuration
 - **React 19** with modern hooks and patterns
-- Drizzle for ORM with PostgreSQL
+- **Drizzle ORM** with PostgreSQL (16 schema tables)
+
+### Authentication & Backend
+
+- **Supabase** (`@supabase/supabase-js`, `@supabase/ssr`) for authentication and database access
+- Server-side client in `src/lib/supabase/server.ts`, browser client in `src/lib/supabase/client.ts`
+- Auth utilities: `src/lib/auth-client.ts`, `src/lib/auth-server.ts`
+- Server actions for auth: `src/lib/actions/auth.ts`
+
+### Content Management
+
+- **Sanity CMS** (`next-sanity`, `@sanity/image-url`) for news and governance content
+- Standalone **Sanity Studio** in `/sanity-studio/` (separate package, schemas for news + governance profiles)
+- Sanity client in `src/lib/sanity/`, rendering components in `src/components/sanity/`
+
+### Payments
+
+- **Stripe** v20 for subscription billing
+- Webhook handler at `src/app/api/stripe/webhook/`
+- Stripe utilities in `src/lib/utils/stripe/`
+
+### Analytics
+
+- **PostHog** (`posthog-js`, `@posthog/react`) for event tracking (cookieless mode)
+
+### AI
+
+- **OpenAI** for embeddings and semantic search
+- AI utilities in `src/lib/ai/` (`embeddings.ts`, `search.ts`)
 
 ### UI Component System
 
@@ -22,27 +50,33 @@ A modern, production-ready Next.js website for Todd Agriscience with comprehensi
 - **Radix UI Slot** for composition patterns
 - **clsx & tailwind-merge** for conditional styling
 
+### Forms & Validation
+
+- **react-hook-form** v7 with **@hookform/resolvers**
+- **Zod** v4 for schema validation
+- Zod schemas in `src/lib/zod-schemas/`
+
 ### Internationalization
 
 - **Multi-language support** (en, es) with architecture ready for expansion
 - **Smart locale detection** from browser settings and localStorage
 - **Type-safe translations** with parameter interpolation
 - **Fallback system** to English for missing translations
+- Translation files structured as `src/messages/{namespace}/{locale}.json` (16 namespaces)
 
 ### Animation & UX
 
-- **Framer Motion v12.23** for component animations and scroll-based effects
-- **Lenis v1.0** for buttery smooth scrolling (matching original feel)
+- **Framer Motion v12** for component animations and scroll-based effects
+- **Lenis v1.0** (`@studio-freight/lenis`) for buttery smooth scrolling
 - **Embla Carousel** for interactive content carousels
-- **Dynamic header** with scroll-based state changes
-- **Advanced theme system** with smooth transitions and scroll-based dark mode
-- **Centralized theme context** with debounced state management
+- **Recharts** for data visualization
+- **react-grid-layout** for the widget dashboard system
 
 ### Development Infrastructure
 
 - **Vitest v4 + React Testing Library v16.3** (unit testing)
-- **Storybook v9.1** with accessibility addon
-- **ESLint v9 + Prettier v3.6** with pre-commit hooks (Husky v9.1)
+- **Storybook v10** with accessibility addon
+- **ESLint v9 + Prettier v3.8** with pre-commit hooks (Husky v9.1)
 - **GitHub Actions** CI/CD pipeline
 
 ### SEO & Performance
@@ -56,63 +90,103 @@ A modern, production-ready Next.js website for Todd Agriscience with comprehensi
 
 ```
 src/
-  app/                    # Next.js App Router
-    [locale]/            # Internationalized pages with layout
-      [...rest]/         # Catch-all route for dynamic pages
-    api/                 # API routes
-    globals.css          # Global styles with Lenis setup
-    layout.tsx           # Root layout with providers
-  components/             # All React components
-    common/              # Reusable components
-      button/            # Custom button with variants & types
-      carousel/          # Embla carousel component
-      locale-switcher/   # Language selection component
-      news-card/         # News article card component
-      placeholder-image/ # Image placeholder component
-      smooth-scroll/     # Smooth scroll wrapper
-    landing/             # Homepage-specific components
-      footer/            # Landing page footer
-      header/            # Landing page header with navigation
-      hero/              # Hero section component
-      news-highlights/ # Combined news + quote card
-      page/              # Landing page layout
-      quote/             # Quote/About section
-      scroll-shrink-wrapper/ # Scroll animation wrapper
-    ui/                  # shadcn/ui components
-      button.tsx         # shadcn/ui button component
-  context/               # React contexts
-    theme/               # Theme context with types
-      ThemeContext.tsx   # Theme and dark mode context
-      types/             # Theme-related TypeScript types
-  data/                  # Static data files
-    featured-news.json   # Featured news articles data
-  i18n/                  # Internationalization config
-    config.ts            # i18n configuration
-    request.ts           # Server-side i18n utilities
-  lib/                   # Utility functions
-    env.ts               # Environment configuration
-    fonts.ts             # Custom font loading
-    locale-utils.ts      # Locale helper functions
-    locales.ts           # Locale definitions
-    logger.ts            # Environment-aware logging utility
-    metadata.ts          # SEO metadata utilities
-    scroll-to-top.tsx    # Scroll to top component
-    utils.ts             # shadcn/ui utility functions
-  messages/              # Translation JSON files
-    en.json              # English translations
-    es.json              # Spanish translations
-  test/                  # Testing utilities
-    test-utils.tsx       # React Testing Library setup
-  types/                 # Global TypeScript types
-  proxy.ts               # next-intl proxy
-public/                  # Static assets
-  fonts/                 # Custom fonts (Neue Haas, Utah WGL)
-  publications/          # PDF documents
-scripts/                 # Build and utility scripts
-.github/workflows/       # CI/CD pipelines
-.storybook/             # Storybook configuration
-  decorators/            # Custom Storybook decorators
-components.json          # shadcn/ui configuration
+  app/                         # Next.js App Router
+    (authenticated)/           # Protected routes (require login)
+      (accounts)/account/      # Account management (profile, security, users, etc.)
+      (misc)/                  # apply, contact, search, welcome, application-success
+      (widgets)/               # Dashboard widget pages
+      [locale]/                # Locale-prefixed authenticated pages
+    (unauthenticated)/         # Pre-auth routes (accept, auth, externship-terms, incoming)
+    [locale]/                  # Marketing/public pages
+      (marketing)/             # Marketing route group
+        page.tsx               # Homepage
+        news/                  # News list & [slug] article pages
+        what-we-do/
+        who-we-are/
+        careers/
+        investors/             # With esg/ and governance/ subpages
+        (contact)/             # login, signup, forgot-password, contact, support
+        disclosures/
+        privacy/, terms/, accessibility/
+        [...rest]/             # 404 catch-all
+    api/
+      stripe/webhook/          # Stripe webhook handler
+    globals.css
+    layout.tsx                 # Root layout with providers
+    providers.tsx              # Client-side provider tree
+    error.tsx, not-found.tsx
+    sitemap.ts, llms.txt
+  components/
+    common/                    # 21 subdirectories — globally reusable components
+      authenticated-header/
+      button/                  # Custom button with variants & themes
+      carousel/
+      cookie-preferences-modal/
+      desktop-gate/
+      disclaimer/
+      form-error-message/
+      header-img/
+      legal-subtext/
+      locale-switcher/
+      news/                    # Featured carousel, latest table
+      news-card/
+      page-hero/
+      password-checklist/
+      placeholder-image/
+      public-inquiry-modal/
+      share-article/
+      unauthenticated-header/
+      utils/                   # fade-in, logout, smooth-scroll, submit-button, theme-reset
+      widgets/                 # add-dropdown, macro-radar, mineral-level, widget-wrapper
+      wordmark/
+    ui/                        # shadcn/ui components (button, card, dialog, input, etc.)
+    sanity/                    # CMS rendering components
+      governance-profile/      # Portable text: body-text, image, quote
+      news/                    # News: header-image, normal, thumbnail-image
+      sanity-link.tsx
+  context/
+    theme/                     # ThemeContext with types and tests
+  data/
+    governance-team.json
+  i18n/
+    config.ts                  # Routing and locale configuration
+    request.ts                 # Server-side i18n utilities
+    message-files.ts           # List of all translation namespaces
+  lib/
+    actions/                   # Server actions (auth.ts, googleSheets.ts)
+    ai/                        # AI embeddings and semantic search (OpenAI)
+    db/
+      schema/                  # 16 Drizzle ORM table definitions
+      queries/
+      types/
+    hooks/                     # useCookiePreferences, useCurrentUrl, useWindowWidth
+    sanity/                    # Sanity client, GROQ queries, utils
+    stripe/                    # Stripe client
+    supabase/                  # client.ts (browser), server.ts (server-side)
+    types/                     # Shared TypeScript type definitions
+    utils/                     # General utils + stripe/ subdirectory
+    zod-schemas/               # auth.ts, db.ts, onboarding.ts
+    auth-client.ts, auth-server.ts
+    env.ts, fonts.ts, locale-utils.ts, locales.ts
+    logger.ts, metadata.ts, routing.ts, utils.ts
+  messages/                    # Translation files (16 namespaces × 2 locales)
+    {namespace}/
+      en.json
+      es.json
+  proxy/                       # next-intl proxy
+  test/
+    test-utils.tsx
+  types/                       # Global TypeScript types
+public/
+  fonts/                       # Custom fonts (Neue Haas Unica, Utah WGL)
+  publications/                # PDF documents
+sanity-studio/                 # Standalone Sanity CMS Studio (separate package)
+  schemaTypes/                 # news.ts, governance-profiles.ts
+scripts/                       # Build and utility scripts
+.github/workflows/             # CI/CD pipelines
+.storybook/                    # Storybook configuration
+  decorators/
+components.json                # shadcn/ui configuration
 ```
 
 ### Development Priorities
@@ -135,21 +209,21 @@ When making changes, prioritize:
   ```
   app/
   ├── [locale]/
-  │   ├── about/
-  │   │   ├── components/       # About page specific components
-  │   │   │   ├── hero/
-  │   │   │   │   ├── types/
-  │   │   │   │   │   └── hero.ts
-  │   │   │   │   ├── hero.tsx
-  │   │   │   │   ├── hero.test.tsx
-  │   │   │   │   └── hero.stories.tsx
-  │   │   │   └── index.ts      # Barrel export for about page components
-  │   │   └── page.tsx          # About page
-  │   └── page.tsx              # Homepage (landing components in src/components/landing/)
+  │   ├── (marketing)/
+  │   │   ├── who-we-are/
+  │   │   │   ├── components/       # Page-specific components
+  │   │   │   │   ├── hero/
+  │   │   │   │   │   ├── types/
+  │   │   │   │   │   │   └── hero.ts
+  │   │   │   │   │   ├── hero.tsx
+  │   │   │   │   │   ├── hero.test.tsx
+  │   │   │   │   │   └── hero.stories.tsx
+  │   │   │   │   └── index.ts      # Barrel export for page components
+  │   │   │   └── page.tsx
   ```
 - **Global components**: Reusable components in `src/components/common/` and `src/components/ui/`
-- **Landing page exception**: Current landing page components remain in `src/components/landing/`
-- **shadcn/ui components**: Direct files in `src/components/ui/` (e.g., `button.tsx`)
+- **Sanity components**: CMS rendering components in `src/components/sanity/`
+- **shadcn/ui components**: Direct files in `src/components/ui/`
 - **Import paths**: Use `@/` alias for all src imports
 - **Naming**: Use kebab-case for directories, PascalCase for components
 - **Component variants**: Use `class-variance-authority` for component styling variants
@@ -217,7 +291,7 @@ Do not create migrations or migrate (i.e. no running `bunx drizzle-kit generate`
 
 ### When Adding New Components
 
-- **Follow slice architecture**: Page-specific components go in `app/[locale]/page-name/components/`
+- **Follow slice architecture**: Page-specific components go in `app/[locale]/(marketing)/page-name/components/` (or in the appropriate route group)
 - **Use TypeScript**: Strict typing for all props and state
 - **Component variants**: Use `class-variance-authority` for styling variants
 - **Theme support**: Integrate with existing ThemeContext when applicable
@@ -248,10 +322,8 @@ Do not create migrations or migrate (i.e. no running `bunx drizzle-kit generate`
 - **Accessibility required**: Follow WCAG guidelines, test with screen readers
 - **Internationalization ready**: Support multi-language from the start
 - **Test-driven approach**: Write tests for new functionality
-- **Properly CopyRight**: All new files should include "Copyright Todd Agriscience, Inc. All rights reserved. as a comment at the top
-- **Comments**: Every exported component, page, and util should have proper jsdocs. Private helper methods, components and .storybook.tsx files are excluded from this principle.
-- **Properly CopyRight**: All new files should include "Copyright Todd Agriscience, Inc. All rights reserved. as a comment at the top
-- **Comments**: Every exported component, page, and util should have proper jsdocs. Private helper methods, components and .storybook.tsx files are excluded from this principle.
+- **Properly CopyRight**: All new files should include "Copyright Todd Agriscience, Inc. All rights reserved." as a comment at the top
+- **Comments**: Every exported component, page, and util should have proper jsdocs. Private helper methods, components and `.storybook.tsx` files are excluded from this principle.
 - **Always format files**: Run `bun format` at the end of every piece of work
 
 ### When Making Changes

--- a/frontend/PARSER_CONTEXT.md
+++ b/frontend/PARSER_CONTEXT.md
@@ -1,0 +1,296 @@
+# Feature Context: Soil Test Parser + Content-to-Markdown Parser
+
+## Project Overview
+
+You're working on the Nightcrawler platform for Todd Agriscience. The platform is a Next.js app (App Router, TypeScript, Drizzle ORM, Supabase auth, PostgreSQL on DigitalOcean, Tailwind, shadcn/ui, Bun).
+
+You're building two parsers. Read this entire file before writing any code.
+
+---
+
+## PARSER 1: Soil Test File Parser
+
+### What it does
+
+Reads soil lab report data (from spreadsheets), converts raw values to PPM where needed, and inserts structured numerical data into the existing database tables (analysis, mineral, ph, solubility).
+
+### Why it exists
+
+Todd's partner lab sends soil test results as spreadsheets. Right now someone manually enters every number. This automates that. Farms test every 3-6 months, so this runs regularly.
+
+### Input format
+
+The lab reports come as spreadsheets with columns like:
+
+```
+No. | Description | Depth | SP(%) | pH | EC(dS/m) | Ca(meq/l) | Mg(meq/l) | Na(meq/l) | Cl | ESP(%) | Gypsum Req | Lime | B(mg/l) | NO3-N(mg/kg) | PO4-P(mg/kg) | K(mg/kg) | Zn(mg/kg) | Mn(mg/kg) | Fe(mg/kg) | Cu(mg/kg) | OM(%)
+```
+
+Example rows (raw from lab, values in meq/l for Ca/Mg/Na):
+
+```
+1  Harden 7     (Lettuce)      69  7.4  1.82  8.8   5.2  4.1   1    0.3  46  68   580  2.6  16   18   2.5  3.7
+2  Spreckels 3E (Celery)       46  7.5  2.13  13.3  4.9  5.1   1.2  0.2  27  64   420  3.9  6.7  14   1.5  2.0
+```
+
+The same data already converted to PPM (from the Excel "Converted Soil Test Data" sheet):
+
+```
+1  Harden 7     (Lettuce)  69  7.4  176.35  63.19  94.26   1    0.3  46  68   580  2.6  16   18   2.5  3.7
+2  Spreckels 3E (Celery)   46  7.5  266.53  59.55  117.25  1.2  0.2  27  64   420  3.9  6.7  14   1.5  2.0
+```
+
+### Conversion factors
+
+- **Calcium**: meq/l × 20.04 = PPM
+- **Magnesium**: meq/l × 12.15 = PPM
+- **Sodium**: meq/l × 22.99 = PPM
+- **EC/Salts**: dS/m × 640 = PPM
+- Values already in mg/kg (PPM), no conversion needed: NO3-N, PO4-P, K, Zn, Mn, Fe, Cu
+
+### Vincent's reference values (from the Data Framework sheet — these are authoritative)
+
+```
+Mineral ideal values (PPM):
+  Calcium: 16,000      Four Lows threshold: below 2,000
+  Magnesium: 11,000    Four Lows threshold: below 4,000
+  Sodium: 500          Four Lows threshold: below 10
+  Potassium: 1,200     Four Lows threshold: below 200
+  Copper: 1.5
+  Zinc: 1.5
+  Sulfur: 85
+  Iron: 85
+  Manganese: 40
+  Chromium: 20
+  Boron: 0.5
+  Aluminum: 140
+  Phosphorus: 1,100
+
+pH:
+  Low: below 5.5
+  Ideal: 6.5 - 7.0
+  High: above 7.5
+
+Note: if pH is low (below 5.5), cancel calcium mineral (lime) in Four Lows treatment.
+```
+
+IMPORTANT: There is a file in the codebase called `standard-values.ts` with DIFFERENT values (much smaller numbers like Ca ideal = 150 PPM). That file uses different reference standards. Vincent's Data Framework values above are the ones to use for this parser. Do NOT use the values from standard-values.ts.
+
+### Lab reference ranges (for determining Low/Med/High tag)
+
+From the lab report footer:
+
+```
+                  pH        EC(dS/m)  Ca(meq/l)  Mg(meq/l)  K(mg/kg)   Zn(mg/kg)  Mn(mg/kg)  Fe(mg/kg)  OM(%)
+Low:             < 7.3      <1.0      < 5        < 3        <250       < 2.5      < 2.5      <5         <1.0
+Medium/Optimal:  7.3-7.8    1.0-2.0   5-10       1/2 Ca     250-350    2.5-4.5    2.5-10     5-10       1-3
+High:            7.8+       2.0+      10+        > Ca       350+       4.5+       10+        10+        3+
+```
+
+### How to determine the "tag" (Low/Med/High)
+
+Compare the real value to the lab reference ranges above. Use the raw (pre-conversion) values for comparison since the ranges are in the original units.
+
+### How to determine "four_lows"
+
+From Vincent's Data Framework: ALL FOUR must be true simultaneously:
+
+- Calcium below 2,000 PPM
+- Magnesium below 4,000 PPM
+- Sodium below 10 PPM
+- Potassium below 200 PPM
+
+### Target database tables
+
+Read these schema files before coding:
+
+**analysis** (`src/lib/db/schema/analysis.ts`):
+
+- `id`: varchar(13) — generate a unique ID
+- `managementZone`: serial FK to management_zone.id
+- `analysisDate`: date
+- `createdAt`, `updatedAt`: timestamps
+
+**mineral** (`src/lib/db/schema/mineral.ts`):
+
+- `analysisId`: varchar(13) FK
+- `name`: varchar (e.g. "Calcium", "Magnesium")
+- `real_value`: numeric — the value IN PPM after conversion
+- `ideal_value`: numeric — from Vincent's Data Framework above
+- `tag`: enum Low/Med/High
+- `four_lows`: boolean
+- `units`: varchar — "ppm"
+
+**ph** (`src/lib/db/schema/ph.ts`):
+
+- `analysisId`: varchar(13) FK
+- `realValue`: numeric
+- `idealValueLower`, `idealValueUpper`: 6.5 and 7.0 from Vincent's framework
+- `low`, `high`: 5.5 and 7.5 from Vincent's framework
+- `tag`: enum Low/Med/High
+
+**solubility** (`src/lib/db/schema/solubility.ts`) — for EC/salts data. Read the schema to see exact fields.
+
+### Implementation
+
+Build as `scripts/parse-soil-test.ts`. Should:
+
+1. Accept a file path argument (CSV or Excel)
+2. Parse each row
+3. Convert meq/l → PPM where needed
+4. Determine tags and four_lows
+5. Generate analysis IDs
+6. Insert into the DB tables
+7. Log what was inserted
+
+Later this becomes an API route for advisor uploads.
+
+### Testing
+
+Test against the DigitalOcean testing DB. Use Vincent's farm (id=2). Create a management zone for testing if needed. The sample data file is in the repo or can be downloaded from the Google Sheet Vincent shared.
+
+Run with: `NODE_TLS_REJECT_UNAUTHORIZED=0 bun run scripts/parse-soil-test.ts <filepath>`
+
+---
+
+## PARSER 2: Content-to-Markdown Parser
+
+### What it does
+
+Takes any content (photos of physical guides, PDFs, Excel sheets with text content, Google Docs) and converts it to clean markdown. One parser, multiple input formats. If it can't understand something (like a hand-drawn diagram), it skips it.
+
+### Why it exists
+
+Todd has ~200 IMPs and physical agricultural guides (old textbook pages, reference charts, compliance documents) that need to be digitized. Vincent and advisors will use this to migrate content into the platform. Oscar is rendering IMPs as markdown in the UI for flexibility.
+
+### The pipeline
+
+```
+Any content (image, PDF, spreadsheet, doc)
+        ↓
+  Detect input type
+        ↓
+  Extract text:
+    - Image → send to vision AI (Gemini or OpenAI)
+    - PDF → extract text, or send pages to vision AI if scanned
+    - Excel/Spreadsheet with text → read cells
+    - Plain text/doc → read directly
+        ↓
+  Format as clean markdown (headings, tables, lists preserved)
+        ↓
+  Output markdown string
+        ↓
+  (Optionally) Store in knowledge_article table + embed for search
+```
+
+### Input types to handle
+
+**Images** (JPG, PNG): Physical guide pages like the ones Vincent sent. These contain:
+
+- Reference tables (vegetable pH tolerance, rooting depths, soil-water characteristics)
+- pH scale diagrams
+- Irrigation diagrams with captions
+- Plain text paragraphs
+  Use a vision AI model to extract text. Preserve tables as markdown tables. Note when something is a diagram/image that can't be converted to text.
+
+**PDFs**: Like the Produce Safety and Marketing guide (26 pages). These are text-based PDFs (not scanned), so text can be extracted directly. Convert to markdown preserving structure (headings, tables, lists, sections).
+
+**Excel/Spreadsheets with text content**: Like the IMP sheet in Vincent's Excel file. The IMP sheet has columns: Category, Trigger, Body. Each row is a separate piece of content. Convert each row to a markdown document.
+
+**IMP format from the Excel** (34 rows of trigger-based recommendations):
+
+- Category: tags like "spinach, amaranthus" or "soil, pasture" or "corn"
+- Trigger: conditions like "low @zinc" or "high @ph" or "@corn + @october-april"
+- Body: the actual recommendation text
+
+Example IMP row:
+
+- Category: "spinach, amaranthus"
+- Trigger: "low @zinc"
+- Body: "In certain Amaranthus species, including spinach and amaranth, plants tend to absorb higher amounts of cadmium..."
+
+### Vision AI setup
+
+The project has an OpenAI API key (`OPENAI_EMBEDDINGS_KEY` in `.env.local`). You can use `gpt-4o` or `gpt-4o-mini` for vision tasks. Or use the Gemini key (`GEMINI_API_KEY`) with `gemini-2.0-flash` for vision.
+
+### Output format
+
+Clean markdown. For reference tables, use markdown tables:
+
+```markdown
+# Relative Tolerance of Vegetable Crops to Soil Acidity
+
+| Slightly Tolerant (pH 6.8-6.0) | Moderately Tolerant (pH 6.8-5.5) | Very Tolerant (pH 6.8-5.0) |
+| ------------------------------ | -------------------------------- | -------------------------- |
+| Asparagus                      | Bean                             | Chicory                    |
+| Beet                           | Brussels sprouts                 | Dandelion                  |
+```
+
+For text content, use headings, paragraphs, and lists as appropriate.
+
+### Implementation
+
+Build as `src/lib/ai/content-parser.ts` with exported functions:
+
+- `parseImage(imagePath: string): Promise<string>` — image → markdown
+- `parsePdf(pdfPath: string): Promise<string>` — PDF → markdown
+- `parseExcelContent(filePath: string, sheetName: string): Promise<string[]>` — spreadsheet → array of markdown strings (one per row/section)
+- `parseContent(filePath: string): Promise<string | string[]>` — auto-detect type and delegate
+
+Also build a script `scripts/parse-content.ts` for CLI usage:
+
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 bun run scripts/parse-content.ts <filepath>
+```
+
+Later this becomes part of the advisor dashboard where they upload files through a UI.
+
+### Integration with search
+
+After parsing content to markdown, it can optionally be:
+
+1. Stored in the `knowledge_article` table (existing schema in `src/lib/db/schema/knowledge.ts`)
+2. Embedded using OpenAI embeddings (existing function in `src/lib/ai/embeddings.ts`)
+3. Made searchable through the existing `/api/search` endpoint
+
+The search system already works — it was built previously using pgvector with cosine similarity. Embeddings use OpenAI `text-embedding-3-large` (3072 dimensions). The `knowledge_article` table has a `vector(3072)` column.
+
+---
+
+## Environment
+
+- `DATABASE_URL` is set in `.env.local` (DigitalOcean PostgreSQL)
+- `NODE_TLS_REJECT_UNAUTHORIZED=0` in `.env.local` for SSL
+- `OPENAI_EMBEDDINGS_KEY` in `.env.local` — for embeddings AND vision
+- `GEMINI_API_KEY` in `.env.local` — alternative for vision
+- Use `bun` to run everything
+- DB connection: `src/lib/db/schema/connection.ts`
+
+## Repo Conventions
+
+- Copyright header: `// Copyright © Todd Agriscience, Inc. All rights reserved.`
+- Use `logger` from `@/lib/logger` instead of console.log (standalone scripts can use console)
+- JSDoc on all exported functions
+- Strict TypeScript
+- kebab-case files, PascalCase components
+- Do NOT create migrations or run `drizzle-kit generate`
+- Do NOT modify `standard-values.ts`
+- Run `bun format` after work
+
+## Key files to read first
+
+1. `src/lib/db/schema/analysis.ts`
+2. `src/lib/db/schema/mineral.ts`
+3. `src/lib/db/schema/ph.ts`
+4. `src/lib/db/schema/solubility.ts`
+5. `src/lib/db/schema/knowledge.ts`
+6. `src/lib/db/schema/connection.ts`
+7. `src/lib/ai/embeddings.ts`
+8. `src/lib/ai/search.ts`
+9. `src/lib/db/schema/standard-values.ts` (read but do NOT use its values for the parser)
+
+## Build order
+
+1. Soil test parser first (structured data, more straightforward)
+2. Content-to-markdown parser second (multimodal, more complex)
+3. Wire markdown output into knowledge base + search (leverages existing infrastructure)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,6 +98,7 @@
     "ua-parser-js": "^2.0.9",
     "undici": "^7.24.0",
     "vaul": "^1.1.2",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,6 +81,7 @@
     "next-intl": "^4.8.3",
     "next-sanity": "^12.1.0",
     "openai": "^6.25.0",
+    "pdf-parse": "^2.4.5",
     "pg": "^8.19.0",
     "posthog-js": "^1.354.3",
     "preact": "10.28.4",

--- a/frontend/scripts/cleanup-first-run.ts
+++ b/frontend/scripts/cleanup-first-run.ts
@@ -1,0 +1,119 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * Cleanup: remove the 9 analyses from the first parser run (farm_id=2)
+ * and their child mineral + solubility rows.
+ *
+ * Usage:
+ *   NODE_TLS_REJECT_UNAUTHORIZED=0 bun run scripts/cleanup-first-run.ts
+ */
+
+import { db } from '@/lib/db/schema/connection';
+import { sql } from 'drizzle-orm';
+
+/** Subquery that selects all analysis IDs belonging to farm_id=2 */
+const FARM2_IDS = sql`(
+  SELECT a.id FROM analysis a
+  JOIN management_zone mz ON mz.id = a.management_zone
+  WHERE mz.farm_id = 2
+)`;
+
+async function main() {
+  // 1. Show analyses
+  console.log('═══════════════════════════════════════════════════════════');
+  console.log('  INSPECTING EXISTING DATA (farm_id=2)');
+  console.log('═══════════════════════════════════════════════════════════\n');
+
+  const analyses = await db.execute(sql`
+    SELECT a.id, a.analysis_date, mz.name AS zone_name
+    FROM analysis a
+    JOIN management_zone mz ON mz.id = a.management_zone
+    WHERE mz.farm_id = 2
+    ORDER BY a.id
+  `);
+
+  console.log(`Found ${analyses.rows.length} analyses for farm_id=2:\n`);
+  for (const r of analyses.rows) {
+    const row = r as Record<string, unknown>;
+    console.log(
+      `  ${row.id}  ${String(row.analysis_date).slice(0, 10)}  zone: ${row.zone_name}`
+    );
+  }
+
+  if (analyses.rows.length === 0) {
+    console.log('Nothing to clean up.');
+    process.exit(0);
+  }
+
+  // 2. Show mineral rows
+  const minerals = await db.execute(sql`
+    SELECT m.analysis_id, m.name, m.real_value, m.units,
+           m.ideal_value, m.tag, m.four_lows
+    FROM mineral m
+    WHERE m.analysis_id IN ${FARM2_IDS}
+    ORDER BY m.analysis_id, m.id
+  `);
+  console.log(`\nMineral rows to delete: ${minerals.rows.length}`);
+  for (const r of minerals.rows) {
+    const row = r as Record<string, unknown>;
+    console.log(
+      `  ${String(row.analysis_id)}  ${String(row.name).padEnd(22)} ${String(row.real_value).padStart(12)} ${row.units}  ideal=${row.ideal_value ?? 'NULL'}  tag=${row.tag ?? 'NULL'}  4L=${row.four_lows ?? 'NULL'}`
+    );
+  }
+
+  // 3. Show solubility rows
+  const solubilities = await db.execute(sql`
+    SELECT s.analysis_id, s.real_value, s.ideal_value, s.units
+    FROM solubility s
+    WHERE s.analysis_id IN ${FARM2_IDS}
+    ORDER BY s.analysis_id
+  `);
+  console.log(`\nSolubility rows to delete: ${solubilities.rows.length}`);
+  for (const r of solubilities.rows) {
+    const row = r as Record<string, unknown>;
+    console.log(
+      `  ${row.analysis_id}  real=${row.real_value}  ideal=${row.ideal_value}  ${row.units}`
+    );
+  }
+
+  // 4. Delete: children first, then analyses
+  console.log('\n═══════════════════════════════════════════════════════════');
+  console.log('  DELETING');
+  console.log('═══════════════════════════════════════════════════════════\n');
+
+  const delMinerals = await db.execute(sql`
+    DELETE FROM mineral WHERE analysis_id IN ${FARM2_IDS}
+  `);
+  console.log(`  Deleted ${delMinerals.rowCount} mineral rows`);
+
+  const delSolubility = await db.execute(sql`
+    DELETE FROM solubility WHERE analysis_id IN ${FARM2_IDS}
+  `);
+  console.log(`  Deleted ${delSolubility.rowCount} solubility rows`);
+
+  const delAnalyses = await db.execute(sql`
+    DELETE FROM analysis a
+    USING management_zone mz
+    WHERE mz.id = a.management_zone AND mz.farm_id = 2
+  `);
+  console.log(`  Deleted ${delAnalyses.rowCount} analysis rows`);
+
+  // 5. Verify
+  const remaining = await db.execute(sql`
+    SELECT count(*) AS cnt
+    FROM analysis a
+    JOIN management_zone mz ON mz.id = a.management_zone
+    WHERE mz.farm_id = 2
+  `);
+  console.log(
+    `\n  Remaining analyses for farm_id=2: ${(remaining.rows[0] as Record<string, unknown>).cnt}`
+  );
+
+  console.log('\nCleanup complete.');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/frontend/scripts/migrate-local-db.ts
+++ b/frontend/scripts/migrate-local-db.ts
@@ -4,13 +4,21 @@ import 'dotenv/config';
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import { Pool } from 'pg';
 
 async function migrateLocalDb() {
-  const db = drizzle(process.env.DATABASE_URL!, { casing: 'snake_case' });
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL!,
+    ssl: false,
+  });
+
+  const db = drizzle(pool, { casing: 'snake_case' });
 
   await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
   await db.execute(sql`CREATE EXTENSION IF NOT EXISTS citext`);
   await migrate(db, { migrationsFolder: 'drizzle' });
+
+  await pool.end();
 }
 
 migrateLocalDb().catch((error) => {

--- a/frontend/scripts/migrate-mineral-schema.ts
+++ b/frontend/scripts/migrate-mineral-schema.ts
@@ -1,0 +1,179 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * One-time migration: update the mineral table and related enums to support
+ * Manganese, Copper, Boron, ideal_value, tag, four_lows, and dimensionless units.
+ *
+ * Usage:
+ *   NODE_TLS_REJECT_UNAUTHORIZED=0 bun run scripts/migrate-mineral-schema.ts
+ */
+
+import { db } from '@/lib/db/schema/connection';
+import { sql } from 'drizzle-orm';
+
+async function inspect() {
+  console.log('═══════════════════════════════════════════════════════════');
+  console.log('  CURRENT DATABASE STATE');
+  console.log('═══════════════════════════════════════════════════════════\n');
+
+  // 1. mineral_types enum values
+  const mineralTypesEnum = await db.execute(
+    sql`SELECT unnest(enum_range(NULL::mineral_types))::text AS value`
+  );
+  console.log(
+    'mineral_types enum:',
+    mineralTypesEnum.rows.map((r: Record<string, unknown>) => r.value)
+  );
+
+  // 2. units enum values
+  const unitsEnum = await db.execute(
+    sql`SELECT unnest(enum_range(NULL::units))::text AS value`
+  );
+  console.log(
+    'units enum:',
+    unitsEnum.rows.map((r: Record<string, unknown>) => r.value)
+  );
+
+  // 3. Check if mineral_tag enum exists
+  const tagEnumExists = await db.execute(
+    sql`SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mineral_tag') AS exists`
+  );
+  console.log(
+    'mineral_tag enum exists:',
+    tagEnumExists.rows[0].exists
+  );
+
+  // 4. mineral table columns
+  const mineralCols = await db.execute(sql`
+    SELECT column_name, data_type, udt_name, is_nullable
+    FROM information_schema.columns
+    WHERE table_name = 'mineral'
+    ORDER BY ordinal_position
+  `);
+  console.log('\nmineral table columns:');
+  for (const row of mineralCols.rows) {
+    const r = row as Record<string, unknown>;
+    console.log(
+      `  ${String(r.column_name).padEnd(20)} ${String(r.udt_name).padEnd(20)} nullable=${r.is_nullable}`
+    );
+  }
+  console.log('');
+}
+
+async function migrate() {
+  console.log('═══════════════════════════════════════════════════════════');
+  console.log('  APPLYING MIGRATIONS');
+  console.log('═══════════════════════════════════════════════════════════\n');
+
+  // --- 1. Add missing values to mineral_types enum ---
+  const mineralTypesEnum = await db.execute(
+    sql`SELECT unnest(enum_range(NULL::mineral_types))::text AS value`
+  );
+  const existingMineralTypes = new Set(
+    mineralTypesEnum.rows.map((r: Record<string, unknown>) => r.value as string)
+  );
+
+  for (const val of ['Manganese', 'Copper', 'Boron']) {
+    if (existingMineralTypes.has(val)) {
+      console.log(`  ✓ mineral_types already has '${val}'`);
+    } else {
+      await db.execute(
+        sql.raw(`ALTER TYPE mineral_types ADD VALUE IF NOT EXISTS '${val}'`)
+      );
+      console.log(`  + Added '${val}' to mineral_types`);
+    }
+  }
+
+  // --- 2. Add 'dimensionless' to units enum ---
+  const unitsEnum = await db.execute(
+    sql`SELECT unnest(enum_range(NULL::units))::text AS value`
+  );
+  const existingUnits = new Set(
+    unitsEnum.rows.map((r: Record<string, unknown>) => r.value as string)
+  );
+
+  if (existingUnits.has('dimensionless')) {
+    console.log(`  ✓ units already has 'dimensionless'`);
+  } else {
+    await db.execute(
+      sql`ALTER TYPE units ADD VALUE IF NOT EXISTS 'dimensionless'`
+    );
+    console.log(`  + Added 'dimensionless' to units`);
+  }
+
+  // --- 3. Create mineral_tag enum if it doesn't exist ---
+  const tagEnumExists = await db.execute(
+    sql`SELECT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mineral_tag') AS exists`
+  );
+
+  if (tagEnumExists.rows[0].exists) {
+    console.log(`  ✓ mineral_tag enum already exists`);
+  } else {
+    await db.execute(
+      sql`CREATE TYPE mineral_tag AS ENUM ('Low', 'Med', 'High')`
+    );
+    console.log(`  + Created mineral_tag enum ('Low', 'Med', 'High')`);
+  }
+
+  // --- 4. Add missing columns to mineral table ---
+  const mineralCols = await db.execute(sql`
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name = 'mineral'
+  `);
+  const existingCols = new Set(
+    mineralCols.rows.map((r: Record<string, unknown>) => r.column_name as string)
+  );
+
+  // ideal_value
+  if (existingCols.has('ideal_value')) {
+    console.log(`  ✓ mineral.ideal_value already exists`);
+  } else {
+    await db.execute(
+      sql`ALTER TABLE mineral ADD COLUMN ideal_value numeric(9,4)`
+    );
+    console.log(`  + Added mineral.ideal_value (numeric(9,4), nullable)`);
+  }
+
+  // tag
+  if (existingCols.has('tag')) {
+    console.log(`  ✓ mineral.tag already exists`);
+  } else {
+    await db.execute(
+      sql`ALTER TABLE mineral ADD COLUMN tag mineral_tag`
+    );
+    console.log(`  + Added mineral.tag (mineral_tag enum, nullable)`);
+  }
+
+  // four_lows
+  if (existingCols.has('four_lows')) {
+    console.log(`  ✓ mineral.four_lows already exists`);
+  } else {
+    await db.execute(
+      sql`ALTER TABLE mineral ADD COLUMN four_lows boolean`
+    );
+    console.log(`  + Added mineral.four_lows (boolean, nullable)`);
+  }
+
+  console.log('');
+}
+
+async function main() {
+  try {
+    await inspect();
+    await migrate();
+
+    console.log('═══════════════════════════════════════════════════════════');
+    console.log('  POST-MIGRATION STATE');
+    console.log('═══════════════════════════════════════════════════════════\n');
+    await inspect();
+
+    console.log('Done.');
+  } catch (err) {
+    console.error('Migration failed:', err);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main();

--- a/frontend/scripts/parse-content.ts
+++ b/frontend/scripts/parse-content.ts
@@ -1,0 +1,224 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * CLI script for the content-to-markdown parser (Parser 2).
+ *
+ * Parses images, PDFs, Excel files, or plain text into clean markdown.
+ *
+ * Usage:
+ *   NODE_TLS_REJECT_UNAUTHORIZED=0 bun run scripts/parse-content.ts <filepath> [options]
+ *
+ * Options:
+ *   --sheet <name>    Use a specific sheet (Excel only)
+ *   --output <path>   Write output to a file instead of stdout
+ *   --save            Store parsed content in the knowledge base (requires DB)
+ *   --category <cat>  Knowledge base category (required with --save)
+ *                     One of: soil, planting, water, insects_disease,
+ *                     harvest_storage, go_to_market, seed_products
+ *   --source <src>    Source attribution for knowledge base entries
+ *
+ * Examples:
+ *   bun run scripts/parse-content.ts photo-of-guide.jpg
+ *   bun run scripts/parse-content.ts produce-safety.pdf --output output.md
+ *   bun run scripts/parse-content.ts imps.xlsx --sheet "IMP"
+ *   bun run scripts/parse-content.ts guide.png --save --category soil --source "Todd Field Guide"
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { parseContent, parseExcelContent } from '@/lib/ai/content-parser';
+
+// ---------------------------------------------------------------------------
+// Valid knowledge base categories
+// ---------------------------------------------------------------------------
+
+const VALID_CATEGORIES = [
+  'soil',
+  'planting',
+  'water',
+  'insects_disease',
+  'harvest_storage',
+  'go_to_market',
+  'seed_products',
+] as const;
+
+type KnowledgeCategory = (typeof VALID_CATEGORIES)[number];
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+interface CliArgs {
+  filePath: string;
+  sheet?: string;
+  outputPath?: string;
+  save: boolean;
+  category?: KnowledgeCategory;
+  source?: string;
+}
+
+function parseArgs(): CliArgs {
+  const args = process.argv.slice(2);
+
+  let filePath: string | null = null;
+  let sheet: string | undefined;
+  let outputPath: string | undefined;
+  let save = false;
+  let category: KnowledgeCategory | undefined;
+  let source: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--sheet':
+        sheet = args[++i];
+        break;
+      case '--output':
+        outputPath = args[++i];
+        break;
+      case '--save':
+        save = true;
+        break;
+      case '--category':
+        category = args[++i] as KnowledgeCategory;
+        break;
+      case '--source':
+        source = args[++i];
+        break;
+      default:
+        if (!args[i].startsWith('--')) {
+          filePath = args[i];
+        }
+    }
+  }
+
+  if (!filePath) {
+    console.error(
+      'Usage: bun run scripts/parse-content.ts <filepath> [options]\n\n' +
+        'Options:\n' +
+        '  --sheet <name>      Sheet name (Excel only)\n' +
+        '  --output <path>     Write output to file\n' +
+        '  --save              Store in knowledge base\n' +
+        '  --category <cat>    Knowledge category (with --save)\n' +
+        '  --source <src>      Source attribution (with --save)'
+    );
+    process.exit(1);
+  }
+
+  if (save && !category) {
+    console.error(
+      'Error: --category is required when using --save.\n' +
+        `Valid categories: ${VALID_CATEGORIES.join(', ')}`
+    );
+    process.exit(1);
+  }
+
+  if (category && !VALID_CATEGORIES.includes(category)) {
+    console.error(
+      `Error: Invalid category "${category}".\n` +
+        `Valid categories: ${VALID_CATEGORIES.join(', ')}`
+    );
+    process.exit(1);
+  }
+
+  return { filePath, sheet, outputPath, save, category, source };
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge base storage
+// ---------------------------------------------------------------------------
+
+async function saveToKnowledgeBase(
+  markdownContent: string,
+  category: KnowledgeCategory,
+  source: string,
+  title: string
+) {
+  // Dynamic imports to avoid loading DB/AI deps unless --save is used
+  const { db } = await import('@/lib/db/schema/connection');
+  const { knowledgeArticle } = await import('@/lib/db/schema');
+  const { getEmbedding } = await import('@/lib/ai/embeddings');
+
+  console.log(`  Embedding: "${title}"...`);
+  const embedding = await getEmbedding(title + ' ' + markdownContent);
+
+  await db.insert(knowledgeArticle).values({
+    title,
+    content: markdownContent,
+    category,
+    source,
+    embedding,
+  });
+
+  console.log(`  ✓ Saved to knowledge base: "${title}"`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs();
+  const resolved = path.resolve(args.filePath);
+  const ext = path.extname(resolved).toLowerCase();
+
+  console.log(`\nFile: ${resolved}`);
+  console.log(`Type: ${ext || 'unknown'}\n`);
+
+  if (!fs.existsSync(resolved)) {
+    console.error(`File not found: ${resolved}`);
+    process.exit(1);
+  }
+
+  let result: string | string[];
+
+  // Use sheet-specific parsing for Excel with --sheet flag
+  if (args.sheet && ['.xlsx', '.xls', '.csv'].includes(ext)) {
+    console.log(`Sheet: ${args.sheet}\n`);
+    result = await parseExcelContent(resolved, args.sheet);
+  } else {
+    result = await parseContent(resolved);
+  }
+
+  // Format output
+  const items = Array.isArray(result) ? result : [result];
+  const combined = items.join('\n\n---\n\n');
+
+  console.log(`Parsed ${items.length} section(s).\n`);
+
+  // Write to file or stdout
+  if (args.outputPath) {
+    const outResolved = path.resolve(args.outputPath);
+    fs.writeFileSync(outResolved, combined, 'utf-8');
+    console.log(`Written to: ${outResolved}\n`);
+  } else {
+    console.log('--- OUTPUT START ---\n');
+    console.log(combined);
+    console.log('\n--- OUTPUT END ---');
+  }
+
+  // Optionally save to knowledge base
+  if (args.save && args.category) {
+    const source = args.source ?? path.basename(resolved);
+    console.log(`\nSaving to knowledge base (category: ${args.category})...`);
+
+    for (let i = 0; i < items.length; i++) {
+      const content = items[i];
+      // Extract title from first heading or use filename
+      const titleMatch = content.match(/^#\s+(.+)$/m);
+      const title =
+        titleMatch?.[1] ??
+        `${path.basename(resolved, ext)}${items.length > 1 ? ` (${i + 1})` : ''}`;
+
+      await saveToKnowledgeBase(content, args.category, source, title);
+    }
+
+    console.log(`\nDone — saved ${items.length} article(s) to knowledge base.`);
+  }
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/frontend/scripts/parse-soil-test.ts
+++ b/frontend/scripts/parse-soil-test.ts
@@ -1,0 +1,883 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * Soil test file parser (Parser 1).
+ *
+ * Reads lab report data from a CSV or Excel spreadsheet, converts raw values
+ * to PPM where needed, and inserts structured data into the analysis, mineral,
+ * and solubility tables.
+ *
+ * Usage:
+ *   NODE_TLS_REJECT_UNAUTHORIZED=0 bun run scripts/parse-soil-test.ts <filepath> [options]
+ *
+ * Options:
+ *   --farm-id <n>        Farm ID to associate analyses with (default: 2)
+ *   --zone-id <n>        Force all rows to a specific management zone ID
+ *   --date <YYYY-MM-DD>  Analysis date for every row (default: today)
+ *   --sheet <name>       Use a specific sheet name instead of auto-detecting
+ *   --dry-run            Parse and log without writing to the database
+ */
+
+import { db } from '@/lib/db/schema/connection';
+import { analysis, managementZone, mineral, solubility } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as xlsx from 'xlsx';
+
+// ---------------------------------------------------------------------------
+// Conversion constants
+// ---------------------------------------------------------------------------
+
+/** Factors for converting meq/l → PPM */
+const MEQ_TO_PPM = {
+  Ca: 20.04,
+  Mg: 12.15,
+  Na: 22.99,
+} as const;
+
+/** EC conversion: dS/m → PPM */
+const EC_TO_PPM = 640;
+
+/**
+ * Ideal EC value in PPM (lower boundary of lab's "Medium/Optimal" range:
+ * 1.0 dS/m × 640 = 640 PPM).
+ */
+const EC_IDEAL_PPM = 640;
+
+// ---------------------------------------------------------------------------
+// Four Lows thresholds (Vincent's Data Framework, PPM)
+// ---------------------------------------------------------------------------
+const FOUR_LOWS_THRESHOLDS = {
+  Calcium: 2000,
+  Magnesium: 4000,
+  Sodium: 10,
+  Potassium: 200,
+};
+
+// ---------------------------------------------------------------------------
+// ID generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a unique analysis ID in the format XXXXXX-XXXXXX
+ * (uppercase alphanumeric, 13 chars total).
+ */
+function generateAnalysisId(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  const seg = (n: number) =>
+    Array.from(
+      { length: n },
+      () => chars[Math.floor(Math.random() * chars.length)]
+    ).join('');
+  return `${seg(6)}-${seg(6)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Raw lab row
+// ---------------------------------------------------------------------------
+
+interface LabRow {
+  no: number;
+  description: string;
+  crop: string | null; // extracted from Depth or Description parenthetical
+  sp: number | null; // Saturation percentage
+  ph: number | null;
+  ec: number | null; // dS/m — raw lab value
+  ca: number | null; // meq/l or PPM (depending on needsConversion)
+  mg: number | null; // meq/l or PPM
+  na: number | null; // meq/l or PPM
+  cl: number | null;
+  esp: number | null;
+  gypsumReq: number | null;
+  lime: number | null;
+  b: number | null; // mg/l  — Boron
+  no3n: number | null; // mg/kg — Nitrate-Nitrogen
+  po4p: number | null; // mg/kg — Phosphate-Phosphorus
+  k: number | null; // mg/kg — Potassium
+  zn: number | null; // mg/kg — Zinc
+  mn: number | null; // mg/kg — Manganese (not in DB enum)
+  fe: number | null; // mg/kg — Iron
+  cu: number | null; // mg/kg — Copper (not in DB enum)
+  om: number | null; // %     — Organic Matter
+}
+
+/** Result from parseFile: rows + whether Ca/Mg/Na are already PPM. */
+interface ParseResult {
+  rows: LabRow[];
+  alreadyPpm: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Header normalisation & column mapping
+// ---------------------------------------------------------------------------
+
+/** Strips everything except lowercase letters and digits. */
+function normaliseHeader(h: string): string {
+  return h.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Known header variants from lab reports and converted spreadsheets.
+ * Keys are normalised header strings; values are LabRow field names.
+ */
+const HEADER_MAP: Record<string, keyof LabRow> = {
+  // Row number
+  no: 'no',
+  number: 'no',
+  // Description / field name
+  description: 'description',
+  fielddescription: 'description',
+  desc: 'description',
+  // Depth / crop column (in converted sheets the crop is here)
+  depth: 'crop',
+  // Saturation percentage
+  sp: 'sp',
+  // pH
+  ph: 'ph',
+  // Electrical conductivity
+  ec: 'ec',
+  ecdsdm: 'ec',
+  // Calcium — raw (meq/l) OR converted (ppm)
+  ca: 'ca',
+  cameql: 'ca',
+  ca2: 'ca', // "Ca2+" normalises to "ca2"
+  // Magnesium
+  mg: 'mg',
+  mgmeql: 'mg',
+  mg2: 'mg', // "Mg2+"
+  // Sodium
+  na: 'na',
+  nameql: 'na',
+  // Chloride
+  cl: 'cl',
+  // Exchangeable Sodium Percentage
+  esp: 'esp',
+  // Gypsum Requirement
+  gypsumreq: 'gypsumReq',
+  // Lime Requirement / Lime Present — both map to lime
+  lime: 'lime',
+  // Boron
+  b: 'b',
+  bmgl: 'b',
+  // Nitrate-Nitrogen
+  no3n: 'no3n',
+  no3nmgkg: 'no3n',
+  // Phosphate-Phosphorus
+  po4p: 'po4p',
+  po4pmgkg: 'po4p',
+  // Potassium
+  k: 'k',
+  kmgkg: 'k',
+  // Zinc
+  zn: 'zn',
+  znmgkg: 'zn',
+  // Manganese
+  mn: 'mn',
+  mnmgkg: 'mn',
+  // Iron
+  fe: 'fe',
+  femgkg: 'fe',
+  // Copper
+  cu: 'cu',
+  cumgkg: 'cu',
+  // Organic Matter
+  om: 'om',
+};
+
+/**
+ * Headers that, when present, indicate we've found the column header row.
+ * We require "pH" plus at least 2 others from this set.
+ */
+const SENTINEL_HEADERS = new Set([
+  'ph',
+  'ca',
+  'cameql',
+  'ca2',
+  'mg',
+  'mgmeql',
+  'mg2',
+  'na',
+  'nameql',
+  'ec',
+  'ecdsdm',
+  'no3n',
+  'no3nmgkg',
+  'sp',
+  'no',
+  'desc',
+  'description',
+]);
+
+// ---------------------------------------------------------------------------
+// File parsing
+// ---------------------------------------------------------------------------
+
+function toNum(v: unknown): number | null {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return isNaN(n) ? null : n;
+}
+
+function toStr(v: unknown): string {
+  return v === null || v === undefined ? '' : String(v).trim();
+}
+
+/** Returns true when a row looks like a units-description row (e.g. "ppm", "%", "mg/L"). */
+function isUnitsRow(row: unknown[]): boolean {
+  const unitPatterns =
+    /^(ppm|%|units|meq\/l|mg\/l|mg\/kg|ds\/m|t\/ac|lbs\/ac)/i;
+  let unitCells = 0;
+  for (const cell of row) {
+    if (unitPatterns.test(toStr(cell))) unitCells++;
+  }
+  return unitCells >= 2;
+}
+
+/**
+ * Checks the units row to decide whether Ca/Mg/Na are already in PPM.
+ * Returns true if the Ca column's unit says "ppm".
+ */
+function detectPpmFromUnitsRow(
+  unitsRow: unknown[],
+  colMap: Partial<Record<keyof LabRow, number>>
+): boolean {
+  const caIdx = colMap['ca'];
+  if (caIdx === undefined) return false;
+  const unit = toStr(unitsRow[caIdx]).toLowerCase();
+  return unit === 'ppm';
+}
+
+/**
+ * Picks the best sheet from the workbook. Priority:
+ *  1. Sheet whose name contains "soil test" (raw or converted)
+ *  2. First sheet
+ */
+function pickSheet(wb: xlsx.WorkBook, override?: string): string {
+  if (override) {
+    if (!wb.SheetNames.includes(override)) {
+      throw new Error(
+        `Sheet "${override}" not found. Available: ${wb.SheetNames.join(', ')}`
+      );
+    }
+    return override;
+  }
+
+  for (const name of wb.SheetNames) {
+    const lower = name.toLowerCase();
+    if (lower.includes('soil test')) return name;
+  }
+  return wb.SheetNames[0];
+}
+
+/**
+ * Reads a CSV or Excel file and returns parsed LabRow objects plus a flag
+ * indicating whether Ca/Mg/Na values are already in PPM.
+ *
+ * The parser auto-detects the header row by scanning for a row that contains
+ * "pH" and at least 2 other known column headers. It also checks the units
+ * row (if present) to decide whether Ca/Mg/Na need meq/l → PPM conversion.
+ */
+function parseFile(filePath: string, sheetOverride?: string): ParseResult {
+  const workbook = xlsx.readFile(filePath, { type: 'file', raw: false });
+  const sheetName = pickSheet(workbook, sheetOverride);
+  console.log(`Using sheet: "${sheetName}"`);
+
+  const sheet = workbook.Sheets[sheetName];
+  const rows: unknown[][] = xlsx.utils.sheet_to_json(sheet, {
+    header: 1,
+    defval: '',
+  });
+
+  // --- Locate the header row ---
+  let headerRowIdx = -1;
+  let colMap: Partial<Record<keyof LabRow, number>> = {};
+
+  for (let i = 0; i < Math.min(rows.length, 30); i++) {
+    const norm = (rows[i] as unknown[]).map((c) => normaliseHeader(toStr(c)));
+    const hasPh = norm.some((h) => h === 'ph');
+    const matchCount = norm.filter((h) => SENTINEL_HEADERS.has(h)).length;
+
+    if (hasPh && matchCount >= 3) {
+      headerRowIdx = i;
+      for (let j = 0; j < norm.length; j++) {
+        const mapped = HEADER_MAP[norm[j]];
+        if (mapped !== undefined) {
+          // Avoid overwriting with a duplicate (e.g. two "Req." columns)
+          if (!(mapped in colMap)) colMap[mapped] = j;
+        }
+      }
+      break;
+    }
+  }
+
+  if (headerRowIdx === -1) {
+    throw new Error(
+      'Could not find header row. Expected a row containing "pH" ' +
+        'and at least 2 other known soil-test columns (Ca, Mg, Na, EC, etc.).'
+    );
+  }
+  console.log(`Header row at index ${headerRowIdx}`);
+
+  // --- Check for a units row immediately after the header ---
+  let dataStartIdx = headerRowIdx + 1;
+  let alreadyPpm = false;
+
+  if (dataStartIdx < rows.length) {
+    const candidateUnits = rows[dataStartIdx] as unknown[];
+    if (isUnitsRow(candidateUnits)) {
+      alreadyPpm = detectPpmFromUnitsRow(candidateUnits, colMap);
+      console.log(
+        `Units row at index ${dataStartIdx} — Ca/Mg/Na already PPM: ${alreadyPpm}`
+      );
+      dataStartIdx++; // skip the units row
+    }
+  }
+
+  // --- Parse data rows ---
+  const dataRows = rows.slice(dataStartIdx);
+  const results: LabRow[] = [];
+
+  for (const raw of dataRows) {
+    const row = raw as unknown[];
+    const get = (field: keyof LabRow): unknown => {
+      const idx = colMap[field];
+      return idx !== undefined ? row[idx] : undefined;
+    };
+
+    const description = toStr(get('description'));
+    const cropRaw = toStr(get('crop')); // may be "(Lettuce)" from Depth col
+    const no = toNum(get('no'));
+
+    // Skip blank rows
+    if (!description && no === null) continue;
+
+    // Skip footer / reference-range rows
+    const descLower = description.toLowerCase();
+    if (
+      descLower.startsWith('low') ||
+      descLower.startsWith('medium') ||
+      descLower.startsWith('high') ||
+      descLower.startsWith('optimal')
+    )
+      continue;
+
+    // Skip conversion-note rows (e.g. "(meq/l )/(charge) = mmol/l")
+    if (descLower.includes('meq/l') || descLower.includes('mmol/l')) continue;
+
+    // Extract crop annotation — could be in Depth col "(Lettuce)" or at the
+    // end of Description "Harden 7 (Lettuce)"
+    const cropFromDesc = description.match(/\(([^)]+)\)$/)?.[1] ?? null;
+    const crop = cropRaw.replace(/[()]/g, '').trim() || cropFromDesc;
+
+    // pH validation: lab pH must be 0–14; anything outside is corrupt data
+    const rawPh = toNum(get('ph'));
+    const ph = rawPh !== null && rawPh >= 0 && rawPh <= 14 ? rawPh : null;
+    if (rawPh !== null && ph === null) {
+      console.log(
+        `  ⚠  Row ${no ?? '?'}: pH value ${rawPh} is outside 0–14 — skipped`
+      );
+    }
+
+    results.push({
+      no: no ?? results.length + 1,
+      description,
+      crop,
+      sp: toNum(get('sp')),
+      ph,
+      ec: toNum(get('ec')),
+      ca: toNum(get('ca')),
+      mg: toNum(get('mg')),
+      na: toNum(get('na')),
+      cl: toNum(get('cl')),
+      esp: toNum(get('esp')),
+      gypsumReq: toNum(get('gypsumReq')),
+      lime: toNum(get('lime')),
+      b: toNum(get('b')),
+      no3n: toNum(get('no3n')),
+      po4p: toNum(get('po4p')),
+      k: toNum(get('k')),
+      zn: toNum(get('zn')),
+      mn: toNum(get('mn')),
+      fe: toNum(get('fe')),
+      cu: toNum(get('cu')),
+      om: toNum(get('om')),
+    });
+  }
+
+  return { rows: results, alreadyPpm };
+}
+
+// ---------------------------------------------------------------------------
+// PPM conversion + mineral building
+// ---------------------------------------------------------------------------
+
+type MineralName =
+  | 'Calcium'
+  | 'Magnesium'
+  | 'Sodium'
+  | 'Potassium'
+  | 'PH'
+  | 'NitrateNitrogen'
+  | 'PhosphatePhosphorus'
+  | 'Zinc'
+  | 'Iron'
+  | 'OrganicMatter'
+  | 'Manganese'
+  | 'Copper'
+  | 'Boron';
+
+type UnitValue = 'ppm' | '%' | 'dimensionless';
+
+type TagValue = 'Low' | 'Med' | 'High';
+
+interface MineralInsert {
+  analysisId: string;
+  name: MineralName;
+  realValue: number;
+  idealValue: number | null;
+  units: UnitValue;
+  tag: TagValue | null;
+  fourLows: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Vincent's Data Framework — ideal values (PPM unless noted)
+// ---------------------------------------------------------------------------
+const IDEAL_VALUES: Partial<Record<MineralName, number>> = {
+  Calcium: 16000,
+  Magnesium: 11000,
+  Sodium: 500,
+  Potassium: 1200,
+  Copper: 1.5,
+  Zinc: 1.5,
+  Iron: 85,
+  Manganese: 40,
+  Boron: 0.5,
+  PhosphatePhosphorus: 1100,
+  // PH ideal stored as midpoint of 6.5–7.0
+  PH: 6.75,
+};
+
+// ---------------------------------------------------------------------------
+// Tag computation (Lab reference ranges)
+// ---------------------------------------------------------------------------
+
+/**
+ * Determines Low / Med / High tag for a mineral based on lab reference
+ * ranges. Ca and Mg tags use meq/l values (converted back from PPM when
+ * the sheet is already in PPM); K/Zn/Mn/Fe/OM/pH use their native units.
+ */
+function computeTag(
+  name: MineralName,
+  row: LabRow,
+  alreadyPpm: boolean
+): TagValue | null {
+  // For Ca/Mg, lab ranges are in meq/l. When alreadyPpm, convert back.
+  const caRaw =
+    row.ca !== null ? (alreadyPpm ? row.ca / MEQ_TO_PPM.Ca : row.ca) : null;
+  const mgRaw =
+    row.mg !== null ? (alreadyPpm ? row.mg / MEQ_TO_PPM.Mg : row.mg) : null;
+
+  switch (name) {
+    case 'PH': {
+      const v = row.ph;
+      if (v === null) return null;
+      if (v < 7.3) return 'Low';
+      if (v <= 7.8) return 'Med';
+      return 'High';
+    }
+    case 'Calcium': {
+      if (caRaw === null) return null;
+      if (caRaw < 5) return 'Low';
+      if (caRaw <= 10) return 'Med';
+      return 'High';
+    }
+    case 'Magnesium': {
+      // Low: <3 meq/l, High: Mg > Ca in meq/l, else Med
+      if (mgRaw === null) return null;
+      if (mgRaw < 3) return 'Low';
+      if (caRaw !== null && mgRaw > caRaw) return 'High';
+      return 'Med';
+    }
+    case 'Potassium': {
+      const v = row.k;
+      if (v === null) return null;
+      if (v < 250) return 'Low';
+      if (v <= 350) return 'Med';
+      return 'High';
+    }
+    case 'Zinc': {
+      const v = row.zn;
+      if (v === null) return null;
+      if (v < 2.5) return 'Low';
+      if (v <= 4.5) return 'Med';
+      return 'High';
+    }
+    case 'Manganese': {
+      const v = row.mn;
+      if (v === null) return null;
+      if (v < 2.5) return 'Low';
+      if (v <= 10) return 'Med';
+      return 'High';
+    }
+    case 'Iron': {
+      const v = row.fe;
+      if (v === null) return null;
+      if (v < 5) return 'Low';
+      if (v <= 10) return 'Med';
+      return 'High';
+    }
+    case 'OrganicMatter': {
+      const v = row.om;
+      if (v === null) return null;
+      if (v < 1.0) return 'Low';
+      if (v <= 3) return 'Med';
+      return 'High';
+    }
+    default:
+      // Na, NO3-N, PO4-P, Cu, B — no lab reference ranges
+      return null;
+  }
+}
+
+/**
+ * Converts a LabRow to an array of mineral insert records.
+ *
+ * When `alreadyPpm` is false, Ca/Mg/Na are converted from meq/l → PPM
+ * using Vincent's conversion factors. When true, values are stored as-is.
+ *
+ * Each mineral row includes ideal_value from Vincent's Data Framework,
+ * a Low/Med/High tag from lab reference ranges, and a four_lows flag.
+ */
+function buildMinerals(
+  row: LabRow,
+  analysisId: string,
+  alreadyPpm: boolean
+): MineralInsert[] {
+  const minerals: MineralInsert[] = [];
+
+  const add = (
+    name: MineralName,
+    value: number | null,
+    units: UnitValue = 'ppm'
+  ) => {
+    if (value !== null && !isNaN(value)) {
+      minerals.push({
+        analysisId,
+        name,
+        realValue: value,
+        idealValue: IDEAL_VALUES[name] ?? null,
+        units,
+        tag: computeTag(name, row, alreadyPpm),
+        fourLows: false, // set after all minerals are built
+      });
+    }
+  };
+
+  if (alreadyPpm) {
+    add('Calcium', row.ca);
+    add('Magnesium', row.mg);
+    add('Sodium', row.na);
+  } else {
+    add('Calcium', row.ca !== null ? row.ca * MEQ_TO_PPM.Ca : null);
+    add('Magnesium', row.mg !== null ? row.mg * MEQ_TO_PPM.Mg : null);
+    add('Sodium', row.na !== null ? row.na * MEQ_TO_PPM.Na : null);
+  }
+
+  // Already in mg/kg (= PPM) regardless of sheet type
+  add('Potassium', row.k);
+  add('NitrateNitrogen', row.no3n);
+  add('PhosphatePhosphorus', row.po4p);
+  add('Zinc', row.zn);
+  add('Iron', row.fe);
+  add('Manganese', row.mn);
+  add('Copper', row.cu);
+  add('Boron', row.b); // mg/l ≈ PPM for dilute solutions
+
+  // pH — dimensionless
+  add('PH', row.ph, 'dimensionless');
+
+  // Organic matter — percentage
+  add('OrganicMatter', row.om, '%');
+
+  // Set four_lows on the four base minerals
+  const fl = checkFourLows(minerals);
+  if (fl) {
+    for (const m of minerals) {
+      if (
+        m.name === 'Calcium' ||
+        m.name === 'Magnesium' ||
+        m.name === 'Sodium' ||
+        m.name === 'Potassium'
+      ) {
+        m.fourLows = true;
+      }
+    }
+  }
+
+  return minerals;
+}
+
+// ---------------------------------------------------------------------------
+// Four Lows detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when all four base minerals are simultaneously below
+ * Vincent's Data Framework thresholds.
+ */
+function checkFourLows(minerals: MineralInsert[]): boolean {
+  const get = (name: MineralName) =>
+    minerals.find((m) => m.name === name)?.realValue ?? null;
+
+  const ca = get('Calcium');
+  const mg = get('Magnesium');
+  const na = get('Sodium');
+  const k = get('Potassium');
+
+  return (
+    ca !== null &&
+    ca < FOUR_LOWS_THRESHOLDS.Calcium &&
+    mg !== null &&
+    mg < FOUR_LOWS_THRESHOLDS.Magnesium &&
+    na !== null &&
+    na < FOUR_LOWS_THRESHOLDS.Sodium &&
+    k !== null &&
+    k < FOUR_LOWS_THRESHOLDS.Potassium
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Skipped-columns logging
+// ---------------------------------------------------------------------------
+
+function logSkipped(row: LabRow) {
+  const skipped: string[] = [];
+  if (row.cl !== null) skipped.push(`Cl=${row.cl} (Chloride — not stored)`);
+  if (row.sp !== null)
+    skipped.push(`SP=${row.sp}% (Saturation % — not stored)`);
+  if (row.esp !== null)
+    skipped.push(`ESP=${row.esp}% (Exchangeable Sodium % — not stored)`);
+  if (row.gypsumReq !== null)
+    skipped.push(`GypReq=${row.gypsumReq} (Gypsum Req — not stored)`);
+  if (row.lime !== null)
+    skipped.push(`Lime=${row.lime} (Lime Req — not stored)`);
+
+  if (skipped.length > 0) {
+    console.log(`  ⚠  Skipped: ${skipped.join(' | ')}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Management zone lookup / creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the ID of an existing management zone matching name + farm, or
+ * creates one and returns its new ID.
+ */
+async function getOrCreateZone(
+  farmId: number,
+  zoneName: string
+): Promise<number> {
+  const existing = await db
+    .select({ id: managementZone.id })
+    .from(managementZone)
+    .where(
+      and(eq(managementZone.farmId, farmId), eq(managementZone.name, zoneName))
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    return existing[0].id;
+  }
+
+  console.log(`  → Creating management zone "${zoneName}" for farm ${farmId}`);
+  const [created] = await db
+    .insert(managementZone)
+    .values({ farmId, name: zoneName })
+    .returning({ id: managementZone.id });
+
+  return created.id;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  let filePath: string | null = null;
+  let farmId = 2;
+  let fixedZoneId: number | null = null;
+  let analysisDate = new Date();
+  let sheetOverride: string | undefined;
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--farm-id':
+        farmId = parseInt(args[++i], 10);
+        break;
+      case '--zone-id':
+        fixedZoneId = parseInt(args[++i], 10);
+        break;
+      case '--date':
+        analysisDate = new Date(args[++i]);
+        break;
+      case '--sheet':
+        sheetOverride = args[++i];
+        break;
+      case '--dry-run':
+        dryRun = true;
+        break;
+      default:
+        if (!args[i].startsWith('--')) filePath = args[i];
+    }
+  }
+
+  if (!filePath) {
+    console.error(
+      'Usage: NODE_TLS_REJECT_UNAUTHORIZED=0 bun run scripts/parse-soil-test.ts' +
+        ' <filepath> [--farm-id <n>] [--zone-id <n>] [--date YYYY-MM-DD]' +
+        ' [--sheet <name>] [--dry-run]'
+    );
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`File not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const dateStr = analysisDate.toISOString().slice(0, 10);
+  console.log(`\nFile    : ${path.resolve(filePath)}`);
+  console.log(`Farm ID : ${farmId}`);
+  console.log(`Date    : ${dateStr}`);
+  console.log(`Dry run : ${dryRun}\n`);
+
+  const { rows, alreadyPpm } = parseFile(filePath, sheetOverride);
+  console.log(
+    `Found ${rows.length} data rows (values ${alreadyPpm ? 'already in PPM' : 'in meq/l — will convert'})\n`
+  );
+
+  let inserted = 0;
+
+  for (const row of rows) {
+    const label = row.description || `Row ${row.no}`;
+    const cropLabel = row.crop ? ` (${row.crop})` : '';
+    console.log(`━━ ${row.no}. ${label}${cropLabel}`);
+
+    // ---- Determine management zone ----
+    let zoneId: number;
+
+    if (fixedZoneId !== null) {
+      zoneId = fixedZoneId;
+    } else {
+      if (!row.description) {
+        console.log(
+          '  ✗ No description — skipping (use --zone-id to assign a zone)'
+        );
+        continue;
+      }
+      // Strip crop annotation "(Lettuce)" etc. from the zone name
+      const zoneName = row.description.replace(/\s*\(.*?\)\s*$/, '').trim();
+
+      if (dryRun) {
+        console.log(
+          `  → Would look up / create zone: "${zoneName}" (farm ${farmId})`
+        );
+        zoneId = 0;
+      } else {
+        zoneId = await getOrCreateZone(farmId, zoneName);
+        console.log(`  Zone ID : ${zoneId}`);
+      }
+    }
+
+    // ---- Build insert data ----
+    const analysisId = generateAnalysisId();
+    const minerals = buildMinerals(row, analysisId, alreadyPpm);
+    const ecPpm = row.ec !== null ? row.ec * EC_TO_PPM : null;
+    const fourLows = checkFourLows(minerals);
+
+    // ---- Log ----
+    console.log(`  Analysis ID : ${analysisId}`);
+
+    if (minerals.length > 0) {
+      console.log(`  Minerals (${minerals.length}):`);
+      for (const m of minerals) {
+        const tagStr = m.tag ? ` [${m.tag}]` : '';
+        const idealStr =
+          m.idealValue !== null ? ` (ideal: ${m.idealValue})` : '';
+        const flStr = m.fourLows ? ' ⚠4L' : '';
+        console.log(
+          `    ${m.name.padEnd(22)} ${m.realValue.toFixed(4).padStart(12)} ${m.units}${tagStr}${idealStr}${flStr}`
+        );
+      }
+    }
+
+    if (ecPpm !== null) {
+      console.log(
+        `  Solubility : EC ${row.ec} dS/m → ${ecPpm.toFixed(2)} PPM` +
+          ` (ideal ${EC_IDEAL_PPM} PPM)`
+      );
+    }
+
+    if (fourLows) {
+      console.log(
+        `  ⚠  FOUR LOWS DETECTED — Ca/Mg/Na/K all below threshold. ' +
+          'Restore soil biology before mineral amendments.`
+      );
+    }
+
+    logSkipped(row);
+
+    // ---- Insert ----
+    if (dryRun) {
+      console.log('  [dry-run] Not writing to DB');
+      continue;
+    }
+
+    await db.insert(analysis).values({
+      id: analysisId,
+      managementZone: zoneId,
+      analysisDate,
+    });
+
+    if (minerals.length > 0) {
+      await db.insert(mineral).values(
+        minerals.map((m) => ({
+          analysisId: m.analysisId,
+          name: m.name,
+          realValue: m.realValue,
+          idealValue: m.idealValue,
+          units: m.units,
+          tag: m.tag,
+          fourLows: m.fourLows,
+        }))
+      );
+    }
+
+    if (ecPpm !== null) {
+      await db.insert(solubility).values({
+        analysisId,
+        real_value: String(ecPpm),
+        ideal_value: String(EC_IDEAL_PPM),
+        units: 'ppm',
+      });
+    }
+
+    console.log(`  ✓ Inserted`);
+    inserted++;
+  }
+
+  console.log(`\nDone — inserted ${inserted} / ${rows.length} analyses.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/frontend/scripts/parse-soil-test.ts
+++ b/frontend/scripts/parse-soil-test.ts
@@ -64,6 +64,7 @@ const FOUR_LOWS_THRESHOLDS = {
  * (uppercase alphanumeric, 13 chars total).
  */
 function generateAnalysisId(): string {
+  // eslint-disable-next-line no-secrets/no-secrets
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
   const seg = (n: number) =>
     Array.from(
@@ -827,8 +828,8 @@ async function main() {
 
     if (fourLows) {
       console.log(
-        `  ⚠  FOUR LOWS DETECTED — Ca/Mg/Na/K all below threshold. ' +
-          'Restore soil biology before mineral amendments.`
+        `  ⚠  FOUR LOWS DETECTED — Ca/Mg/Na/K all below threshold. ` +
+          `Restore soil biology before mineral amendments.`
       );
     }
 

--- a/frontend/src/app/(unauthenticated)/[locale]/(marketing)/who-we-are/page.test.tsx
+++ b/frontend/src/app/(unauthenticated)/[locale]/(marketing)/who-we-are/page.test.tsx
@@ -14,6 +14,7 @@ vi.mock('next/image', () => ({
     src: string | { src: string };
     alt: string;
   }) => (
+    // eslint-disable-next-line @next/next/no-img-element
     <img src={typeof src === 'string' ? src : src.src} alt={alt} {...props} />
   ),
 }));

--- a/frontend/src/app/(unauthenticated)/accept/components/accept-form.tsx
+++ b/frontend/src/app/(unauthenticated)/accept/components/accept-form.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ErrorMessage } from '@hookform/error-message';
 import { UserSelect } from '@/lib/types/db';
@@ -30,7 +30,7 @@ export default function AcceptForm({
     handleSubmit,
     getValues,
     trigger,
-    watch,
+    control,
     formState: { errors, isSubmitting },
   } = useForm<AcceptInvite>({
     resolver: zodResolver(acceptInviteSchema),
@@ -45,6 +45,9 @@ export default function AcceptForm({
       confirmPassword: '',
     },
   });
+
+  const password = useWatch({ control, name: 'password' });
+  const confirmPassword = useWatch({ control, name: 'confirmPassword' });
 
   async function onSubmit() {
     await trigger();
@@ -231,8 +234,8 @@ export default function AcceptForm({
             </Field>
           </div>
           <PasswordChecklist
-            password={watch('password')}
-            confirmationPassword={watch('confirmPassword')}
+            password={password}
+            confirmationPassword={confirmPassword}
           />
           <SubmitButton
             buttonText="Accept Invitation"

--- a/frontend/src/lib/ai/content-parser.ts
+++ b/frontend/src/lib/ai/content-parser.ts
@@ -1,0 +1,465 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * @fileoverview
+ * Content-to-Markdown parser (Parser 2).
+ *
+ * Takes any content (images, PDFs, Excel sheets, plain text) and converts it
+ * to clean markdown. One parser, multiple input formats.
+ *
+ * Supported formats:
+ *  - Images (JPG, PNG, WEBP, GIF) → vision AI extracts text/tables
+ *  - PDFs → text extraction, with vision AI fallback for scanned pages
+ *  - Excel/Spreadsheets → reads cells and formats as markdown
+ *  - Plain text → pass-through with minimal formatting
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import OpenAI from 'openai';
+import type { ChatCompletionContentPart } from 'openai/resources/chat/completions';
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_EMBEDDINGS_KEY ?? 'NOTAKEY',
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif']);
+const PDF_EXTENSIONS = new Set(['.pdf']);
+const EXCEL_EXTENSIONS = new Set(['.xlsx', '.xls', '.csv']);
+const TEXT_EXTENSIONS = new Set(['.txt', '.md', '.markdown']);
+
+const VISION_MODEL = 'gpt-4o-mini';
+
+/**
+ * Minimum number of characters per PDF page for text extraction to be
+ * considered successful. Below this threshold the page is treated as
+ * scanned/image-based and sent to vision AI instead.
+ */
+const MIN_TEXT_CHARS_PER_PAGE = 50;
+
+// ---------------------------------------------------------------------------
+// Vision AI helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends an image buffer to GPT-4o-mini vision and asks it to extract content
+ * as clean markdown.
+ *
+ * @param imageBase64 - Base64-encoded image data
+ * @param mimeType - MIME type of the image (e.g. "image/png")
+ * @param context - Optional context hint for the AI (e.g. "This is page 3 of a PDF")
+ * @returns Markdown string extracted from the image
+ */
+async function extractMarkdownFromImage(
+  imageBase64: string,
+  mimeType: string,
+  context?: string
+): Promise<string> {
+  const systemPrompt = `You are a document digitization assistant. Your job is to convert images of physical documents, guides, reference charts, and textbook pages into clean, well-structured markdown.
+
+Rules:
+- Preserve ALL text content faithfully — do not summarize or omit anything.
+- Convert tables into markdown tables with proper alignment.
+- Use appropriate heading levels (# ## ###) based on the document structure.
+- Use bullet lists or numbered lists where the original uses them.
+- For diagrams or hand-drawn illustrations that cannot be converted to text, insert a note like: *[Diagram: brief description of what it shows]*
+- For pH scales, color charts, or visual references, describe them as a table or list.
+- Do not add any content that is not in the original image.
+- Do not wrap output in a markdown code block — just return the markdown directly.`;
+
+  const userContent: ChatCompletionContentPart[] = [
+    {
+      type: 'image_url',
+      image_url: {
+        url: `data:${mimeType};base64,${imageBase64}`,
+        detail: 'high',
+      },
+    },
+    {
+      type: 'text',
+      text: context
+        ? `${context}\n\nExtract all text content from this image as clean markdown.`
+        : 'Extract all text content from this image as clean markdown.',
+    },
+  ];
+
+  const response = await openai.chat.completions.create({
+    model: VISION_MODEL,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userContent },
+    ],
+    max_tokens: 4096,
+    temperature: 0,
+  });
+
+  return response.choices[0]?.message?.content?.trim() ?? '';
+}
+
+/**
+ * Determines the MIME type for a given file extension.
+ */
+function mimeTypeForExtension(ext: string): string {
+  switch (ext.toLowerCase()) {
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.png':
+      return 'image/png';
+    case '.webp':
+      return 'image/webp';
+    case '.gif':
+      return 'image/gif';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Image parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses an image file (JPG, PNG, WEBP, GIF) and extracts its content as
+ * markdown using GPT-4o-mini vision.
+ *
+ * @param imagePath - Absolute or relative path to the image file
+ * @returns Markdown string extracted from the image
+ */
+export async function parseImage(imagePath: string): Promise<string> {
+  const resolved = path.resolve(imagePath);
+
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Image file not found: ${resolved}`);
+  }
+
+  const ext = path.extname(resolved).toLowerCase();
+  if (!IMAGE_EXTENSIONS.has(ext)) {
+    throw new Error(
+      `Unsupported image format: ${ext}. Supported: ${[...IMAGE_EXTENSIONS].join(', ')}`
+    );
+  }
+
+  const buffer = fs.readFileSync(resolved);
+  const base64 = buffer.toString('base64');
+  const mimeType = mimeTypeForExtension(ext);
+
+  return extractMarkdownFromImage(base64, mimeType);
+}
+
+// ---------------------------------------------------------------------------
+// PDF parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a PDF file and converts it to markdown.
+ *
+ * For text-based PDFs, extracts text directly using pdf-parse. For scanned
+ * PDFs (pages with very little extractable text), falls back to vision AI
+ * on a per-page basis.
+ *
+ * @param pdfPath - Absolute or relative path to the PDF file
+ * @returns Markdown string of the full PDF content
+ */
+export async function parsePdf(pdfPath: string): Promise<string> {
+  const resolved = path.resolve(pdfPath);
+
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`PDF file not found: ${resolved}`);
+  }
+
+  const { PDFParse } = await import('pdf-parse');
+  const buffer = fs.readFileSync(resolved);
+
+  const parser = new PDFParse({ data: new Uint8Array(buffer) });
+  const textResult = await parser.getText();
+  await parser.destroy();
+
+  const rawText = textResult.text?.trim() ?? '';
+  const pageCount = textResult.total ?? 1;
+
+  // If the total extracted text is substantial, format it as markdown
+  if (rawText.length >= MIN_TEXT_CHARS_PER_PAGE * pageCount) {
+    return formatTextAsMarkdown(rawText);
+  }
+
+  // Sparse text — likely a scanned PDF. We can't easily render PDF pages to
+  // images without heavy dependencies (e.g. poppler, pdf2pic). Return
+  // whatever text we got with a note about the limitation.
+  if (rawText.length > 0) {
+    return (
+      formatTextAsMarkdown(rawText) +
+      '\n\n---\n\n*Note: Some pages in this PDF may contain scanned images. ' +
+      'For best results with scanned documents, convert individual pages to ' +
+      'images and use the image parser.*'
+    );
+  }
+
+  return (
+    '*This PDF appears to be fully scanned/image-based with no extractable text. ' +
+    'Convert pages to images (e.g. using a screenshot tool or PDF-to-image converter) ' +
+    'and parse each page individually using the image parser.*'
+  );
+}
+
+/**
+ * Applies basic markdown formatting heuristics to raw extracted PDF text.
+ *
+ * Detects headings (short all-caps or bold lines), preserves paragraph
+ * breaks, and cleans up extra whitespace.
+ */
+function formatTextAsMarkdown(text: string): string {
+  const lines = text.split('\n');
+  const output: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trimEnd();
+    const trimmed = line.trim();
+
+    // Skip completely empty lines but preserve paragraph breaks
+    if (trimmed === '') {
+      // Avoid double blank lines
+      if (output.length > 0 && output[output.length - 1] !== '') {
+        output.push('');
+      }
+      continue;
+    }
+
+    // Detect likely headings: short lines that are ALL CAPS or end with ':'
+    // and are followed by longer text
+    const isShortLine = trimmed.length < 80;
+    const isAllCaps =
+      trimmed === trimmed.toUpperCase() &&
+      /[A-Z]/.test(trimmed) &&
+      trimmed.length > 2;
+    const nextLine = i + 1 < lines.length ? lines[i + 1]?.trim() : '';
+    const nextIsContent = (nextLine?.length ?? 0) > trimmed.length;
+
+    if (isShortLine && isAllCaps && nextIsContent) {
+      // Main heading
+      output.push(`## ${titleCase(trimmed)}`);
+      output.push('');
+    } else {
+      output.push(trimmed);
+    }
+  }
+
+  return output.join('\n').trim();
+}
+
+/** Converts an ALL CAPS string to Title Case. */
+function titleCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/\b(And|Or|The|A|An|In|On|At|To|For|Of|With)\b/g, (w) =>
+      w.toLowerCase()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Excel/Spreadsheet parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses an Excel file and converts a specified sheet's content to an array
+ * of markdown strings (one per logical section or row).
+ *
+ * For IMP-style sheets (with Category/Trigger/Body columns), each row becomes
+ * a separate markdown document. For generic sheets, the entire sheet is
+ * converted to a single markdown table.
+ *
+ * @param filePath - Path to the Excel/CSV file
+ * @param sheetName - Name of the sheet to parse (uses first sheet if not found)
+ * @returns Array of markdown strings
+ */
+export async function parseExcelContent(
+  filePath: string,
+  sheetName?: string
+): Promise<string[]> {
+  const resolved = path.resolve(filePath);
+
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`File not found: ${resolved}`);
+  }
+
+  // xlsx is a CJS module — import dynamically for ESM compat
+  const xlsx = await import('xlsx');
+  const workbook = xlsx.readFile(resolved, { type: 'file', raw: false });
+
+  // Pick the requested sheet, or fall back to first sheet
+  const targetSheet =
+    sheetName && workbook.SheetNames.includes(sheetName)
+      ? sheetName
+      : workbook.SheetNames[0];
+
+  const sheet = workbook.Sheets[targetSheet];
+  const rows: Record<string, unknown>[] = xlsx.utils.sheet_to_json(sheet, {
+    defval: '',
+  });
+
+  if (rows.length === 0) {
+    return ['*Empty sheet — no content found.*'];
+  }
+
+  const headers = Object.keys(rows[0]);
+  const headersLower = headers.map((h) => h.toLowerCase().trim());
+
+  // Detect IMP-style sheets (Category/Trigger/Body columns)
+  const hasCategory = headersLower.some(
+    (h) => h === 'category' || h === 'categories'
+  );
+  const hasTrigger = headersLower.some(
+    (h) => h === 'trigger' || h === 'triggers'
+  );
+  const hasBody = headersLower.some(
+    (h) => h === 'body' || h === 'content' || h === 'recommendation'
+  );
+
+  if (hasCategory && hasTrigger && hasBody) {
+    return parseImpSheet(rows, headers);
+  }
+
+  // Generic sheet → convert to a single markdown table
+  return [convertToMarkdownTable(rows, headers)];
+}
+
+/**
+ * Converts IMP-style spreadsheet rows (Category/Trigger/Body) into individual
+ * markdown documents.
+ */
+function parseImpSheet(
+  rows: Record<string, unknown>[],
+  headers: string[]
+): string[] {
+  // Find the actual header keys (case-insensitive match)
+  const catKey = headers.find((h) =>
+    ['category', 'categories'].includes(h.toLowerCase().trim())
+  )!;
+  const trigKey = headers.find((h) =>
+    ['trigger', 'triggers'].includes(h.toLowerCase().trim())
+  )!;
+  const bodyKey = headers.find((h) =>
+    ['body', 'content', 'recommendation'].includes(h.toLowerCase().trim())
+  )!;
+
+  const results: string[] = [];
+
+  for (const row of rows) {
+    const category = String(row[catKey] ?? '').trim();
+    const trigger = String(row[trigKey] ?? '').trim();
+    const body = String(row[bodyKey] ?? '').trim();
+
+    // Skip empty rows
+    if (!body) continue;
+
+    const parts: string[] = [];
+
+    // Build a title from trigger or category
+    const title = trigger || category || 'Untitled';
+    parts.push(`# ${title}`);
+    parts.push('');
+
+    if (category) {
+      parts.push(`**Categories:** ${category}`);
+      parts.push('');
+    }
+
+    if (trigger) {
+      parts.push(`**Trigger:** ${trigger}`);
+      parts.push('');
+    }
+
+    parts.push(body);
+
+    results.push(parts.join('\n'));
+  }
+
+  return results;
+}
+
+/**
+ * Converts a generic array of row objects into a markdown table.
+ */
+function convertToMarkdownTable(
+  rows: Record<string, unknown>[],
+  headers: string[]
+): string {
+  const lines: string[] = [];
+
+  // Header row
+  lines.push('| ' + headers.join(' | ') + ' |');
+  // Separator row
+  lines.push('| ' + headers.map(() => '---').join(' | ') + ' |');
+
+  // Data rows
+  for (const row of rows) {
+    const cells = headers.map((h) => {
+      const val = String(row[h] ?? '').trim();
+      // Escape pipe characters in cell content
+      return val.replace(/\|/g, '\\|');
+    });
+    lines.push('| ' + cells.join(' | ') + ' |');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Unified parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Auto-detects the file type and parses it to markdown.
+ *
+ * - Images → single markdown string via vision AI
+ * - PDFs → single markdown string via text extraction (+ vision fallback)
+ * - Excel/CSV → array of markdown strings (one per section/row for IMPs,
+ *   or one element for generic sheets)
+ * - Text files → single markdown string (pass-through)
+ *
+ * @param filePath - Path to the file to parse
+ * @returns Markdown content — a single string, or an array for spreadsheets
+ */
+export async function parseContent(
+  filePath: string
+): Promise<string | string[]> {
+  const resolved = path.resolve(filePath);
+
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`File not found: ${resolved}`);
+  }
+
+  const ext = path.extname(resolved).toLowerCase();
+
+  if (IMAGE_EXTENSIONS.has(ext)) {
+    return parseImage(resolved);
+  }
+
+  if (PDF_EXTENSIONS.has(ext)) {
+    return parsePdf(resolved);
+  }
+
+  if (EXCEL_EXTENSIONS.has(ext)) {
+    return parseExcelContent(resolved);
+  }
+
+  if (TEXT_EXTENSIONS.has(ext)) {
+    const text = fs.readFileSync(resolved, 'utf-8');
+    return text.trim();
+  }
+
+  throw new Error(
+    `Unsupported file type: ${ext}. Supported: ` +
+      [
+        ...IMAGE_EXTENSIONS,
+        ...PDF_EXTENSIONS,
+        ...EXCEL_EXTENSIONS,
+        ...TEXT_EXTENSIONS,
+      ].join(', ')
+  );
+}

--- a/frontend/src/lib/db/queries/get-standard-values.ts
+++ b/frontend/src/lib/db/queries/get-standard-values.ts
@@ -33,10 +33,11 @@ export interface StandardValueThresholds {
   max: number;
 }
 
-/** Maps mineral type enum values to their corresponding standard_values column prefix */
+/** Maps mineral type enum values to their corresponding standard_values column prefix.
+ *  Minerals without standard_values columns (Manganese, Copper, Boron) map to null. */
 const mineralToStandardValueType: Record<
   (typeof mineralTypes.enumValues)[number],
-  StandardValueType
+  StandardValueType | null
 > = {
   Calcium: 'calcium',
   Magnesium: 'magnesium',
@@ -49,6 +50,9 @@ const mineralToStandardValueType: Record<
   Zinc: 'zinc',
   Iron: 'iron',
   OrganicMatter: 'organicMatter',
+  Manganese: null,
+  Copper: null,
+  Boron: null,
 };
 
 /**
@@ -64,6 +68,7 @@ export async function getStandardValues(
   type: (typeof mineralTypes.enumValues)[number]
 ): Promise<StandardValueThresholds | null> {
   const mappedType = mineralToStandardValueType[type];
+  if (mappedType === null) return null;
 
   // Dynamic column lookup — AnyPgColumn erases the per-column name brand
   // so Drizzle's .select() accepts columns from different mineral types uniformly.

--- a/frontend/src/lib/db/schema/index.ts
+++ b/frontend/src/lib/db/schema/index.ts
@@ -7,7 +7,7 @@ export { integratedManagementPlan } from './integrated-management-plan';
 export { farmInfoInternalApplication } from './internal-application';
 export { knowledgeArticle, knowledgeCategoryEnum } from './knowledge';
 export { managementZone } from './management-zone';
-export { mineral, mineralTypes } from './mineral';
+export { mineral, mineralTag, mineralTypes, units } from './mineral';
 export { oxidationRate } from './oxidation-rate';
 export { solubility } from './solubility';
 export { user, accountAgreementAcceptance, userRoleEnum } from './user';

--- a/frontend/src/lib/db/schema/mineral.ts
+++ b/frontend/src/lib/db/schema/mineral.ts
@@ -1,6 +1,7 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import {
+  boolean,
   numeric,
   pgEnum,
   pgTable,
@@ -23,9 +24,15 @@ export const mineralTypes = pgEnum('mineral_types', [
   'Zinc',
   'Iron',
   'OrganicMatter',
+  'Manganese',
+  'Copper',
+  'Boron',
 ]);
 
-export const units = pgEnum('units', ['ppm', '%']);
+export const units = pgEnum('units', ['ppm', '%', 'dimensionless']);
+
+/** Tag indicating whether a mineral reading is Low, Med (optimal), or High. */
+export const mineralTag = pgEnum('mineral_tag', ['Low', 'Med', 'High']);
 
 /** A table that describes a single mineral and its values for a given analysis. */
 export const mineral = pgTable('mineral', {
@@ -39,8 +46,14 @@ export const mineral = pgTable('mineral', {
   name: mineralTypes().notNull(),
   /** The real value of the mineral (see the unit field for units) */
   realValue: numeric({ precision: 9, scale: 4 }).notNull().$type<number>(),
+  /** The ideal value from Vincent's Data Framework (same units as realValue) */
+  idealValue: numeric({ precision: 9, scale: 4 }).$type<number>(),
   /** The unit which this mineral is being measured in. Almost always PPM */
   units: units().notNull(),
+  /** Low / Med / High tag based on lab reference ranges */
+  tag: mineralTag(),
+  /** True when Ca, Mg, Na, and K are all simultaneously below Four Lows thresholds */
+  fourLows: boolean(),
   /** Actionable information or recommendation associated with this mineral reading. */
   actionableInfo: text(),
   createdAt: timestamp().notNull().defaultNow(),


### PR DESCRIPTION
## Description

Adds two developer scripts from the original parser branch:

1. **Soil Test Parser** (`scripts/parse-soil-test.ts`) — reads lab Excel/CSV
reports, converts units (meq/l → PPM), and inserts results into the
analysis, mineral, and solubility tables automatically.

2. **Content Parser** (`scripts/parse-content.ts` + `src/lib/ai/content-parser.ts`) -  converts images, PDFs, and Excel files into clean markdown using
GPT-4o-mini vision, with optional save to the knowledge base.

Also includes the mineral schema migration (`migrate-mineral-schema.ts`)
that adds Manganese, Copper, Boron, ideal_value, tag, and four_lows
to the mineral table.

**Note:** Vercel preview deployments are failing because this branch
predates the monorepo restructure (103 commits behind main, uses old
`frontend/` structure). No production impact. Cherry pick to a fresh
branch from main is the intended next step per Vincent.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used conventional commits where appropriate.
