### PR TITLE
Fix missing OpenAI embeddings key handling

### DIFF
--- a/packages/db/src/utils/get-embedding.ts
+++ b/packages/db/src/utils/get-embedding.ts
@@ -4,8 +4,14 @@ import OpenAI from 'openai';
 
 const OPENAI_API_KEY = process.env.OPENAI_EMBEDDINGS_KEY;
 
+if (!OPENAI_API_KEY) {
+  throw new Error(
+    'Missing OPENAI_EMBEDDINGS_KEY. Set it in apps/site/.env.local for local development and in Vercel environment variables for deployed environments.'
+  );
+}
+
 const openai = new OpenAI({
-  apiKey: OPENAI_API_KEY ?? 'NOTAKEY',
+  apiKey: OPENAI_API_KEY,
 });
 
 export async function getEmbedding(text: string): Promise<number[]> {


### PR DESCRIPTION
## Description

Fixes #1004

Removes the `NOTAKEY` fallback for `OPENAI_EMBEDDINGS_KEY` in the OpenAI embeddings client setup.

Previously, when `OPENAI_EMBEDDINGS_KEY` was missing, the app initialized the OpenAI client with the placeholder value `NOTAKEY`, causing inference search to fail later with a generic OpenAI/auth error. This change fails early with a clear missing environment variable error, making the root cause easier to diagnose in logs.

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
  - Not applicable; this is an environment variable guard/config handling change.
- [ ] You've included inline docs for your change, where applicable.
  - Not applicable; the thrown error message documents the required env var.
- [ ] Any components that you've modified are accessible.
  - Not applicable; no UI components were modified.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate