### PR TITLE
feat(db,ci): fail-loud remote migrations, env-aware reconcile + importers

### DIFF
--- a/.agent/workflows/modifying-database.md
+++ b/.agent/workflows/modifying-database.md
@@ -4,3 +4,10 @@ description: When modifying database tables
 
 1. Apply changes to the schema.
 2. DO NOT create migrations or run migrations (e.g., absolutely no running `bunx drizzle-kit generate`). Let the specific backend teams handle migrations.
+
+## How migrations reach staging/prod (for the backend team)
+
+- Committed migrations live in `packages/db/drizzle/*.sql` + `meta/_journal.json`. CI applies them with the ledger-based drizzle migrator (`scripts/migrate-remote-db.ts`), never `drizzle-kit push` — push silently no-ops in CI (interactive enum resolver, no TTY, exits 0), which is how prod once drifted.
+- Merge to `main` → "Database Compatibility Check" workflow migrates **staging**. Cutting a release → "Release Database Compatibility Check And Push" migrates **prod**, then chains the Vercel deploy. Both fail loudly on any mismatch.
+- If a database has drifted (schema present but ledger disagrees), run the manual "DB Reconcile" workflow (Actions → workflow_dispatch → pick `staging`/`prod`, run `verify` first, then `apply`).
+- Row data for sheet-mirrored tables (seed varieties, general IMPs) is loaded by the importers in `packages/db/scripts/import-*.ts`; they default to the local Docker DB, and can target remotes with `--env staging|prod` plus `--commit --confirm <env>` and `OPENAI_EMBEDDINGS_KEY`.

--- a/.github/workflows/db-reconcile.yml
+++ b/.github/workflows/db-reconcile.yml
@@ -129,11 +129,24 @@ jobs:
           # this workflow handles. If it is missing we are pointed at a wrong
           # or empty database and must not proceed (an apply run would rebuild
           # a ledger full of claims about schema that does not exist).
-          baseline=$(has_table knowledge_article)
-          if [ "$baseline" != "t" ]; then
-            echo "::error::Baseline table knowledge_article is missing — wrong or empty database? Refusing to continue."
-            exit 1
-          fi
+           baseline=$(has_table knowledge_article)
+            if [ "$baseline" != "t" ]; then
+              echo "::error::Baseline table knowledge_article is missing — wrong or empty database? Refusing to continue."
+              exit 1
+            fi
+
+            # This break-glass workflow only knows how to verify + apply migrations
+            # through 0014 (the probes and the apply FILES list are hardcoded). The
+            # ledger rebuild, by contrast, writes a row for EVERY journal entry — so
+            # if a newer migration has landed, rebuilding would stamp it "applied"
+            # without this workflow ever verifying it, reintroducing the exact
+            # silent drift this workflow exists to fix. Refuse until it is extended.
+            KNOWN_HEAD="0014_general-imp"
+            JOURNAL_HEAD=$(jq -r '.entries[-1].tag' drizzle/meta/_journal.json)
+            if [ "$JOURNAL_HEAD" != "$KNOWN_HEAD" ]; then
+              echo "::error::Journal head '$JOURNAL_HEAD' is beyond '$KNOWN_HEAD' — extend the verify/apply steps in this workflow before reconciling."
+              exit 1
+            fi
 
           # classify <migration> <object=t|f>... -> sets $state to "applied"
           # (all objects present) or "missing" (none present). A partial mix
@@ -318,19 +331,23 @@ jobs:
           # migrations never require editing this workflow. The drizzle migrator
           # gates on created_at (`when > max(created_at)`), so after this it
           # sees the journal head and runs nothing.
-          echo "Rebuilding drizzle migration ledger from meta/_journal.json..."
-          VALUES=$(
-            jq -r '.entries[] | [.tag, (.when|tostring)] | @tsv' drizzle/meta/_journal.json \
-            | while IFS=$'\t' read -r tag when; do
-                hash=$(sha256sum "drizzle/${tag}.sql" | cut -d' ' -f1)
-                printf "('%s',%s),\n" "$hash" "$when"
-              done \
-            | sed '$ s/,$//'
-          )
-          if [ -z "$VALUES" ]; then
-            echo "::error::No journal entries found — refusing to truncate the ledger."
-            exit 1
-          fi
+           echo "Rebuilding drizzle migration ledger from meta/_journal.json..."
+            # Loop in the MAIN shell (process substitution, not a pipe) so an
+            # `exit 1` here actually aborts the step, and check every file + hash so
+            # a missing or unreadable .sql can never silently write an empty hash.
+            declare -a ROWS=()
+            while IFS=$'\t' read -r tag when; do
+              sql="drizzle/${tag}.sql"
+              [ -f "$sql" ] || { echo "::error::Journal references $sql but the file is missing — refusing to rebuild the ledger."; exit 1; }
+              hash=$(sha256sum "$sql" | cut -d' ' -f1)
+              [ -n "$hash" ] || { echo "::error::Failed to hash $sql — refusing to write an empty ledger hash."; exit 1; }
+              ROWS+=("('$hash',$when)")
+            done < <(jq -r '.entries[] | [.tag, (.when|tostring)] | @tsv' drizzle/meta/_journal.json)
+            if [ ${#ROWS[@]} -eq 0 ]; then
+              echo "::error::No journal entries found — refusing to truncate the ledger."
+              exit 1
+            fi
+            VALUES=$(IFS=,; echo "${ROWS[*]}")
 
           PGPASSWORD="$DB_PASSWORD" $PSQL "$CONN" --single-transaction -v ON_ERROR_STOP=1 -c "
             create schema if not exists drizzle;

--- a/.github/workflows/db-reconcile.yml
+++ b/.github/workflows/db-reconcile.yml
@@ -1,23 +1,29 @@
-name: Prod DB Reconcile (Apply Pending Migrations)
+name: DB Reconcile (Apply Pending Migrations)
 
-# One-off, manually triggered reconciliation for production.
+# Manually triggered, break-glass reconciliation for prod or staging.
 #
-# Background: the release workflow uses `drizzle-kit push`, which crashes on
-# drizzle-kit's interactive enum resolver in CI (no TTY) yet exits 0 -> the
-# "Push to production" step reports success while applying nothing. As a result
-# prod silently drifted behind `main` (frozen at the 1.1.9 schema).
+# Background: the release/main-push workflows used `drizzle-kit push`, which
+# crashes on drizzle-kit's interactive enum resolver in CI (no TTY) yet exits
+# 0 -> the push step reported success while applying nothing, and prod
+# silently drifted behind `main` (frozen at the 1.1.9 schema). Those
+# workflows now run the ledger-based drizzle migrator instead; this workflow
+# exists to bring a drifted database back to a state the migrator understands.
 #
-# This workflow applies the committed migration `.sql` files (0010-0014) that
-# prod is missing, verbatim, in a single all-or-nothing transaction, then
-# rebuilds the drizzle migration ledger so future `drizzle-kit migrate` runs are
-# consistent. It defaults to `verify` (read-only) so you can confirm real prod
-# state before any writes.
-#
-# Targets prod via the PROD_DATABASE_* secrets. For staging, run the manual
-# psql path (see packages/db/drizzle/*.sql) or add a staging-secret variant.
+# It applies the committed migration `.sql` files (0010-0014) the target is
+# missing, verbatim, in a single all-or-nothing transaction, then rebuilds the
+# drizzle migration ledger from meta/_journal.json so future ledger-based
+# migrations run cleanly. It defaults to `verify` (read-only) so you can
+# confirm the real database state before any writes.
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: 'Target database'
+        required: true
+        type: choice
+        options:
+          - staging
+          - prod
       mode:
         description: 'verify = read-only state check; apply = run pending migrations + rebuild ledger'
         required: true
@@ -29,7 +35,7 @@ on:
 
 jobs:
   reconcile:
-    name: Reconcile production schema (${{ inputs.mode }})
+    name: Reconcile ${{ inputs.environment }} schema (${{ inputs.mode }})
     runs-on: ubuntu-latest
     env:
       PROD_DATABASE_HOST: ${{ secrets.PROD_DATABASE_HOST }}
@@ -37,7 +43,14 @@ jobs:
       PROD_DATABASE_USER: ${{ secrets.PROD_DATABASE_USER }}
       PROD_DATABASE_PASSWORD: ${{ secrets.PROD_DATABASE_PASSWORD }}
       PROD_DATABASE_DATABASE: ${{ secrets.PROD_DATABASE_DATABASE }}
+      STAGING_DATABASE_HOST: ${{ secrets.STAGING_DATABASE_HOST }}
+      STAGING_DATABASE_PORT: ${{ secrets.STAGING_DATABASE_PORT }}
+      STAGING_DATABASE_USER: ${{ secrets.STAGING_DATABASE_USER }}
+      STAGING_DATABASE_PASSWORD: ${{ secrets.STAGING_DATABASE_PASSWORD }}
+      STAGING_DATABASE_DATABASE: ${{ secrets.STAGING_DATABASE_DATABASE }}
       DATABASE_PEM_CERT: ${{ secrets.DATABASE_PEM_CERT }}
+      # Falls back to the shared cert when no staging-specific secret exists.
+      STAGING_DATABASE_PEM_CERT: ${{ secrets.STAGING_DATABASE_PEM_CERT || secrets.DATABASE_PEM_CERT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -54,25 +67,56 @@ jobs:
           sudo apt-get install -y postgresql-client-18
           /usr/lib/postgresql/18/bin/psql --version
 
-      - name: Write prod CA certificate
+      - name: Select environment and write CA certificate
         run: |
-          printf '%s\n' "$DATABASE_PEM_CERT" | sed -e 's/\r$//' > /tmp/prod-db-ca.pem
-          openssl x509 -in /tmp/prod-db-ca.pem -noout -subject
+          set -euo pipefail
+          case "${{ inputs.environment }}" in
+            prod)
+              {
+                echo "DB_HOST=$PROD_DATABASE_HOST"
+                echo "DB_PORT=$PROD_DATABASE_PORT"
+                echo "DB_USER=$PROD_DATABASE_USER"
+                echo "DB_PASSWORD=$PROD_DATABASE_PASSWORD"
+                echo "DB_DATABASE=$PROD_DATABASE_DATABASE"
+              } >> "$GITHUB_ENV"
+              CA_RAW="$DATABASE_PEM_CERT"
+              ;;
+            staging)
+              {
+                echo "DB_HOST=$STAGING_DATABASE_HOST"
+                echo "DB_PORT=$STAGING_DATABASE_PORT"
+                echo "DB_USER=$STAGING_DATABASE_USER"
+                echo "DB_PASSWORD=$STAGING_DATABASE_PASSWORD"
+                echo "DB_DATABASE=$STAGING_DATABASE_DATABASE"
+              } >> "$GITHUB_ENV"
+              CA_RAW="$STAGING_DATABASE_PEM_CERT"
+              ;;
+            *)
+              echo "::error::Unknown environment '${{ inputs.environment }}'"
+              exit 1
+              ;;
+          esac
+          # Tolerate both secret storage formats: quote-wrapped with escaped
+          # newlines, or a plain multi-line PEM (possibly with CRLF endings).
+          printf '%s\n' "$CA_RAW" \
+            | sed -e '1s/^"//' -e '$s/"$//' -e 's/\\n/\n/g' -e 's/\r$//' \
+            > /tmp/db-ca.pem
+          openssl x509 -in /tmp/db-ca.pem -noout -subject
 
-      - name: Verify current production schema state
+      - name: Verify current schema state
         id: verify
         working-directory: ./packages/db
         run: |
           set -euo pipefail
           PSQL=/usr/lib/postgresql/18/bin/psql
           # sslmode=verify-full also validates the server certificate's hostname
-          # against PROD_DATABASE_HOST (verify-ca only validates the CA chain).
-          # If the provider's certificate cannot match the hostname, downgrading
-          # back to verify-ca requires explicit justification.
-          CONN="host=$PROD_DATABASE_HOST port=$PROD_DATABASE_PORT user=$PROD_DATABASE_USER dbname=$PROD_DATABASE_DATABASE sslmode=verify-full sslrootcert=/tmp/prod-db-ca.pem"
+          # against DB_HOST (verify-ca only validates the CA chain). If the
+          # provider's certificate cannot match the hostname, downgrading back
+          # to verify-ca requires explicit justification.
+          CONN="host=$DB_HOST port=$DB_PORT user=$DB_USER dbname=$DB_DATABASE sslmode=verify-full sslrootcert=/tmp/db-ca.pem"
 
           probe() {
-            PGPASSWORD="$PROD_DATABASE_PASSWORD" $PSQL "$CONN" -v ON_ERROR_STOP=1 -tAc "$1"
+            PGPASSWORD="$DB_PASSWORD" $PSQL "$CONN" -v ON_ERROR_STOP=1 -tAc "$1"
           }
           has_table()  { probe "select (to_regclass('public.$1') is not null);"; }
           has_enum()   { probe "select exists (select 1 from pg_type t join pg_namespace n on n.oid = t.typnamespace where n.nspname = 'public' and t.typtype = 'e' and t.typname = '$1');"; }
@@ -80,6 +124,16 @@ jobs:
           # Postgres truncates identifiers to 63 bytes, so compare constraint
           # names against left(name, 63) — 0011's reviewed_by FK name is longer.
           has_fk()     { probe "select exists (select 1 from pg_constraint c join pg_namespace n on n.oid = c.connamespace where n.nspname = 'public' and c.contype = 'f' and c.conname = left('$1', 63));"; }
+
+          # Baseline sanity check: knowledge_article predates every migration
+          # this workflow handles. If it is missing we are pointed at a wrong
+          # or empty database and must not proceed (an apply run would rebuild
+          # a ledger full of claims about schema that does not exist).
+          baseline=$(has_table knowledge_article)
+          if [ "$baseline" != "t" ]; then
+            echo "::error::Baseline table knowledge_article is missing — wrong or empty database? Refusing to continue."
+            exit 1
+          fi
 
           # classify <migration> <object=t|f>... -> sets $state to "applied"
           # (all objects present) or "missing" (none present). A partial mix
@@ -97,7 +151,7 @@ jobs:
             elif [ ${#present[@]} -eq 0 ]; then
               state="missing"
             else
-              echo "::error::Migration $mig is PARTIALLY applied — present: ${present[*]}; missing: ${missing[*]}. Refusing to skip or re-apply; repair production manually."
+              echo "::error::Migration $mig is PARTIALLY applied — present: ${present[*]}; missing: ${missing[*]}. Refusing to skip or re-apply; repair the database manually."
               exit 1
             fi
             echo "$mig: $state (present: ${present[*]:-none}; missing: ${missing[*]:-none})"
@@ -180,7 +234,7 @@ jobs:
         run: |
           set -euo pipefail
           PSQL=/usr/lib/postgresql/18/bin/psql
-          CONN="host=$PROD_DATABASE_HOST port=$PROD_DATABASE_PORT user=$PROD_DATABASE_USER dbname=$PROD_DATABASE_DATABASE sslmode=verify-full sslrootcert=/tmp/prod-db-ca.pem"
+          CONN="host=$DB_HOST port=$DB_PORT user=$DB_USER dbname=$DB_DATABASE sslmode=verify-full sslrootcert=/tmp/db-ca.pem"
 
           declare -a FILES=()
           [ "${{ steps.verify.outputs.state_0010 }}" = "applied" ] || FILES+=("drizzle/0010_add-farm-advisor-profile-notes.sql")
@@ -215,14 +269,14 @@ jobs:
             declare -a ARGS=()
             for f in "${FILES[@]}"; do ARGS+=(-f "$f"); done
 
-            PGPASSWORD="$PROD_DATABASE_PASSWORD" $PSQL "$CONN" \
+            PGPASSWORD="$DB_PASSWORD" $PSQL "$CONN" \
               --single-transaction \
               -v ON_ERROR_STOP=1 \
               "${ARGS[@]}"
           fi
 
           echo "Re-verifying post-apply state..."
-          PGPASSWORD="$PROD_DATABASE_PASSWORD" $PSQL "$CONN" -v ON_ERROR_STOP=1 -c "
+          PGPASSWORD="$DB_PASSWORD" $PSQL "$CONN" -v ON_ERROR_STOP=1 -c "
             select
               exists (select 1 from information_schema.columns
                       where table_name='farm' and column_name='advisor_profile_notes') as has_0010,
@@ -238,11 +292,12 @@ jobs:
         run: |
           set -euo pipefail
           PSQL=/usr/lib/postgresql/18/bin/psql
-          CONN="host=$PROD_DATABASE_HOST port=$PROD_DATABASE_PORT user=$PROD_DATABASE_USER dbname=$PROD_DATABASE_DATABASE sslmode=verify-full sslrootcert=/tmp/prod-db-ca.pem"
+          CONN="host=$DB_HOST port=$DB_PORT user=$DB_USER dbname=$DB_DATABASE sslmode=verify-full sslrootcert=/tmp/db-ca.pem"
 
-          # Only rebuild the ledger once the schema is fully at 0014, otherwise
-          # the ledger would claim migrations that are not actually applied.
-          all_present=$(PGPASSWORD="$PROD_DATABASE_PASSWORD" $PSQL "$CONN" -tAc "
+          # Only rebuild the ledger once the schema is fully at the journal
+          # head, otherwise the ledger would claim migrations that are not
+          # actually applied.
+          all_present=$(PGPASSWORD="$DB_PASSWORD" $PSQL "$CONN" -tAc "
             select
               (exists (select 1 from information_schema.columns
                        where table_name='farm' and column_name='advisor_profile_notes'))
@@ -253,41 +308,42 @@ jobs:
           ")
 
           if [ "$all_present" != "t" ]; then
-            echo "::error::Schema is not fully at 0014 — refusing to rebuild the ledger. Inspect production manually."
+            echo "::error::Schema is not fully at the journal head — refusing to rebuild the ledger. Inspect the database manually."
             exit 1
           fi
 
           # Rewrite drizzle.__drizzle_migrations to match the committed journal
-          # exactly: (hash = sha256 of each drizzle/*.sql, created_at = the
-          # entry's `when` from meta/_journal.json). After this, drizzle-kit
-          # migrate sees max(created_at) = 0014 and runs nothing.
-          echo "Rebuilding drizzle migration ledger..."
-          PGPASSWORD="$PROD_DATABASE_PASSWORD" $PSQL "$CONN" --single-transaction -v ON_ERROR_STOP=1 -c "
+          # exactly: (hash = sha256 of each drizzle/<tag>.sql, created_at = the
+          # entry's `when` from meta/_journal.json). Generated at runtime so new
+          # migrations never require editing this workflow. The drizzle migrator
+          # gates on created_at (`when > max(created_at)`), so after this it
+          # sees the journal head and runs nothing.
+          echo "Rebuilding drizzle migration ledger from meta/_journal.json..."
+          VALUES=$(
+            jq -r '.entries[] | [.tag, (.when|tostring)] | @tsv' drizzle/meta/_journal.json \
+            | while IFS=$'\t' read -r tag when; do
+                hash=$(sha256sum "drizzle/${tag}.sql" | cut -d' ' -f1)
+                printf "('%s',%s),\n" "$hash" "$when"
+              done \
+            | sed '$ s/,$//'
+          )
+          if [ -z "$VALUES" ]; then
+            echo "::error::No journal entries found — refusing to truncate the ledger."
+            exit 1
+          fi
+
+          PGPASSWORD="$DB_PASSWORD" $PSQL "$CONN" --single-transaction -v ON_ERROR_STOP=1 -c "
             create schema if not exists drizzle;
             create table if not exists drizzle.__drizzle_migrations (
               id serial primary key, hash text not null, created_at bigint
             );
             truncate drizzle.__drizzle_migrations restart identity;
             insert into drizzle.__drizzle_migrations (hash, created_at) values
-              ('975001fad5a72b6f1f43c5c8395d6f59eec01ddf936af94a3369055b6320b5d2',1772158369112),
-              ('5122ab423af507bc15381676e426fff720cc84c4b6aab3b2d75df2ec3d92fdd4',1772419343026),
-              ('d95f61fb84052d7b5f2b7ba4d2445f968736f00c674b4b261ad7443122565fd9',1772647120414),
-              ('4c718e922e8a98fd4fbc547601573e8fecbdeae287e9708ccc149c9fa3ccc9b6',1772652027714),
-              ('6a3bfa23e83ab8c44317e24c9c2fb10530a4d7aca63d39b813d00af21cc384d8',1773609705183),
-              ('8c22c468dd0133a85aae187903de71ff6807c9ef2b33eaedd13cc7c9ac9b9407',1773866423805),
-              ('a992c16783efa7f20cfe480a2e572cf2f8a4715be02a4173cea17d7208fd1285',1774049121695),
-              ('89687c693499aef5c4bd06d901895ce4293f68efdb3d54b517540ae5d9a1ac4d',1774461530048),
-              ('5ecafcb2c53b16f46904b00a2f628a45beedfee3e4dd72ef28252742972beab2',1774461530049),
-              ('6459ea25b35f78653612aa2980f13ea1c56104f5beab74fe041cfadac54e534a',1774461530050),
-              ('6d5f2f2b26c96897ac38772ffae5c509cc356b3b384d81fd6c79aa95860540b4',1774461530051),
-              ('ba2c3a746915605d227f9d3c47308ad6138b84258d3f18d22549366f557a3505',1774461530052),
-              ('14c40e9e42e755c184009241686870f94232b75b7440c247243219ca6c030c79',1781913600000),
-              ('22d21f78f5484b45a788cd34115676ef41367742ccb27105b8a1bcde776b8251',1782000000000),
-              ('39e249b43e5ef87a3a5056d066f1cb0ab9259cec8fa7f055691de83fb74cad8e',1782885722357);
+            $VALUES;
           "
 
           echo "Ledger rebuilt. Current ledger:"
-          PGPASSWORD="$PROD_DATABASE_PASSWORD" $PSQL "$CONN" -v ON_ERROR_STOP=1 -c "
+          PGPASSWORD="$DB_PASSWORD" $PSQL "$CONN" -v ON_ERROR_STOP=1 -c "
             select id, left(hash, 12) as hash12, created_at
             from drizzle.__drizzle_migrations order by id;
           "

--- a/.github/workflows/pr-database-compatibility-check.yml
+++ b/.github/workflows/pr-database-compatibility-check.yml
@@ -31,6 +31,8 @@ jobs:
       STAGING_DATABASE_PASSWORD: ${{ secrets.STAGING_DATABASE_PASSWORD }}
       STAGING_DATABASE_DATABASE: ${{ secrets.STAGING_DATABASE_DATABASE }}
       DATABASE_PEM_CERT: ${{ secrets.DATABASE_PEM_CERT }}
+      # Falls back to the shared cert when no staging-specific secret exists.
+      STAGING_DATABASE_PEM_CERT: ${{ secrets.STAGING_DATABASE_PEM_CERT || secrets.DATABASE_PEM_CERT }}
       LOCAL_DATABASE_HOST: 127.0.0.1
       LOCAL_DATABASE_PORT: 5432
       LOCAL_DATABASE_USER: postgres
@@ -77,12 +79,16 @@ jobs:
             "host=$LOCAL_DATABASE_HOST port=$LOCAL_DATABASE_PORT user=$LOCAL_DATABASE_USER dbname=$LOCAL_DATABASE_DATABASE sslmode=disable" \
             --file=/tmp/staging-db.sql
 
-      - name: Validate PR schema against cloned staging DB
-        id: push-check
+      # The clone carries staging's drizzle ledger (pg_dump copies
+      # drizzle.__drizzle_migrations), so replaying the ledger-based migrator
+      # here is a true dry-run of exactly what the staging step will apply.
+      # drizzle-kit push is banned in CI: its interactive enum resolver aborts
+      # without a TTY while still exiting 0, which is how prod silently drifted.
+      - name: Validate migrations against cloned staging DB
+        id: migrate-check
         working-directory: ./packages/db
-        run: bunx drizzle-kit push --config=drizzle-local.config.ts
+        run: bun run db:local:migrate
 
-        # we are using push instead of generate -> migrate because drizzle-kit is scuffed at the moment when it comes to making enums for some reason
-      - name: Push to staging if successful
+      - name: Migrate staging
         working-directory: ./packages/db
-        run: bunx drizzle-kit push --config=drizzle-staging.config.ts
+        run: bunx tsx scripts/migrate-remote-db.ts --env staging

--- a/.github/workflows/release-database-compatibility-check.yml
+++ b/.github/workflows/release-database-compatibility-check.yml
@@ -1,3 +1,5 @@
+# NOTE: vercel-deploy-on-release.yml triggers on this workflow's display name
+# via `workflow_run`. Renaming `name:` below silently stops prod deploys.
 name: Release Database Compatibility Check And Push
 
 on:
@@ -75,11 +77,16 @@ jobs:
             "host=$LOCAL_DATABASE_HOST port=$LOCAL_DATABASE_PORT user=$LOCAL_DATABASE_USER dbname=$LOCAL_DATABASE_DATABASE sslmode=disable" \
             --file=/tmp/prod-db.sql
 
-      - name: Validate release schema against cloned production DB
-        id: push-check
+      # The clone carries prod's drizzle ledger (pg_dump copies
+      # drizzle.__drizzle_migrations), so replaying the ledger-based migrator
+      # here is a true dry-run of exactly what the prod step will apply.
+      # drizzle-kit push is banned in CI: its interactive enum resolver aborts
+      # without a TTY while still exiting 0, which is how prod silently drifted.
+      - name: Validate release migrations against cloned production DB
+        id: migrate-check
         working-directory: ./packages/db
-        run: bunx drizzle-kit push --config=drizzle-local.config.ts
+        run: bun run db:local:migrate
 
-      - name: Push to production
+      - name: Migrate production
         working-directory: ./packages/db
-        run: bunx drizzle-kit push --config=drizzle-prod.config.ts
+        run: bunx tsx scripts/migrate-remote-db.ts --env prod

--- a/.github/workflows/vercel-deploy-on-release.yml
+++ b/.github/workflows/vercel-deploy-on-release.yml
@@ -5,6 +5,9 @@ env:
 
 on:
   workflow_run:
+    # Matched by DISPLAY NAME against release-database-compatibility-check.yml.
+    # If that workflow's `name:` changes without updating this list, prod
+    # deploys silently stop firing.
     workflows:
       - Release Database Compatibility Check And Push
     types:

--- a/packages/db/drizzle-staging.config.ts
+++ b/packages/db/drizzle-staging.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     database: process.env.STAGING_DATABASE_DATABASE!,
     ssl: {
       // Fall back to the shared cert — CI historically only sets DATABASE_PEM_CERT.
-      ca: process.env.STAGING_DATABASE_PEM_CERT ?? process.env.DATABASE_PEM_CERT!,
+      ca:
+        process.env.STAGING_DATABASE_PEM_CERT ?? process.env.DATABASE_PEM_CERT!,
       rejectUnauthorized: false,
     },
   },

--- a/packages/db/drizzle-staging.config.ts
+++ b/packages/db/drizzle-staging.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
     password: process.env.STAGING_DATABASE_PASSWORD,
     database: process.env.STAGING_DATABASE_DATABASE!,
     ssl: {
-      ca: process.env.STAGING_DATABASE_PEM_CERT!,
+      // Fall back to the shared cert — CI historically only sets DATABASE_PEM_CERT.
+      ca: process.env.STAGING_DATABASE_PEM_CERT ?? process.env.DATABASE_PEM_CERT!,
       rejectUnauthorized: false,
     },
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -26,6 +26,7 @@
     "db:local:down": "docker compose down",
     "db:local:wipe": "tsx scripts/wipe-local-db.ts",
     "db:local:migrate": "tsx scripts/migrate-local-db.ts",
+    "db:migrate:remote": "tsx scripts/migrate-remote-db.ts",
     "db:local:seed": "tsx scripts/seed-local-db.ts",
     "db:create-admin-farm-user": "tsx scripts/create-admin-farm-user.ts",
     "db:seed-knowledge": "tsx scripts/seed-knowledge.ts",

--- a/packages/db/scripts/import-general-imps.ts
+++ b/packages/db/scripts/import-general-imps.ts
@@ -11,29 +11,31 @@
  *      packages/db/data/general-imps.csv
  *   2. Dry run (writes nothing):   tsx scripts/import-general-imps.ts
  *   3. Commit to local DB:         tsx scripts/import-general-imps.ts --commit
+ *   4. Remote (staging/prod):      tsx scripts/import-general-imps.ts --env staging
+ *                                  ... --env staging --commit --confirm staging
  *
  * Flags:
- *   --file <path>   CSV path (default: data/general-imps.csv)
- *   --commit        Actually write to the local DB (otherwise dry-run)
+ *   --file <path>    CSV path (default: data/general-imps.csv)
+ *   --env <name>     Target DB: local (default), staging, prod
+ *   --commit         Actually write to the target DB (otherwise dry-run)
+ *   --confirm <name> Required for remote --commit; must repeat the --env value.
+ *                    Remote commits also require OPENAI_EMBEDDINGS_KEY.
  */
 
 import 'dotenv/config';
 import { readFileSync } from 'node:fs';
-import { drizzle } from 'drizzle-orm/node-postgres';
 import { eq, inArray, notInArray } from 'drizzle-orm';
 import { generalImp, knowledgeArticle } from '../src/schema';
-import {
-  embed,
-  getArg,
-  hash,
-  parseCsv,
-  requireLocalDatabaseUrl,
-  slugify,
-} from './lib/importer-lib';
+import { createTargetDb, resolveImporterTarget } from './lib/db-target';
+import { embed, getArg, hash, parseCsv, slugify } from './lib/importer-lib';
 
 // ---- CLI args -------------------------------------------------------------
 const COMMIT = process.argv.includes('--commit');
 const CSV_PATH = getArg('file') ?? 'data/general-imps.csv';
+
+// A committed run replacing the whole mirror must never proceed from a
+// truncated/garbled CSV export — the prune step would wipe the real rows.
+const MIN_IMPS = 5;
 
 // ---- helpers --------------------------------------------------------------
 /** Strip the single quotes the sheet wraps concept titles in, e.g. 'Copper'. */
@@ -93,13 +95,13 @@ function embedText(imp: ParsedImp): string {
 async function main() {
   // Validate the DB target up front so a misconfigured environment fails fast
   // on dry runs too, not only once --commit is passed.
-  const databaseUrl = requireLocalDatabaseUrl();
+  const target = resolveImporterTarget();
 
   const csv = readFileSync(CSV_PATH, 'utf8');
   const rows = parseCsv(csv);
   const imps = classify(rows);
 
-  console.log(`\nParsed ${CSV_PATH}`);
+  console.log(`\nParsed ${CSV_PATH} (target: ${target.env})`);
   console.log(`  IMPs:         ${imps.length}`);
   console.log(`  With trigger: ${imps.filter((i) => i.triggerRaw).length}`);
   console.log(`  With title:   ${imps.filter((i) => i.title).length}`);
@@ -113,12 +115,20 @@ async function main() {
 
   if (!COMMIT) {
     console.log(
-      '\nDry run only. Re-run with --commit to write to the local DB.\n'
+      `\nDry run only. Re-run with --commit to write to the ${target.env} DB` +
+        (target.env === 'local' ? '.\n' : ` (plus --confirm ${target.env}).\n`)
     );
     return;
   }
 
-  const db = drizzle(databaseUrl, { casing: 'snake_case' });
+  if (imps.length < MIN_IMPS) {
+    throw new Error(
+      `Only ${imps.length} IMPs parsed (< ${MIN_IMPS}) — the CSV looks ` +
+        'truncated or malformed. Refusing to commit and prune.'
+    );
+  }
+
+  const db = createTargetDb(target);
 
   // Slug is the stable identity used to match a sheet row to its existing DB
   // row on re-import, so it must not depend on row order. First pass counts
@@ -213,20 +223,24 @@ async function main() {
   const keptSlugs = Array.from(usedSlugs);
   if (keptSlugs.length > 0) {
     const stale = await db
-      .select({ kId: generalImp.knowledgeArticleId })
+      .select({ kId: generalImp.knowledgeArticleId, slug: generalImp.slug })
       .from(generalImp)
       .where(notInArray(generalImp.slug, keptSlugs));
-    const staleIds = stale.map((r) => r.kId);
-    if (staleIds.length > 0) {
-      await db
-        .delete(knowledgeArticle)
-        .where(inArray(knowledgeArticle.id, staleIds));
-      pruned = staleIds.length;
+    if (stale.length > 0) {
+      console.log(`\nPruning ${stale.length} stale row(s) from ${target.env}:`);
+      for (const r of stale) console.log(`  - ${r.slug}`);
+      await db.delete(knowledgeArticle).where(
+        inArray(
+          knowledgeArticle.id,
+          stale.map((r) => r.kId)
+        )
+      );
+      pruned = stale.length;
     }
   }
 
   console.log(
-    `\nCommitted: ${written} IMPs, ${embeddings} embeddings, ` +
+    `\nCommitted to ${target.env}: ${written} IMPs, ${embeddings} embeddings, ` +
       `${pruned} stale rows pruned.\n`
   );
 }

--- a/packages/db/scripts/import-general-imps.ts
+++ b/packages/db/scripts/import-general-imps.ts
@@ -24,7 +24,7 @@
 
 import 'dotenv/config';
 import { readFileSync } from 'node:fs';
-import { eq, inArray, notInArray } from 'drizzle-orm';
+import { count, eq, inArray, notInArray } from 'drizzle-orm';
 import { generalImp, knowledgeArticle } from '../src/schema';
 import { createTargetDb, resolveImporterTarget } from './lib/db-target';
 import { embed, getArg, hash, parseCsv, slugify } from './lib/importer-lib';
@@ -37,6 +37,11 @@ const CSV_PATH = getArg('file') ?? 'data/general-imps.csv';
 // truncated/garbled CSV export — the prune step would wipe the real rows.
 const MIN_IMPS = 5;
 
+// An absolute floor can't catch a partially-truncated CSV — it clears MIN_IMPS
+// yet would prune the missing rows as "stale". Also refuse to prune more than
+// this fraction of the rows already in the target, unless --allow-large-prune.
+const MAX_PRUNE_FRACTION = 0.2;
+const ALLOW_LARGE_PRUNE = process.argv.includes('--allow-large-prune');
 // ---- helpers --------------------------------------------------------------
 /** Strip the single quotes the sheet wraps concept titles in, e.g. 'Copper'. */
 function cleanTitle(s: string): string {
@@ -128,121 +133,142 @@ async function main() {
     );
   }
 
-  const db = createTargetDb(target);
-
-  // Slug is the stable identity used to match a sheet row to its existing DB
-  // row on re-import, so it must not depend on row order. First pass counts
-  // how often each base slug occurs across the whole sheet; a base slug that
-  // occurs once is used bare, while EVERY row sharing a duplicated base slug
-  // gets a suffix hashed from its own content (no first-row "winner" claims
-  // the bare slug, so reordering rows can never swap DB identities). The
-  // -2/-3 fallback only fires for the pathological case of duplicated rows
-  // with identical content (and therefore identical hashes).
-  const baseSlugOf = (imp: ParsedImp): string =>
-    slugify(imp.title ?? imp.tags[0] ?? 'imp') || 'imp';
-  const baseSlugCounts = new Map<string, number>();
-  for (const imp of imps) {
-    const base = baseSlugOf(imp);
-    baseSlugCounts.set(base, (baseSlugCounts.get(base) ?? 0) + 1);
-  }
-  const usedSlugs = new Set<string>();
-  const stableSlug = (base: string, seed: string): string => {
-    if ((baseSlugCounts.get(base) ?? 0) <= 1) {
-      usedSlugs.add(base);
-      return base;
+  const { db, close } = createTargetDb(target);
+  try {
+    // Slug is the stable identity used to match a sheet row to its existing DB
+    // row on re-import, so it must not depend on row order. First pass counts
+    // how often each base slug occurs across the whole sheet; a base slug that
+    // occurs once is used bare, while EVERY row sharing a duplicated base slug
+    // gets a suffix hashed from its own content (no first-row "winner" claims
+    // the bare slug, so reordering rows can never swap DB identities). The
+    // -2/-3 fallback only fires for the pathological case of duplicated rows
+    // with identical content (and therefore identical hashes).
+    const baseSlugOf = (imp: ParsedImp): string =>
+      slugify(imp.title ?? imp.tags[0] ?? 'imp') || 'imp';
+    const baseSlugCounts = new Map<string, number>();
+    for (const imp of imps) {
+      const base = baseSlugOf(imp);
+      baseSlugCounts.set(base, (baseSlugCounts.get(base) ?? 0) + 1);
     }
-    const suffix = hash(seed).slice(0, 8);
-    let s = `${base}-${suffix}`;
-    let n = 2;
-    while (usedSlugs.has(s)) {
-      s = `${base}-${suffix}-${n}`;
-      n += 1;
-    }
-    usedSlugs.add(s);
-    return s;
-  };
-
-  let written = 0;
-  let embeddings = 0;
-
-  for (const imp of imps) {
-    const embedInput = embedText(imp);
-    const slug = stableSlug(baseSlugOf(imp), embedInput);
-    const contentHash = hash(embedInput);
-    const fields = {
-      title: imp.title,
-      tags: imp.tags,
-      triggerRaw: imp.triggerRaw,
-      content: imp.content,
-      sourceContentHash: contentHash,
+    const usedSlugs = new Set<string>();
+    const stableSlug = (base: string, seed: string): string => {
+      if ((baseSlugCounts.get(base) ?? 0) <= 1) {
+        usedSlugs.add(base);
+        return base;
+      }
+      const suffix = hash(seed).slice(0, 8);
+      let s = `${base}-${suffix}`;
+      let n = 2;
+      while (usedSlugs.has(s)) {
+        s = `${base}-${suffix}-${n}`;
+        n += 1;
+      }
+      usedSlugs.add(s);
+      return s;
     };
 
-    const [existing] = await db
-      .select()
-      .from(generalImp)
-      .where(eq(generalImp.slug, slug))
-      .limit(1);
+    let written = 0;
+    let embeddings = 0;
 
-    // Wrap the knowledge_article + general_imp writes in a single transaction
-    // so a mid-row failure can't leave an orphan knowledge_article row (the
-    // prune step only reaches knowledge rows still owned by a general_imp).
-    if (existing) {
-      const needsReembed = existing.sourceContentHash !== contentHash;
-      const embedding = needsReembed ? await embed(embedInput) : null;
-      await db.transaction(async (tx) => {
-        if (embedding) {
+    for (const imp of imps) {
+      const embedInput = embedText(imp);
+      const slug = stableSlug(baseSlugOf(imp), embedInput);
+      const contentHash = hash(embedInput);
+      const fields = {
+        title: imp.title,
+        tags: imp.tags,
+        triggerRaw: imp.triggerRaw,
+        content: imp.content,
+        sourceContentHash: contentHash,
+      };
+
+      const [existing] = await db
+        .select()
+        .from(generalImp)
+        .where(eq(generalImp.slug, slug))
+        .limit(1);
+
+      // Wrap the knowledge_article + general_imp writes in a single transaction
+      // so a mid-row failure can't leave an orphan knowledge_article row (the
+      // prune step only reaches knowledge rows still owned by a general_imp).
+      if (existing) {
+        const needsReembed = existing.sourceContentHash !== contentHash;
+        const embedding = needsReembed ? await embed(embedInput) : null;
+        await db.transaction(async (tx) => {
+          if (embedding) {
+            await tx
+              .update(knowledgeArticle)
+              .set({ embedding })
+              .where(eq(knowledgeArticle.id, existing.knowledgeArticleId));
+          }
           await tx
-            .update(knowledgeArticle)
-            .set({ embedding })
-            .where(eq(knowledgeArticle.id, existing.knowledgeArticleId));
-        }
-        await tx
-          .update(generalImp)
-          .set(fields)
-          .where(eq(generalImp.id, existing.id));
-      });
-      if (needsReembed) embeddings += 1;
-    } else {
-      const embedding = await embed(embedInput);
-      await db.transaction(async (tx) => {
-        const [k] = await tx
-          .insert(knowledgeArticle)
-          .values({ embedding })
-          .returning({ id: knowledgeArticle.id });
-        await tx
-          .insert(generalImp)
-          .values({ knowledgeArticleId: k.id, slug, ...fields });
-      });
-      embeddings += 1;
+            .update(generalImp)
+            .set(fields)
+            .where(eq(generalImp.id, existing.id));
+        });
+        if (needsReembed) embeddings += 1;
+      } else {
+        const embedding = await embed(embedInput);
+        await db.transaction(async (tx) => {
+          const [k] = await tx
+            .insert(knowledgeArticle)
+            .values({ embedding })
+            .returning({ id: knowledgeArticle.id });
+          await tx
+            .insert(generalImp)
+            .values({ knowledgeArticleId: k.id, slug, ...fields });
+        });
+        embeddings += 1;
+      }
+      written += 1;
     }
-    written += 1;
-  }
 
-  // ---- prune stale rows (the sheet is the source of truth) ----------------
-  let pruned = 0;
-  const keptSlugs = Array.from(usedSlugs);
-  if (keptSlugs.length > 0) {
-    const stale = await db
-      .select({ kId: generalImp.knowledgeArticleId, slug: generalImp.slug })
-      .from(generalImp)
-      .where(notInArray(generalImp.slug, keptSlugs));
-    if (stale.length > 0) {
-      console.log(`\nPruning ${stale.length} stale row(s) from ${target.env}:`);
-      for (const r of stale) console.log(`  - ${r.slug}`);
-      await db.delete(knowledgeArticle).where(
-        inArray(
-          knowledgeArticle.id,
-          stale.map((r) => r.kId)
-        )
-      );
-      pruned = stale.length;
+    // ---- prune stale rows (the sheet is the source of truth) ----------------
+    let pruned = 0;
+    const keptSlugs = Array.from(usedSlugs);
+    if (keptSlugs.length > 0) {
+      const stale = await db
+        .select({ kId: generalImp.knowledgeArticleId, slug: generalImp.slug })
+        .from(generalImp)
+        .where(notInArray(generalImp.slug, keptSlugs));
+      // Relative safety net against a truncated CSV (see MAX_PRUNE_FRACTION).
+      const [{ n: existing }] = await db
+        .select({ n: count() })
+        .from(generalImp);
+      if (
+        !ALLOW_LARGE_PRUNE &&
+        existing > 0 &&
+        stale.length > existing * MAX_PRUNE_FRACTION
+      ) {
+        throw new Error(
+          `Refusing to prune ${stale.length} of ${existing} rows ` +
+            `(> ${MAX_PRUNE_FRACTION * 100}% of the target) — the CSV may be ` +
+            'truncated. Re-run with --allow-large-prune if this is intentional.'
+        );
+      }
+
+      if (stale.length > 0) {
+        console.log(
+          `\nPruning ${stale.length} stale row(s) from ${target.env}:`
+        );
+        for (const r of stale) console.log(`  - ${r.slug}`);
+        await db.delete(knowledgeArticle).where(
+          inArray(
+            knowledgeArticle.id,
+            stale.map((r) => r.kId)
+          )
+        );
+        pruned = stale.length;
+      }
     }
-  }
 
-  console.log(
-    `\nCommitted to ${target.env}: ${written} IMPs, ${embeddings} embeddings, ` +
-      `${pruned} stale rows pruned.\n`
-  );
+    console.log(
+      `\nCommitted to ${target.env}: ${written} IMPs, ${embeddings} embeddings, ` +
+        `${pruned} stale rows pruned.\n`
+    );
+  } finally {
+    await close();
+  }
 }
 
 main().catch((error) => {

--- a/packages/db/scripts/import-seed-varieties.ts
+++ b/packages/db/scripts/import-seed-varieties.ts
@@ -10,29 +10,32 @@
  *      save to packages/db/data/variety-inventory.csv
  *   2. Dry run (writes nothing):   tsx scripts/import-seed-varieties.ts
  *   3. Commit to local DB:         tsx scripts/import-seed-varieties.ts --commit
+ *   4. Remote (staging/prod):      tsx scripts/import-seed-varieties.ts --env staging
+ *                                  ... --env staging --commit --confirm staging
  *
  * Flags:
- *   --file <path>   CSV path (default: data/variety-inventory.csv)
- *   --commit        Actually write to the local DB (otherwise dry-run)
+ *   --file <path>    CSV path (default: data/variety-inventory.csv)
+ *   --env <name>     Target DB: local (default), staging, prod
+ *   --commit         Actually write to the target DB (otherwise dry-run)
+ *   --confirm <name> Required for remote --commit; must repeat the --env value.
+ *                    Remote commits also require OPENAI_EMBEDDINGS_KEY.
  */
 
 import 'dotenv/config';
 import { readFileSync } from 'node:fs';
-import { drizzle } from 'drizzle-orm/node-postgres';
 import { eq, inArray, notInArray } from 'drizzle-orm';
 import { knowledgeArticle, seedCrop, seedVariety } from '../src/schema';
-import {
-  embed,
-  getArg,
-  hash,
-  parseCsv,
-  requireLocalDatabaseUrl,
-  slugify,
-} from './lib/importer-lib';
+import { createTargetDb, resolveImporterTarget } from './lib/db-target';
+import { embed, getArg, hash, parseCsv, slugify } from './lib/importer-lib';
 
 // ---- CLI args -------------------------------------------------------------
 const COMMIT = process.argv.includes('--commit');
 const CSV_PATH = getArg('file') ?? 'data/variety-inventory.csv';
+
+// A committed run replacing the whole mirror must never proceed from a
+// truncated/garbled CSV export — the prune step would wipe the real rows.
+// The real sheet holds ~90 crops / ~940 varieties.
+const MIN_VARIETIES = 50;
 
 // ---- small helpers --------------------------------------------------------
 function isNumericCode(s: string): boolean {
@@ -169,7 +172,7 @@ function classify(rows: string[][]) {
 async function main() {
   // Validate the DB target up front so a misconfigured environment fails fast
   // on dry runs too, not only once --commit is passed.
-  const databaseUrl = requireLocalDatabaseUrl();
+  const target = resolveImporterTarget();
 
   const csv = readFileSync(CSV_PATH, 'utf8');
   const rows = parseCsv(csv);
@@ -184,7 +187,7 @@ async function main() {
   for (const c of crops)
     for (const v of c.varieties) statusCounts[v.status] += 1;
 
-  console.log(`\nParsed ${CSV_PATH}`);
+  console.log(`\nParsed ${CSV_PATH} (target: ${target.env})`);
   console.log(`  Crops:     ${crops.length}`);
   console.log(`  Varieties: ${varietyCount}`);
   console.log(
@@ -216,12 +219,21 @@ async function main() {
 
   if (!COMMIT) {
     console.log(
-      '\nDry run only. Re-run with --commit to write to the local DB.\n'
+      `\nDry run only. Re-run with --commit to write to the ${target.env} DB` +
+        (target.env === 'local' ? '.\n' : ` (plus --confirm ${target.env}).\n`)
     );
     return;
   }
 
-  const db = drizzle(databaseUrl, { casing: 'snake_case' });
+  if (crops.length === 0 || varietyCount < MIN_VARIETIES) {
+    throw new Error(
+      `Only ${crops.length} crops / ${varietyCount} varieties parsed ` +
+        `(need >= 1 crop and >= ${MIN_VARIETIES} varieties) — the CSV looks ` +
+        'truncated or malformed. Refusing to commit and prune.'
+    );
+  }
+
+  const db = createTargetDb(target);
   const usedSlugs = new Set<string>();
   const uniqueSlug = (base: string): string => {
     let s = base || 'item';
@@ -345,29 +357,32 @@ async function main() {
   if (keptSlugs.length > 0) {
     // Guard: an empty kept-set would match everything and wipe the tables.
     const staleVarieties = await db
-      .select({ kId: seedVariety.knowledgeArticleId })
+      .select({ kId: seedVariety.knowledgeArticleId, slug: seedVariety.slug })
       .from(seedVariety)
       .where(notInArray(seedVariety.slug, keptSlugs));
     const staleCrops = await db
-      .select({ kId: seedCrop.knowledgeArticleId })
+      .select({ kId: seedCrop.knowledgeArticleId, slug: seedCrop.slug })
       .from(seedCrop)
       .where(notInArray(seedCrop.slug, keptSlugs));
 
-    const staleKnowledgeIds = [
-      ...staleVarieties.map((r) => r.kId),
-      ...staleCrops.map((r) => r.kId),
-    ];
-    if (staleKnowledgeIds.length > 0) {
-      await db
-        .delete(knowledgeArticle)
-        .where(inArray(knowledgeArticle.id, staleKnowledgeIds));
-      pruned = staleKnowledgeIds.length;
+    const stale = [...staleVarieties, ...staleCrops];
+    if (stale.length > 0) {
+      console.log(`\nPruning ${stale.length} stale row(s) from ${target.env}:`);
+      for (const r of stale) console.log(`  - ${r.slug}`);
+      await db.delete(knowledgeArticle).where(
+        inArray(
+          knowledgeArticle.id,
+          stale.map((r) => r.kId)
+        )
+      );
+      pruned = stale.length;
     }
   }
 
   console.log(
-    `\nCommitted: ${cropsWritten} crops, ${varietiesWritten} varieties, ` +
-      `${embeddings} embeddings generated, ${pruned} stale rows pruned.\n`
+    `\nCommitted to ${target.env}: ${cropsWritten} crops, ` +
+      `${varietiesWritten} varieties, ${embeddings} embeddings generated, ` +
+      `${pruned} stale rows pruned.\n`
   );
 }
 

--- a/packages/db/scripts/import-seed-varieties.ts
+++ b/packages/db/scripts/import-seed-varieties.ts
@@ -23,7 +23,7 @@
 
 import 'dotenv/config';
 import { readFileSync } from 'node:fs';
-import { eq, inArray, notInArray } from 'drizzle-orm';
+import { count, eq, inArray, notInArray } from 'drizzle-orm';
 import { knowledgeArticle, seedCrop, seedVariety } from '../src/schema';
 import { createTargetDb, resolveImporterTarget } from './lib/db-target';
 import { embed, getArg, hash, parseCsv, slugify } from './lib/importer-lib';
@@ -37,6 +37,12 @@ const CSV_PATH = getArg('file') ?? 'data/variety-inventory.csv';
 // The real sheet holds ~90 crops / ~940 varieties.
 const MIN_VARIETIES = 50;
 
+// An absolute floor can't catch a CSV truncated to, say, 300 of ~940 rows — it
+// clears MIN_VARIETIES yet would prune the ~640 missing rows as "stale". So also
+// refuse to prune more than this fraction of the rows already in the target,
+// unless --allow-large-prune is passed for an intentional bulk deletion.
+const MAX_PRUNE_FRACTION = 0.2;
+const ALLOW_LARGE_PRUNE = process.argv.includes('--allow-large-prune');
 // ---- small helpers --------------------------------------------------------
 function isNumericCode(s: string): boolean {
   return /^\d+$/.test(s.trim());
@@ -233,157 +239,181 @@ async function main() {
     );
   }
 
-  const db = createTargetDb(target);
-  const usedSlugs = new Set<string>();
-  const uniqueSlug = (base: string): string => {
-    let s = base || 'item';
-    let n = 2;
-    while (usedSlugs.has(s)) {
-      s = `${base}-${n}`;
-      n += 1;
-    }
-    usedSlugs.add(s);
-    return s;
-  };
-
-  let cropsWritten = 0;
-  let varietiesWritten = 0;
-  let embeddings = 0;
-
-  for (const crop of crops) {
-    const cropSlug = uniqueSlug(slugify(crop.name));
-    const cropText = `${crop.name}\n${crop.description}`;
-    const cropHash = hash(cropText);
-
-    const [existing] = await db
-      .select()
-      .from(seedCrop)
-      .where(eq(seedCrop.slug, cropSlug))
-      .limit(1);
-
-    let cropId: number;
-    if (existing) {
-      cropId = existing.id;
-      if (existing.sourceContentHash !== cropHash) {
-        await db
-          .update(knowledgeArticle)
-          .set({ embedding: await embed(cropText) })
-          .where(eq(knowledgeArticle.id, existing.knowledgeArticleId));
-        embeddings += 1;
+  const { db, close } = createTargetDb(target);
+  try {
+    const usedSlugs = new Set<string>();
+    const uniqueSlug = (base: string): string => {
+      let s = base || 'item';
+      let n = 2;
+      while (usedSlugs.has(s)) {
+        s = `${base}-${n}`;
+        n += 1;
       }
-      await db
-        .update(seedCrop)
-        .set({
-          name: crop.name,
-          description: crop.description,
-          sourceContentHash: cropHash,
-        })
-        .where(eq(seedCrop.id, cropId));
-    } else {
-      const [k] = await db
-        .insert(knowledgeArticle)
-        .values({ embedding: await embed(cropText) })
-        .returning({ id: knowledgeArticle.id });
-      embeddings += 1;
-      const [inserted] = await db
-        .insert(seedCrop)
-        .values({
-          knowledgeArticleId: k.id,
-          name: crop.name,
-          slug: cropSlug,
-          description: crop.description,
-          sourceContentHash: cropHash,
-        })
-        .returning({ id: seedCrop.id });
-      cropId = inserted.id;
-    }
-    cropsWritten += 1;
+      usedSlugs.add(s);
+      return s;
+    };
 
-    for (const v of crop.varieties) {
-      const vSlug = uniqueSlug(`${cropSlug}-${slugify(v.name)}`);
-      const vText = `${crop.name} ${v.name}\n${v.description}`;
-      const vHash = hash(vText);
-      const fields = {
-        seedCropId: cropId,
-        name: v.name,
-        description: v.description,
-        status: v.status,
-        pricePerOzCents: v.pricePerOzCents,
-        pricePerLbCents: v.pricePerLbCents,
-        pricePerPlantCents: v.pricePerPlantCents,
-        inventoryNote: v.inventoryNote,
-        lastProduced: v.lastProduced,
-        location: v.location,
-        sourceContentHash: vHash,
-      };
+    let cropsWritten = 0;
+    let varietiesWritten = 0;
+    let embeddings = 0;
 
-      const [existingV] = await db
+    for (const crop of crops) {
+      const cropSlug = uniqueSlug(slugify(crop.name));
+      const cropText = `${crop.name}\n${crop.description}`;
+      const cropHash = hash(cropText);
+
+      const [existing] = await db
         .select()
-        .from(seedVariety)
-        .where(eq(seedVariety.slug, vSlug))
+        .from(seedCrop)
+        .where(eq(seedCrop.slug, cropSlug))
         .limit(1);
 
-      if (existingV) {
-        if (existingV.sourceContentHash !== vHash) {
+      let cropId: number;
+      if (existing) {
+        cropId = existing.id;
+        if (existing.sourceContentHash !== cropHash) {
           await db
             .update(knowledgeArticle)
-            .set({ embedding: await embed(vText) })
-            .where(eq(knowledgeArticle.id, existingV.knowledgeArticleId));
+            .set({ embedding: await embed(cropText) })
+            .where(eq(knowledgeArticle.id, existing.knowledgeArticleId));
           embeddings += 1;
         }
         await db
-          .update(seedVariety)
-          .set(fields)
-          .where(eq(seedVariety.id, existingV.id));
+          .update(seedCrop)
+          .set({
+            name: crop.name,
+            description: crop.description,
+            sourceContentHash: cropHash,
+          })
+          .where(eq(seedCrop.id, cropId));
       } else {
         const [k] = await db
           .insert(knowledgeArticle)
-          .values({ embedding: await embed(vText) })
+          .values({ embedding: await embed(cropText) })
           .returning({ id: knowledgeArticle.id });
         embeddings += 1;
-        await db
-          .insert(seedVariety)
-          .values({ knowledgeArticleId: k.id, slug: vSlug, ...fields });
+        const [inserted] = await db
+          .insert(seedCrop)
+          .values({
+            knowledgeArticleId: k.id,
+            name: crop.name,
+            slug: cropSlug,
+            description: crop.description,
+            sourceContentHash: cropHash,
+          })
+          .returning({ id: seedCrop.id });
+        cropId = inserted.id;
       }
-      varietiesWritten += 1;
-    }
-  }
-  // ---- prune stale rows (the sheet is the source of truth) ----------------
-  // Any crop/variety whose slug this run did NOT produce was removed or
-  // renamed in the sheet, so drop it. Deleting the knowledge_article row
-  // cascades to its seed_crop / seed_variety child via the FK.
-  let pruned = 0;
-  const keptSlugs = Array.from(usedSlugs);
-  if (keptSlugs.length > 0) {
-    // Guard: an empty kept-set would match everything and wipe the tables.
-    const staleVarieties = await db
-      .select({ kId: seedVariety.knowledgeArticleId, slug: seedVariety.slug })
-      .from(seedVariety)
-      .where(notInArray(seedVariety.slug, keptSlugs));
-    const staleCrops = await db
-      .select({ kId: seedCrop.knowledgeArticleId, slug: seedCrop.slug })
-      .from(seedCrop)
-      .where(notInArray(seedCrop.slug, keptSlugs));
+      cropsWritten += 1;
 
-    const stale = [...staleVarieties, ...staleCrops];
-    if (stale.length > 0) {
-      console.log(`\nPruning ${stale.length} stale row(s) from ${target.env}:`);
-      for (const r of stale) console.log(`  - ${r.slug}`);
-      await db.delete(knowledgeArticle).where(
-        inArray(
-          knowledgeArticle.id,
-          stale.map((r) => r.kId)
-        )
-      );
-      pruned = stale.length;
-    }
-  }
+      for (const v of crop.varieties) {
+        const vSlug = uniqueSlug(`${cropSlug}-${slugify(v.name)}`);
+        const vText = `${crop.name} ${v.name}\n${v.description}`;
+        const vHash = hash(vText);
+        const fields = {
+          seedCropId: cropId,
+          name: v.name,
+          description: v.description,
+          status: v.status,
+          pricePerOzCents: v.pricePerOzCents,
+          pricePerLbCents: v.pricePerLbCents,
+          pricePerPlantCents: v.pricePerPlantCents,
+          inventoryNote: v.inventoryNote,
+          lastProduced: v.lastProduced,
+          location: v.location,
+          sourceContentHash: vHash,
+        };
 
-  console.log(
-    `\nCommitted to ${target.env}: ${cropsWritten} crops, ` +
-      `${varietiesWritten} varieties, ${embeddings} embeddings generated, ` +
-      `${pruned} stale rows pruned.\n`
-  );
+        const [existingV] = await db
+          .select()
+          .from(seedVariety)
+          .where(eq(seedVariety.slug, vSlug))
+          .limit(1);
+
+        if (existingV) {
+          if (existingV.sourceContentHash !== vHash) {
+            await db
+              .update(knowledgeArticle)
+              .set({ embedding: await embed(vText) })
+              .where(eq(knowledgeArticle.id, existingV.knowledgeArticleId));
+            embeddings += 1;
+          }
+          await db
+            .update(seedVariety)
+            .set(fields)
+            .where(eq(seedVariety.id, existingV.id));
+        } else {
+          const [k] = await db
+            .insert(knowledgeArticle)
+            .values({ embedding: await embed(vText) })
+            .returning({ id: knowledgeArticle.id });
+          embeddings += 1;
+          await db
+            .insert(seedVariety)
+            .values({ knowledgeArticleId: k.id, slug: vSlug, ...fields });
+        }
+        varietiesWritten += 1;
+      }
+    }
+    // ---- prune stale rows (the sheet is the source of truth) ----------------
+    // Any crop/variety whose slug this run did NOT produce was removed or
+    // renamed in the sheet, so drop it. Deleting the knowledge_article row
+    // cascades to its seed_crop / seed_variety child via the FK.
+    let pruned = 0;
+    const keptSlugs = Array.from(usedSlugs);
+    if (keptSlugs.length > 0) {
+      // Guard: an empty kept-set would match everything and wipe the tables.
+      const staleVarieties = await db
+        .select({ kId: seedVariety.knowledgeArticleId, slug: seedVariety.slug })
+        .from(seedVariety)
+        .where(notInArray(seedVariety.slug, keptSlugs));
+      const staleCrops = await db
+        .select({ kId: seedCrop.knowledgeArticleId, slug: seedCrop.slug })
+        .from(seedCrop)
+        .where(notInArray(seedCrop.slug, keptSlugs));
+
+      const stale = [...staleVarieties, ...staleCrops];
+      // Relative safety net against a truncated CSV (see MAX_PRUNE_FRACTION).
+      const [{ n: existingCrops }] = await db
+        .select({ n: count() })
+        .from(seedCrop);
+      const [{ n: existingVarieties }] = await db
+        .select({ n: count() })
+        .from(seedVariety);
+      const existingTotal = existingCrops + existingVarieties;
+      if (
+        !ALLOW_LARGE_PRUNE &&
+        existingTotal > 0 &&
+        stale.length > existingTotal * MAX_PRUNE_FRACTION
+      ) {
+        throw new Error(
+          `Refusing to prune ${stale.length} of ${existingTotal} rows ` +
+            `(> ${MAX_PRUNE_FRACTION * 100}% of the target) — the CSV may be ` +
+            'truncated. Re-run with --allow-large-prune if this is intentional.'
+        );
+      }
+      if (stale.length > 0) {
+        console.log(
+          `\nPruning ${stale.length} stale row(s) from ${target.env}:`
+        );
+        for (const r of stale) console.log(`  - ${r.slug}`);
+        await db.delete(knowledgeArticle).where(
+          inArray(
+            knowledgeArticle.id,
+            stale.map((r) => r.kId)
+          )
+        );
+        pruned = stale.length;
+      }
+    }
+    console.log(
+      `\nCommitted to ${target.env}: ${cropsWritten} crops, ` +
+        `${varietiesWritten} varieties, ${embeddings} embeddings generated, ` +
+        `${pruned} stale rows pruned.\n`
+    );
+  } finally {
+    await close();
+  }
 }
 
 main().catch((error) => {

--- a/packages/db/scripts/lib/db-target.ts
+++ b/packages/db/scripts/lib/db-target.ts
@@ -1,0 +1,115 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * @fileoverview
+ * Resolves which database a script talks to: the local Docker instance
+ * (default, unchanged behavior) or staging/prod via an explicit `--env` flag.
+ * Remote writes are gated behind `--confirm <env>` so nobody points a
+ * table-rebuilding importer at production by accident.
+ */
+
+import type { PoolConfig } from 'pg';
+import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { getArg, requireLocalDatabaseUrl } from './importer-lib';
+
+export type DbEnv = 'local' | 'staging' | 'prod';
+export type RemoteDbEnv = Exclude<DbEnv, 'local'>;
+
+/**
+ * Normalizes a PEM certificate that may arrive quote-wrapped and/or with
+ * escaped newlines (both storage formats exist across our GitHub secrets and
+ * .env files — see the equivalent sed in pr-database-compatibility-check.yml).
+ */
+export function normalizePemCert(raw: string): string {
+  return raw
+    .replace(/^"/, '')
+    .replace(/"$/, '')
+    .replace(/\\n/g, '\n')
+    .replace(/\r/g, '');
+}
+
+function requireEnvVar(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not set — required to connect to this DB.`);
+  }
+  return value;
+}
+
+/**
+ * Builds a node-postgres PoolConfig for staging or prod from the
+ * STAGING_DATABASE_* / PROD_DATABASE_* env vars.
+ *
+ * TLS validates the CA chain but skips hostname verification (the psql
+ * `verify-ca` posture both DB workflows already use for pg_dump); never
+ * downgrade to `rejectUnauthorized: false`, which would skip the chain too.
+ */
+export function resolveRemoteDbConfig(env: RemoteDbEnv): PoolConfig {
+  const prefix = env === 'prod' ? 'PROD_DATABASE' : 'STAGING_DATABASE';
+  const caRaw =
+    env === 'staging'
+      ? (process.env.STAGING_DATABASE_PEM_CERT ??
+        requireEnvVar('DATABASE_PEM_CERT'))
+      : requireEnvVar('DATABASE_PEM_CERT');
+  return {
+    host: requireEnvVar(`${prefix}_HOST`),
+    port: Number(requireEnvVar(`${prefix}_PORT`)),
+    user: requireEnvVar(`${prefix}_USER`),
+    password: requireEnvVar(`${prefix}_PASSWORD`),
+    database: requireEnvVar(`${prefix}_DATABASE`),
+    ssl: {
+      ca: normalizePemCert(caRaw),
+      rejectUnauthorized: true,
+      checkServerIdentity: () => undefined,
+    },
+  };
+}
+
+export interface ImporterTarget {
+  env: DbEnv;
+  connection: string | PoolConfig;
+}
+
+/**
+ * Resolves the importer's target DB from CLI flags:
+ *   (no flag) / --env local   -> local Docker DB (localhost guard, as before)
+ *   --env staging|prod        -> remote; dry runs need nothing further, but
+ *                                --commit additionally requires:
+ *                                  --confirm <same env>  (typed-name guard)
+ *                                  OPENAI_EMBEDDINGS_KEY (placeholder
+ *                                  embeddings must never reach a shared DB)
+ */
+export function resolveImporterTarget(): ImporterTarget {
+  const env = (getArg('env') ?? 'local') as DbEnv;
+  if (!['local', 'staging', 'prod'].includes(env)) {
+    throw new Error(`Unknown --env "${env}" — expected local, staging, prod.`);
+  }
+  if (env === 'local') {
+    return { env, connection: requireLocalDatabaseUrl() };
+  }
+
+  if (process.argv.includes('--commit')) {
+    const confirm = getArg('confirm');
+    if (confirm !== env) {
+      throw new Error(
+        `Refusing --commit against ${env}: pass --confirm ${env} to prove ` +
+          `the target is intentional (got "${confirm ?? ''}").`
+      );
+    }
+    if (!process.env.OPENAI_EMBEDDINGS_KEY) {
+      throw new Error(
+        `Refusing --commit against ${env} without OPENAI_EMBEDDINGS_KEY: ` +
+          'placeholder embeddings would poison semantic search for everyone.'
+      );
+    }
+  }
+  return { env, connection: resolveRemoteDbConfig(env) };
+}
+
+/** Opens a drizzle handle for a resolved importer target. */
+export function createTargetDb(target: ImporterTarget) {
+  return typeof target.connection === 'string'
+    ? drizzle(target.connection, { casing: 'snake_case' })
+    : drizzle(new Pool(target.connection), { casing: 'snake_case' });
+}

--- a/packages/db/scripts/lib/db-target.ts
+++ b/packages/db/scripts/lib/db-target.ts
@@ -107,9 +107,18 @@ export function resolveImporterTarget(): ImporterTarget {
   return { env, connection: resolveRemoteDbConfig(env) };
 }
 
-/** Opens a drizzle handle for a resolved importer target. */
+/**
+ * Opens a drizzle handle for a resolved importer target, plus a `close()` that
+ * ends the underlying pool. Callers MUST await close() (e.g. in a finally),
+ * otherwise the pooled connections keep the Node process alive until the DB's
+ * idle timeout — remote importer runs would appear to hang after finishing.
+ */
 export function createTargetDb(target: ImporterTarget) {
-  return typeof target.connection === 'string'
-    ? drizzle(target.connection, { casing: 'snake_case' })
-    : drizzle(new Pool(target.connection), { casing: 'snake_case' });
+  if (typeof target.connection === 'string') {
+    const db = drizzle(target.connection, { casing: 'snake_case' });
+    return { db, close: () => db.$client.end() };
+  }
+  const pool = new Pool(target.connection);
+  const db = drizzle(pool, { casing: 'snake_case' });
+  return { db, close: () => pool.end() };
 }

--- a/packages/db/scripts/migrate-remote-db.ts
+++ b/packages/db/scripts/migrate-remote-db.ts
@@ -24,7 +24,9 @@ import { resolveRemoteDbConfig } from './lib/db-target';
 async function main() {
   const env = getArg('env');
   if (env !== 'staging' && env !== 'prod') {
-    throw new Error('Usage: tsx scripts/migrate-remote-db.ts --env staging|prod');
+    throw new Error(
+      'Usage: tsx scripts/migrate-remote-db.ts --env staging|prod'
+    );
   }
 
   // No CREATE EXTENSION here (unlike migrate-local-db.ts): staging/prod

--- a/packages/db/scripts/migrate-remote-db.ts
+++ b/packages/db/scripts/migrate-remote-db.ts
@@ -1,0 +1,64 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * @fileoverview
+ * Applies the committed drizzle migrations to staging or prod using the
+ * ledger-based drizzle-orm migrator (the same mechanism as
+ * migrate-local-db.ts). This replaces `drizzle-kit push` in CI, whose
+ * interactive enum resolver aborts in a TTY-less runner while still exiting 0
+ * — the silent no-op that let prod drift behind main.
+ *
+ * Usage: tsx scripts/migrate-remote-db.ts --env staging|prod
+ * (run from packages/db; requires STAGING_DATABASE_* / PROD_DATABASE_* and
+ * the CA cert env vars — see scripts/lib/db-target.ts)
+ */
+
+import 'dotenv/config';
+import { readFileSync } from 'node:fs';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import { Pool } from 'pg';
+import { getArg } from './lib/importer-lib';
+import { resolveRemoteDbConfig } from './lib/db-target';
+
+async function main() {
+  const env = getArg('env');
+  if (env !== 'staging' && env !== 'prod') {
+    throw new Error('Usage: tsx scripts/migrate-remote-db.ts --env staging|prod');
+  }
+
+  // No CREATE EXTENSION here (unlike migrate-local-db.ts): staging/prod
+  // already have vector + citext, and the CI role may lack the privilege.
+  const pool = new Pool(resolveRemoteDbConfig(env));
+  try {
+    const db = drizzle(pool, { casing: 'snake_case' });
+    await migrate(db, { migrationsFolder: 'drizzle' });
+
+    // Belt and braces: the ledger must now cover every committed migration.
+    // A mismatch means something applied fewer migrations than the journal
+    // claims — fail loudly instead of letting the schema drift silently.
+    const journal = JSON.parse(
+      readFileSync('drizzle/meta/_journal.json', 'utf8')
+    ) as { entries: unknown[] };
+    const { rows } = await pool.query<{ count: number }>(
+      'select count(*)::int as count from drizzle.__drizzle_migrations'
+    );
+    const ledgerCount = rows[0].count;
+    if (ledgerCount !== journal.entries.length) {
+      throw new Error(
+        `Ledger on ${env} has ${ledgerCount} entries but the committed ` +
+          `journal has ${journal.entries.length} — schema and ledger disagree.`
+      );
+    }
+    console.log(
+      `Migrated ${env}: ledger at ${ledgerCount}/${journal.entries.length} entries.`
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((error) => {
+  console.error('Remote migration failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

Prod silently drifted behind `main` because CI applied schema changes with `drizzle-kit push`, which aborts on its interactive enum resolver in a TTY-less runner while still exiting 0 — the "Push to production" step reported success while applying nothing (that's how `/v` broke on a missing `seed_variety` table). This PR removes that failure mode and finishes the plumbing needed to roll out `general_imp` (migration 0014) + its data to staging and prod.

## What

- **New `packages/db/scripts/migrate-remote-db.ts`** (`--env staging|prod`): applies committed migrations with the ledger-based drizzle-orm migrator (same mechanism as `migrate-local-db.ts`), then asserts the ledger covers every journal entry. Any failure exits non-zero.
- **CI workflows now migrate instead of push.** Both the main-push (staging) and release (prod) DB workflows run the migrator against the pg_dump clone first (a true dry-run — the clone carries the ledger) and then against the real database. The stale "push because drizzle-kit is scuffed" path is gone.
- **Reconcile workflow is environment-aware.** `prod-db-reconcile.yml` → `db-reconcile.yml` with a required `environment` input (`staging`/`prod`); adds a `knowledge_article` baseline probe (refuses to run against a wrong/empty DB) and builds the ledger rebuild rows at runtime from `meta/_journal.json` + `sha256sum` (verified byte-identical to the previously hardcoded 15 rows) so 0015+ never require editing the workflow.
- **Importers gain a guarded remote mode** via `scripts/lib/db-target.ts`: `--env staging|prod` for dry runs; committing remotely additionally requires `--confirm <env>` and `OPENAI_EMBEDDINGS_KEY` (placeholder embeddings must never reach a shared DB), plus a parsed-row floor so a truncated CSV export can't prune a live mirror. Default local behavior unchanged.
- **Fixes:** `STAGING_DATABASE_PEM_CERT` was read by `drizzle-staging.config.ts` but never set in CI (now falls back to `DATABASE_PEM_CERT`); documented the display-name coupling between the release workflow and `vercel-deploy-on-release.yml`.

## Verification

- `tsc --noEmit`, `eslint`, and the package test suites pass.
- Fresh local DB: migrator applies 0000–0014, ledger = 15 entries, `general_imp` exists; re-run is a no-op; bad target/credentials exit 1 loudly.
- Importer gates verified: missing `--confirm`, wrong `--env`, and missing `OPENAI_EMBEDDINGS_KEY` all refuse before touching anything; remote dry-run parses without connecting.
- Runtime-generated ledger rows match the old hardcoded values exactly.

## Rollout (after merge)

1. The main-push staging workflow will fail red once — expected, staging has no ledger yet.
2. Actions → **DB Reconcile**: `prod` `verify` → `apply`, then `staging` `verify` → `apply` (creates `general_imp` + rebuilds ledgers).
3. Re-run **Database Compatibility Check** — should be green end-to-end.
4. Cut a release → prod migrates (no-op) → Vercel deploy chains as before.
5. Load the 33 IMPs per env: `bunx tsx scripts/import-general-imps.ts --env staging` (dry run) then `--commit --confirm staging`; repeat for `prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)