### PR TITLE
feat(site): on-demand revalidation webhook for Sanity content

### DIFF
--- a/apps/site/env.example
+++ b/apps/site/env.example
@@ -83,6 +83,11 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="pk_test_your_key_here"
 # Stripe webhook signing secret for /api/stripe/webhook. Private.
 STRIPE_WEBHOOK_SECRET="whsec_your_webhook_secret_here"
 
+# Shared secret for the Sanity on-demand revalidation webhook (/api/revalidate). Private.
+# Generate with `openssl rand -hex 32`; the same value goes in the Sanity webhook's
+# x-revalidate-secret header (sanity.io/manage -> API -> Webhooks).
+SANITY_REVALIDATE_SECRET="your-random-secret-here"
+
 # SMTP settings for internal seed-order notifications. Optional until email delivery is configured.
 ORDER_EMAIL_HOST="smtp.example.com"
 ORDER_EMAIL_PORT="587"

--- a/apps/site/src/app/api/revalidate/route.test.ts
+++ b/apps/site/src/app/api/revalidate/route.test.ts
@@ -1,0 +1,65 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from './route';
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { warn: vi.fn(), error: vi.fn() },
+  logger: { warn: vi.fn(), error: vi.fn() },
+}));
+
+import { revalidatePath } from 'next/cache';
+
+function makeRequest(secret?: string, body?: unknown): Request {
+  return new Request('http://localhost/api/revalidate', {
+    method: 'POST',
+    headers: secret ? { 'x-revalidate-secret': secret } : {},
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe('POST /api/revalidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('SANITY_REVALIDATE_SECRET', 'test-secret');
+  });
+
+  it('returns 503 when the secret is not configured', async () => {
+    vi.stubEnv('SANITY_REVALIDATE_SECRET', '');
+    const res = await POST(makeRequest('test-secret'));
+    expect(res.status).toBe(503);
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for a missing or wrong secret', async () => {
+    const missing = await POST(makeRequest());
+    expect(missing.status).toBe(401);
+
+    const wrong = await POST(makeRequest('nope'));
+    expect(wrong.status).toBe(401);
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('revalidates the whole route cache with a valid secret', async () => {
+    const res = await POST(makeRequest('test-secret', { _type: 'news' }));
+    expect(res.status).toBe(200);
+    expect(revalidatePath).toHaveBeenCalledWith('/', 'layout');
+    const json = (await res.json()) as {
+      revalidated: boolean;
+      documentType: string | null;
+    };
+    expect(json.revalidated).toBe(true);
+    expect(json.documentType).toBe('news');
+  });
+
+  it('handles a missing body gracefully', async () => {
+    const res = await POST(makeRequest('test-secret'));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { documentType: string | null };
+    expect(json.documentType).toBeNull();
+  });
+});

--- a/apps/site/src/app/api/revalidate/route.ts
+++ b/apps/site/src/app/api/revalidate/route.ts
@@ -1,0 +1,65 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import logger from '@/lib/logger';
+import { revalidatePath } from 'next/cache';
+import { NextResponse } from 'next/server';
+
+/**
+ * Reads the shared secret that authenticates Sanity webhook calls.
+ *
+ * @returns {string | undefined} - The configured secret, or undefined when not set
+ */
+function getRevalidateSecret(): string | undefined {
+  return process.env.SANITY_REVALIDATE_SECRET;
+}
+
+/**
+ * On-demand ISR revalidation endpoint for Sanity content changes.
+ *
+ * Sanity calls this webhook whenever a document is published, unpublished, or
+ * deleted, so content edits appear on the site immediately instead of waiting
+ * out the listing revalidation window. The caller must present the shared
+ * secret in the `x-revalidate-secret` header. The whole route cache is purged
+ * (`revalidatePath('/', 'layout')`) — content changes are infrequent enough
+ * that a full purge is simpler and safer than per-path mapping.
+ *
+ * Setup: create a webhook in sanity.io/manage (dataset `production`, on
+ * create/update/delete) pointing at `/api/revalidate` with the header
+ * `x-revalidate-secret: $SANITY_REVALIDATE_SECRET`, and set the same value in
+ * the Vercel environment.
+ *
+ * @param {Request} request - The incoming webhook request
+ * @returns {Promise<NextResponse>} - JSON result with revalidation status
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  const secret = getRevalidateSecret();
+  if (!secret) {
+    logger.error('SANITY_REVALIDATE_SECRET is not configured.');
+    return NextResponse.json(
+      { error: 'Revalidation is not configured' },
+      { status: 503 }
+    );
+  }
+
+  const provided = request.headers.get('x-revalidate-secret');
+  if (provided !== secret) {
+    return NextResponse.json({ error: 'Invalid secret' }, { status: 401 });
+  }
+
+  let documentType: string | undefined;
+  try {
+    const body = (await request.json()) as { _type?: string };
+    documentType = typeof body._type === 'string' ? body._type : undefined;
+  } catch {
+    // Body is optional — Sanity payload shape is not required for a full purge.
+  }
+
+  revalidatePath('/', 'layout');
+  logger.warn('Sanity revalidation triggered', { documentType });
+
+  return NextResponse.json({
+    revalidated: true,
+    documentType: documentType ?? null,
+    now: Date.now(),
+  });
+}


### PR DESCRIPTION
## Summary

Content edits currently wait out ISR windows (60-minute listings, 24-hour sitemaps) before appearing on the live site. This PR adds `POST /api/revalidate` so a Sanity webhook can purge the route cache the moment a document is published, unpublished, or deleted — publish in Studio, live in seconds.

## How it works

- Sanity webhook calls `POST /api/revalidate` with an `x-revalidate-secret` header
- Route validates the secret against `SANITY_REVALIDATE_SECRET` (503 if unconfigured, 401 on mismatch)
- On success, purges the full route cache via `revalidatePath('/', 'layout')` — content changes are infrequent enough that a full purge is simpler and safer than per-path mapping
- Logs the triggering document type; tolerates missing/invalid body

## Deploy steps (after merge)

1. Set `SANITY_REVALIDATE_SECRET` in Vercel env (any long random string)
2. In [sanity.io/manage](https://www.sanity.io/manage) → project `website` → API → Webhooks: create a webhook on dataset `production` for create/update/delete, URL `https://toddagriscience.com/api/revalidate`, with HTTP header `x-revalidate-secret: <same value>`

## Testing

- 4 unit tests: unconfigured (503), missing/wrong secret (401), success + full-purge call, missing body
- `bun validate` passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)