### PR TITLE
feat(site): move farm name into sidebar, drop dashboard header

### DIFF
--- a/apps/site/src/app/(authenticated)/(shell)/(widgets)/page.tsx
+++ b/apps/site/src/app/(authenticated)/(shell)/(widgets)/page.tsx
@@ -1,13 +1,11 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import { NavLinks } from '@/components/common/authenticated-header/nav-links';
 import { managementZone } from '@nightcrawler/db/schema';
 import { db } from '@nightcrawler/db/schema/connection';
 import { getAuthenticatedInfo } from '@/lib/utils/get-authenticated-info';
 import { asc, eq } from 'drizzle-orm';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { getAccountShellData } from '../(accounts)/account/db';
 import ZoneTemplate from './components/zone-template';
 
 /**
@@ -30,7 +28,6 @@ export default async function DashboardPage({
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const currentUser = await getAuthenticatedInfo();
-  const { farmName } = await getAccountShellData();
 
   // Fetch ALL management zones for the farm (oldest first)
   const allManagementZones = await db
@@ -87,18 +84,6 @@ export default async function DashboardPage({
 
   return (
     <div className="flex h-screen flex-col">
-      <header
-        className="flex w-full items-center justify-between px-3 pt-3 pb-2"
-        role="banner"
-      >
-        <h1 className="text-foreground truncate text-lg font-medium">
-          {farmName}
-        </h1>
-        <div className="flex flex-row items-center gap-6">
-          <NavLinks />
-        </div>
-      </header>
-
       <div className="flex flex-1 overflow-hidden">
         <main className="flex-1 overflow-auto">
           <ZoneTemplate

--- a/apps/site/src/app/(authenticated)/components/sidebar/sidebar.test.tsx
+++ b/apps/site/src/app/(authenticated)/components/sidebar/sidebar.test.tsx
@@ -17,6 +17,7 @@ const getManagementZones = vi.fn(async () => [
 
 vi.mock('@/app/(authenticated)/(shell)/(accounts)/account/db', () => ({
   getManagementZones: () => getManagementZones(),
+  getAccountShellData: async () => ({ farmName: 'Green Acres' }),
 }));
 
 vi.mock('@/app/(authenticated)/actions/search-modal', () => ({
@@ -39,6 +40,11 @@ afterEach(() => {
 });
 
 describe('Sidebar', () => {
+  it('shows the farm name at the top', async () => {
+    await renderSidebar();
+    expect(screen.getByText('Green Acres')).toBeInTheDocument();
+  });
+
   it('renders the primary nav links', async () => {
     await renderSidebar();
     // Search is a modal trigger (button), not a route link.

--- a/apps/site/src/app/(authenticated)/components/sidebar/sidebar.tsx
+++ b/apps/site/src/app/(authenticated)/components/sidebar/sidebar.tsx
@@ -28,7 +28,7 @@ export default async function Sidebar() {
     <aside className="w-[280px] shrink-0 border-r border-[#D9D9D9]/30 bg-[var(--background)] flex flex-col h-screen overflow-y-auto">
       {/* Farm name + collapse control */}
       <div className="flex items-center justify-between gap-2 px-3 pt-2">
-        <span className="text-foreground truncate text-sm font-medium">
+        <span className="text-foreground truncate pl-3 text-sm font-medium">
           {farmName}
         </span>
         <SidebarCollapseToggle />

--- a/apps/site/src/app/(authenticated)/components/sidebar/sidebar.tsx
+++ b/apps/site/src/app/(authenticated)/components/sidebar/sidebar.tsx
@@ -26,15 +26,12 @@ export default async function Sidebar() {
 
   return (
     <aside className="w-[280px] shrink-0 border-r border-[#D9D9D9]/30 bg-[var(--background)] flex flex-col h-screen overflow-y-auto">
-      {/* Farm name + collapse control — title aligns with the nav item labels
-          (empty icon-sized spacer mirrors SidebarNavItem's icon + gap). */}
+      {/* Farm name + collapse control — title's left edge aligns with the nav
+          item icons (row px-3 + inner px-3, matching SidebarNavItem's px-3). */}
       <div className="flex items-center justify-between gap-2 px-3 pt-2">
-        <div className="flex min-w-0 flex-1 items-center gap-2.5 px-3">
-          <span className="size-4 shrink-0" aria-hidden="true" />
-          <span className="text-foreground truncate text-sm font-medium">
-            {farmName}
-          </span>
-        </div>
+        <span className="text-foreground min-w-0 flex-1 truncate px-3 text-sm font-medium">
+          {farmName}
+        </span>
         <SidebarCollapseToggle />
       </div>
 

--- a/apps/site/src/app/(authenticated)/components/sidebar/sidebar.tsx
+++ b/apps/site/src/app/(authenticated)/components/sidebar/sidebar.tsx
@@ -26,11 +26,15 @@ export default async function Sidebar() {
 
   return (
     <aside className="w-[280px] shrink-0 border-r border-[#D9D9D9]/30 bg-[var(--background)] flex flex-col h-screen overflow-y-auto">
-      {/* Farm name + collapse control */}
+      {/* Farm name + collapse control — title aligns with the nav item labels
+          (empty icon-sized spacer mirrors SidebarNavItem's icon + gap). */}
       <div className="flex items-center justify-between gap-2 px-3 pt-2">
-        <span className="text-foreground truncate pl-3 text-sm font-medium">
-          {farmName}
-        </span>
+        <div className="flex min-w-0 flex-1 items-center gap-2.5 px-3">
+          <span className="size-4 shrink-0" aria-hidden="true" />
+          <span className="text-foreground truncate text-sm font-medium">
+            {farmName}
+          </span>
+        </div>
         <SidebarCollapseToggle />
       </div>
 

--- a/apps/site/src/app/(authenticated)/components/sidebar/sidebar.tsx
+++ b/apps/site/src/app/(authenticated)/components/sidebar/sidebar.tsx
@@ -6,7 +6,10 @@ import SidebarUserFooter from './sidebar-user-footer';
 import SidebarSearchButton from './sidebar-search-button';
 import SidebarCollapseToggle from './sidebar-collapse-toggle';
 import ZoneItem from './zone-item';
-import { getManagementZones } from '@/app/(authenticated)/(shell)/(accounts)/account/db';
+import {
+  getAccountShellData,
+  getManagementZones,
+} from '@/app/(authenticated)/(shell)/(accounts)/account/db';
 import { LuBell, LuShoppingCart } from 'react-icons/lu';
 
 /**
@@ -16,12 +19,18 @@ import { LuBell, LuShoppingCart } from 'react-icons/lu';
  * @returns {React.ReactNode} - The sidebar navigation
  */
 export default async function Sidebar() {
-  const zones = await getManagementZones();
+  const [zones, { farmName }] = await Promise.all([
+    getManagementZones(),
+    getAccountShellData(),
+  ]);
 
   return (
     <aside className="w-[280px] shrink-0 border-r border-[#D9D9D9]/30 bg-[var(--background)] flex flex-col h-screen overflow-y-auto">
-      {/* Collapse control */}
-      <div className="flex items-center justify-end px-2 pt-2">
+      {/* Farm name + collapse control */}
+      <div className="flex items-center justify-between gap-2 px-3 pt-2">
+        <span className="text-foreground truncate text-sm font-medium">
+          {farmName}
+        </span>
         <SidebarCollapseToggle />
       </div>
 


### PR DESCRIPTION
## What

Moves the **farm name** into the top of the platform **sidebar** and **deletes** the inline dashboard (`/`) header.

The dashboard header showed the farm name plus a `NavLinks` cluster (Order, Contact, Account, Logout) that duplicated the sidebar. Now:
- Farm name sits at the top of the sidebar (left, collapse toggle right).
- The header is gone — the sidebar is the single nav.
- Orders / Contact / Account already exist in the sidebar; **logout is dropped** from the dashboard (still available on `/account`).

## How

- `sidebar.tsx`: `await getAccountShellData()` (alongside `getManagementZones()`, same `db.ts`) and render `farmName` in the top row (`justify-between`, truncated).
- `(widgets)/page.tsx`: remove the `<header>` block and the now-unused `NavLinks` / `getAccountShellData` / `farmName`. Empty-state branch unchanged.
- `sidebar.test.tsx`: mock `getAccountShellData`; assert the farm name renders.

## Notes

- Farm name hides when the sidebar collapses (aside animates to `w-0`) and shows in the mobile sidebar sheet.

## Verification

- `bun type-check` ✅ · `bun run lint` ✅ (0 errors) · `bun run test -- sidebar` ✅ (4 passing) · `next build` ✅ (119 pages)
- Independent diff review: no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
