### PR TITLE
fix(deps): override adm-zip to 0.6.0 for high audit failure

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -220,6 +220,7 @@
   "overrides": {
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "@grpc/grpc-js": "^1.14.4",
+    "adm-zip": "^0.6.0",
     "basic-ftp": "^5.3.1",
     "dompurify": "3.3.2",
     "esbuild": "^0.28.1",
@@ -1744,7 +1745,7 @@
 
     "acorn-loose": ["acorn-loose@8.5.2", "", { "dependencies": { "acorn": "^8.15.0" } }, "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A=="],
 
-    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+    "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "form-data": "^4.0.6",
     "ws": "^8.21.0",
     "nodemailer": "^9.0.1",
-    "linkify-it": "^5.0.1"
+    "linkify-it": "^5.0.1",
+    "adm-zip": "^0.6.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
Added only an adm-zip override to ^0.6.0 (the high audit failure)
Bump the Sanity runtime-cli transitive adm-zip past GHSA-xcpc-8h2w-3j85 so bun audit --audit-level=high passes.
