### PR TITLE
feat(site): zone template page with 4 cards, remove widget grid

### DIFF
--- a/apps/site/src/app/(authenticated)/(shell)/(widgets)/components/zone-template.tsx
+++ b/apps/site/src/app/(authenticated)/(shell)/(widgets)/components/zone-template.tsx
@@ -10,7 +10,12 @@ const TEST_PERIOD_MONTHS = 6;
 /** Placeholder until advisors are modeled in the DB. */
 const LEAD_ADVISOR_PLACEHOLDER = 'Not assigned';
 
-const CARD_CLASS = 'rounded-xl border border-stone-200 p-6';
+/** Shared vertical spacing for each stacked section. */
+const SECTION_CLASS = 'py-6';
+
+/** Small uppercase, letter-spaced section label. */
+const LABEL_CLASS =
+  'text-xs font-medium uppercase tracking-wider text-foreground/40';
 
 function addMonths(date: Date, months: number): Date {
   const next = new Date(date);
@@ -28,9 +33,10 @@ function formatDate(date: Date | null): string {
 }
 
 /**
- * Per-management-zone template. Renders four stacked cards: zone info, mineral
- * IMPs (placeholder until the analysis tables are wired), client observations
- * (shell only for now), and search.
+ * Per-management-zone template. Renders four stacked sections separated by
+ * divider lines: zone info, mineral IMPs (placeholder until the analysis
+ * tables are wired), client observations (shell only for now), and a search
+ * form that submits to the knowledge-base search page.
  *
  * @param {object} props - Component props.
  * @param {number} props.zoneId - Selected management zone id.
@@ -57,10 +63,10 @@ export default async function ZoneTemplate({
     : null;
 
   return (
-    <div className="mx-auto flex max-w-4xl flex-col gap-6 p-6">
+    <div className="divide-foreground/10 mx-auto max-w-4xl divide-y px-6">
       {/* Info */}
-      <section className={CARD_CLASS}>
-        <h2 className="text-xl font-medium text-foreground">{zoneName}</h2>
+      <section className={SECTION_CLASS}>
+        <h2 className="text-foreground text-xl font-medium">{zoneName}</h2>
         <div className="mt-4 flex flex-wrap gap-x-12 gap-y-3 text-sm">
           <div>
             <span className="text-foreground/50">Sample </span>
@@ -78,36 +84,50 @@ export default async function ZoneTemplate({
       </section>
 
       {/* Mineral IMPs — placeholder until analysis tables are wired */}
-      <section className={CARD_CLASS}>
-        <p className="text-sm italic text-foreground/50">
+      <section className={SECTION_CLASS}>
+        <p className={LABEL_CLASS}>Mineral IMPs</p>
+        <p className="text-foreground/50 mt-4 text-sm italic">
           Info not currently available
         </p>
       </section>
 
       {/* Observations — shell only for now */}
-      <section className={CARD_CLASS}>
-        <h3 className="text-foreground">Observations</h3>
+      <section className={SECTION_CLASS}>
+        <p className={LABEL_CLASS}>Zone observations</p>
         <button
           type="button"
           disabled
-          className="mt-4 text-sm text-foreground/50"
+          className="border-foreground/20 text-foreground/50 mt-4 w-full rounded-md border border-dashed px-4 py-3 text-left text-sm"
         >
           + Add an observation to {zoneName}
         </button>
       </section>
 
-      {/* Search */}
-      <section className={CARD_CLASS}>
-        <label htmlFor="zone-search" className="text-foreground">
-          Search
+      {/* Search — submits to the knowledge-base search page */}
+      <section className={SECTION_CLASS}>
+        <label htmlFor="zone-search" className={LABEL_CLASS}>
+          Ask about this zone or search your farm records
         </label>
-        <input
-          id="zone-search"
-          type="search"
-          disabled
-          placeholder="Search…"
-          className="mt-4 w-full rounded-md border border-stone-200 bg-stone-50 px-3 py-2 text-sm"
-        />
+        <form
+          action="/search"
+          method="get"
+          role="search"
+          className="mt-4 flex gap-2"
+        >
+          <input
+            id="zone-search"
+            name="q"
+            type="search"
+            placeholder="e.g. What does this mean for my tomatoes?"
+            className="border-foreground/15 text-foreground flex-1 rounded-md border bg-transparent px-3 py-2 text-sm"
+          />
+          <button
+            type="submit"
+            className="border-foreground/15 text-foreground hover:bg-foreground/5 rounded-md border px-5 py-2 text-sm"
+          >
+            Ask
+          </button>
+        </form>
       </section>
     </div>
   );

--- a/apps/site/src/app/(authenticated)/(shell)/(widgets)/components/zone-template.tsx
+++ b/apps/site/src/app/(authenticated)/(shell)/(widgets)/components/zone-template.tsx
@@ -1,0 +1,114 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { analysis } from '@nightcrawler/db/schema';
+import { db } from '@nightcrawler/db/schema/connection';
+import { desc, eq } from 'drizzle-orm';
+
+/** Months between a soil sample and the next scheduled one. */
+const TEST_PERIOD_MONTHS = 6;
+
+/** Placeholder until advisors are modeled in the DB. */
+const LEAD_ADVISOR_PLACEHOLDER = 'Not assigned';
+
+const CARD_CLASS = 'rounded-xl border border-stone-200 p-6';
+
+function addMonths(date: Date, months: number): Date {
+  const next = new Date(date);
+  next.setMonth(next.getMonth() + months);
+  return next;
+}
+
+function formatDate(date: Date | null): string {
+  if (!date) return '—';
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Per-management-zone template. Renders four stacked cards: zone info, mineral
+ * IMPs (placeholder until the analysis tables are wired), client observations
+ * (shell only for now), and search.
+ *
+ * @param {object} props - Component props.
+ * @param {number} props.zoneId - Selected management zone id.
+ * @param {string} props.zoneName - Selected management zone name.
+ * @returns {Promise<React.ReactNode>} The rendered zone template.
+ */
+export default async function ZoneTemplate({
+  zoneId,
+  zoneName,
+}: {
+  zoneId: number;
+  zoneName: string;
+}) {
+  const [latest] = await db
+    .select({ analysisDate: analysis.analysisDate })
+    .from(analysis)
+    .where(eq(analysis.managementZone, zoneId))
+    .orderBy(desc(analysis.analysisDate))
+    .limit(1);
+
+  const sampleDate = latest?.analysisDate ?? null;
+  const nextDate = sampleDate
+    ? addMonths(sampleDate, TEST_PERIOD_MONTHS)
+    : null;
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 p-6">
+      {/* Info */}
+      <section className={CARD_CLASS}>
+        <h2 className="text-xl font-medium text-foreground">{zoneName}</h2>
+        <div className="mt-4 flex flex-wrap gap-x-12 gap-y-3 text-sm">
+          <div>
+            <span className="text-foreground/50">Sample </span>
+            <span className="text-foreground">{formatDate(sampleDate)}</span>
+          </div>
+          <div>
+            <span className="text-foreground/50">Next </span>
+            <span className="text-foreground">{formatDate(nextDate)}</span>
+          </div>
+          <div>
+            <span className="text-foreground/50">Lead Advisor </span>
+            <span className="text-foreground">{LEAD_ADVISOR_PLACEHOLDER}</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Mineral IMPs — placeholder until analysis tables are wired */}
+      <section className={CARD_CLASS}>
+        <p className="text-sm italic text-foreground/50">
+          Info not currently available
+        </p>
+      </section>
+
+      {/* Observations — shell only for now */}
+      <section className={CARD_CLASS}>
+        <h3 className="text-foreground">Observations</h3>
+        <button
+          type="button"
+          disabled
+          className="mt-4 text-sm text-foreground/50"
+        >
+          + Add an observation to {zoneName}
+        </button>
+      </section>
+
+      {/* Search */}
+      <section className={CARD_CLASS}>
+        <label htmlFor="zone-search" className="text-foreground">
+          Search
+        </label>
+        <input
+          id="zone-search"
+          type="search"
+          disabled
+          placeholder="Search…"
+          className="mt-4 w-full rounded-md border border-stone-200 bg-stone-50 px-3 py-2 text-sm"
+        />
+      </section>
+    </div>
+  );
+}

--- a/apps/site/src/app/(authenticated)/(shell)/(widgets)/page.tsx
+++ b/apps/site/src/app/(authenticated)/(shell)/(widgets)/page.tsx
@@ -1,24 +1,14 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import { NavLinks } from '@/components/common/authenticated-header/nav-links';
-import AddWidgetDropdown from '@/components/common/widgets/add-widget-dropdown';
-import { Button } from '@/components/ui';
-import { managementZone, widget, widgetEnum } from '@nightcrawler/db/schema';
+import { managementZone } from '@nightcrawler/db/schema';
 import { db } from '@nightcrawler/db/schema/connection';
 import { getAuthenticatedInfo } from '@/lib/utils/get-authenticated-info';
 import { asc, eq } from 'drizzle-orm';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getAccountShellData } from '../(accounts)/account/db';
-import CurrentTab from '../../components/tabs/current-tab';
-import { NamedTab } from '../../components/tabs/types';
-
-// -- Commented out: tab-based imports (kept for future use) ---
-//import PlatformTabContent from '../../components/tabs/tab-content';
-//import PlatformTabs from '../../components/tabs/tabs';
-//import { getTablessManagementZones } from '../../components/tabs/utils';
-//import { getSelectedTab, getSelectedTabHash } from './utils';
-//import { tab } from '@nightcrawler/db/schema/tab';
+import ZoneTemplate from './components/zone-template';
 
 /**
  * Dashboard homepage metadata - uses specific title without template
@@ -29,7 +19,8 @@ export const metadata: Metadata = {
 
 /**
  * Dashboard page - served at "/" route for authenticated users.
- * Shows a left sidebar listing all management zones and the selected zone's content.
+ * Shows a left sidebar listing all management zones and the selected zone's
+ * template (info, mineral IMPs, observations, search).
  *
  * @returns {React.ReactNode} - The dashboard page component
  */
@@ -39,7 +30,6 @@ export default async function DashboardPage({
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const currentUser = await getAuthenticatedInfo();
-  const canEdit = currentUser.role === 'Admin';
   const { farmName } = await getAccountShellData();
 
   // Fetch ALL management zones for the farm (oldest first)
@@ -58,7 +48,7 @@ export default async function DashboardPage({
             Your platform is ready when you are
           </h1>
           <p className="text-foreground/75 text-lg font-light">
-            There are no management zones or dashboard tabs on this account yet.
+            There are no management zones on this account yet.
             <br />
             You can keep exploring the platform while we finish setting things
             up.
@@ -95,28 +85,8 @@ export default async function DashboardPage({
     allManagementZones.find((z) => String(z.id) === zoneParam) ||
     allManagementZones[0];
 
-  // Build a NamedTab-compatible object for CurrentTab (it expects this shape)
-  const selectedTab: NamedTab = {
-    id: selectedZone.id,
-    user: currentUser.id,
-    managementZone: selectedZone.id,
-    name: selectedZone.name,
-  };
-
-  // Fetch widgets for the selected zone (for the Add Widget dropdown)
-  const widgets = await db
-    .select()
-    .from(widget)
-    .where(eq(widget.managementZone, selectedZone.id));
-  const allWidgetTypes = widgetEnum.enumValues;
-  const existingWidgetNames = new Set(widgets.map((w) => w.name));
-  const availableWidgets = allWidgetTypes.filter(
-    (widgetType) => !existingWidgetNames.has(widgetType)
-  );
-
   return (
     <div className="flex h-screen flex-col">
-      {/* Header — full width, same as before */}
       <header
         className="flex w-full items-center justify-between px-3 pt-3 pb-2"
         role="banner"
@@ -125,29 +95,16 @@ export default async function DashboardPage({
           {farmName}
         </h1>
         <div className="flex flex-row items-center gap-6">
-          {canEdit ? (
-            <AddWidgetDropdown
-              managementZoneId={selectedZone.id}
-              availableWidgets={availableWidgets}
-            >
-              <Button
-                size="sm"
-                variant="default"
-                className="h-[34px] w-[96px] hover:cursor-pointer hover:shadow-sm bg-[#D9D9D9]/32 text-foreground border-none focus-visible:ring-transparent!
-  focus-visible:ring-offset-transparent!"
-              >
-                Add widget
-              </Button>
-            </AddWidgetDropdown>
-          ) : null}
           <NavLinks />
         </div>
       </header>
 
-      {/* Body — content */}
       <div className="flex flex-1 overflow-hidden">
         <main className="flex-1 overflow-auto">
-          <CurrentTab currentTab={selectedTab} />
+          <ZoneTemplate
+            zoneId={selectedZone.id}
+            zoneName={selectedZone.name ?? 'Unnamed zone'}
+          />
         </main>
       </div>
     </div>


### PR DESCRIPTION
## Description

Problem statement   

The authenticated home page (/) rendered each management zone as a draggable widget grid. Widgets were never the long-term direction for the zone view — the plan is a structured, advisor-driven layout where each management zone shows its soil-analysis info, mineral-based recommendations (IMPs), client observations, and search in a consistent template.

Context

This is the first step toward the zone-based dashboard. The full vision (per design) is a per-zone template with four cards. The data layer for the mineral IMPs (the analysis / mineral / oxidationRate / solubility tables and the recommendation-matching logic) isn't wired up yet and depends on an in-progress source-of-truth decision with the agronomy side, so the mineral IMP card ships as a placeholder for now.

What this PR does

  - Replaces the widget grid on / with a 4-card zone template (ZoneTemplate), rendered for the currently selected management zone:
    a. Info — zone name, sample date (from the latest soil analysis), next sample date (sample + 6 months), and lead advisor (placeholder — no advisor field exists yet).
    b. Mineral IMPs — "Info not currently available" placeholder until the analysis tables are wired.
    c. Observations — card shell with a (currently non-functional) "Add an observation" affordance; the backing table is a follow-up.
    d. Search — placeholder search input.
  - Stops rendering the widget grid (CurrentTab / WidgetsGrid / AddWidgetDropdown) on the zone page. Zone selection via ?zone=<id> and the sidebar are unchanged.
  
Testing

  - Verified locally: the 4 cards render for the selected zone, dates compute correctly from a real analysis (Sample → Next = +6 months), zone switching via the sidebar updates the cards, and the empty state still shows for farms with no zones.