### PR TITLE
fix: route sidebar support button to Support Tools page

### DIFF
--- a/apps/site/src/app/(authenticated)/(chromeless)/(with-header)/support-tools/components/support-links-section.tsx
+++ b/apps/site/src/app/(authenticated)/(chromeless)/(with-header)/support-tools/components/support-links-section.tsx
@@ -9,13 +9,13 @@ import {
   BiSolidUserMinus,
 } from 'react-icons/bi';
 
-interface ContactLinkItem {
+interface SupportLinkItem {
   label: string;
   href: string;
   icon: React.ReactNode;
 }
 
-const contactLinkItems: ContactLinkItem[] = [
+const supportLinkItems: SupportLinkItem[] = [
   {
     label: 'Training request',
     href: 'mailto:service.us@toddagriscience.com',
@@ -38,10 +38,10 @@ const contactLinkItems: ContactLinkItem[] = [
   },
 ];
 
-export default function ContactLinksSection() {
+export default function SupportLinksSection() {
   return (
     <section className="mt-10 border-t border-[#D9D9D9]">
-      {contactLinkItems.map((item) => (
+      {supportLinkItems.map((item) => (
         <Link
           href={item.href}
           className="group flex w-full items-center min-h-11 justify-between border-b border-[#D9D9D9] px-0.5 py-2 transition-opacity hover:opacity-70"

--- a/apps/site/src/app/(authenticated)/(chromeless)/(with-header)/support-tools/layout.tsx
+++ b/apps/site/src/app/(authenticated)/(chromeless)/(with-header)/support-tools/layout.tsx
@@ -3,10 +3,10 @@
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Contact | Todd',
+  title: 'Support Tools | Todd',
 };
 
-export default function ContactLayout({
+export default function SupportToolsLayout({
   children,
 }: {
   children: React.ReactNode;

--- a/apps/site/src/app/(authenticated)/(chromeless)/(with-header)/support-tools/page.tsx
+++ b/apps/site/src/app/(authenticated)/(chromeless)/(with-header)/support-tools/page.tsx
@@ -4,10 +4,10 @@ import { Button } from '@/components/ui/button';
 import { Mail, MessageCircle } from 'lucide-react';
 import Link from 'next/link';
 import { BiArrowBack } from 'react-icons/bi';
-import ContactLinksSection from './components/contact-links-section';
+import SupportLinksSection from './components/support-links-section';
 
 /** Authenticated support tools page. */
-export default async function ContactPage() {
+export default async function SupportToolsPage() {
   return (
     <main className="mx-auto w-full">
       <div className="border-b border-[#D9D9D9]">
@@ -52,7 +52,7 @@ export default async function ContactPage() {
           </Button>
         </div>
 
-        <ContactLinksSection />
+        <SupportLinksSection />
       </section>
     </main>
   );

--- a/apps/site/src/app/(authenticated)/components/sidebar/sidebar-user-footer.tsx
+++ b/apps/site/src/app/(authenticated)/components/sidebar/sidebar-user-footer.tsx
@@ -1,11 +1,10 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import SidebarNavItem from './sidebar-nav-item';
-import IrisIcon from './iris-icon';
-import { LuSettings } from 'react-icons/lu';
+import { LuLifeBuoy, LuSettings } from 'react-icons/lu';
 
 /**
- * Sidebar footer — renders the Contact and Account navigation entries pinned to
+ * Sidebar footer — renders the Support and Account navigation entries pinned to
  * the bottom of the sidebar.
  *
  * @returns {React.ReactNode} - The sidebar account footer
@@ -13,8 +12,11 @@ import { LuSettings } from 'react-icons/lu';
 export default function SidebarUserFooter() {
   return (
     <div className="border-t border-[#D9D9D9]/30 px-3 py-3">
-      <SidebarNavItem href="/contact" icon={<IrisIcon />}>
-        Contact
+      <SidebarNavItem
+        href="/support-tools"
+        icon={<LuLifeBuoy className="size-4" />}
+      >
+        Support
       </SidebarNavItem>
       <SidebarNavItem
         href="/account"


### PR DESCRIPTION
Fixes #998

The authenticated "Support Tools" page (`apps/site/src/app/(authenticated)/(chromeless)/(with-header)/contact/page.tsx`) was dead code — `apps/site/src/proxy/all-users-page.ts` lists `'contact'` in `allUserRoutesIntl`, which forces `/contact` to always route through the unauthenticated i18n middleware regardless of login state. As a result, `/contact` always served the public marketing contact form, and the authenticated Support Tools content (Email/SMS + Training request/Recent Updates/Data Deletion Request/Disclosures) could never actually be reached by any URL.

This PR:
- Moves the page from `contact/` to `support-tools/` (new route: `/support-tools`), which isn't subject to the `allUserRoutesIntl` rule, making it reachable for the first time.
- Renames the internal component/exports to match (`ContactLinksSection` → `SupportLinksSection`, `ContactLayout` → `SupportToolsLayout`, metadata title updated).
- Updates the sidebar's footer nav item (`sidebar-user-footer.tsx`) to link to `/support-tools` instead of `/contact`, changes its label from "Contact" to "Support", and replaces the misleading `IrisIcon` (which implied nonexistent "Iris" functionality) with `LuLifeBuoy`, matching the icon convention already used for the adjacent "Account" link (`LuSettings`).

The public marketing `/contact` page is untouched and continues to work as before for all users.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable. (Existing `sidebar-user-footer.test.tsx` suite still passes; no new tests needed since behavior covered is a link/label/icon swap, not new logic.)
- [] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible. (Nav item structure unchanged — same link/icon/label pattern as the adjacent Account item.)
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate