### PR TITLE
fix: pin third-party GitHub Actions to immutable commit SHAs 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 #v6
         with:
           node-version: '20'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
         with:
           bun-version: 'latest'
 
@@ -38,7 +38,7 @@ jobs:
         run: bun run build-storybook
 
       - name: Upload Next.js build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
         if: always()
         with:
           name: nextjs-build
@@ -48,7 +48,7 @@ jobs:
           retention-days: 7
 
       - name: Upload Storybook build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
         if: always()
         with:
           name: storybook-build

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 #v6
         with:
           node-version: '20'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
         with:
           bun-version: 'latest'
 

--- a/.github/workflows/db-reconcile.yml
+++ b/.github/workflows/db-reconcile.yml
@@ -53,7 +53,7 @@ jobs:
       STAGING_DATABASE_PEM_CERT: ${{ secrets.STAGING_DATABASE_PEM_CERT || secrets.DATABASE_PEM_CERT }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
 
       - name: Install PostgreSQL 18 client
         run: |

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 
@@ -38,12 +38,12 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Wait for status checks to complete
-        uses: lewagon/wait-on-check-action@v1.8.0
+        uses: lewagon/wait-on-check-action@eb1f8d8fb8af5d2d3c1978a3fae7ef38eaa587e8 # v1.8.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-regexp: '^(Code Quality Checks|Unit Tests|Build Application|Security Audit)$'

--- a/.github/workflows/pr-database-compatibility-check.yml
+++ b/.github/workflows/pr-database-compatibility-check.yml
@@ -40,10 +40,10 @@ jobs:
       LOCAL_DATABASE_DATABASE: nightcrawler_validation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install PostgreSQL 18 client
         run: |

--- a/.github/workflows/release-database-compatibility-check.yml
+++ b/.github/workflows/release-database-compatibility-check.yml
@@ -40,10 +40,10 @@ jobs:
       LOCAL_DATABASE_DATABASE: nightcrawler_validation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
 
       - name: Install PostgreSQL 18 client
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
         with:
           bun-version: 'latest'
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 #v6
         with:
           node-version: '20'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
         with:
           bun-version: 'latest'
 
@@ -32,7 +32,7 @@ jobs:
         run: bun run --filter @nightcrawler/site test:coverage
 
       - name: Upload test coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           file: ./apps/site/coverage/lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/vercel-deploy-on-hotfix-push.yml
+++ b/.github/workflows/vercel-deploy-on-hotfix-push.yml
@@ -13,8 +13,8 @@ jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
       - name: Install Vercel CLI
         run: bun install --global vercel@latest
       - name: Pull Vercel Environment Information

--- a/.github/workflows/vercel-deploy-on-release.yml
+++ b/.github/workflows/vercel-deploy-on-release.yml
@@ -18,8 +18,8 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
       - name: Install Vercel CLI
         run: bun i --global vercel@latest
       - name: Pull Vercel Environment Information


### PR DESCRIPTION
## Description

Pinned all third-party and GitHub-official Actions in .github/workflows/ from mutable version tags (e.g. @v5) to immutable commit SHAs (e.g. @abc123... # v5). This prevents a repointed or compromised tag from injecting unreviewed code into CI runs. No logic or behavior was changed — this is a security hygiene update only.

Fixes #1015 

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] Any components that you've modified are accessible.
- [ ] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
