### PR TITLE
Update brace-expansion dependency to version 5.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "esbuild": "^0.28.1",
     "fast-uri": "^3.1.3",
     "minimatch": "^10.2.3",
-    "brace-expansion": "^5.0.7",
+    "brace-expansion": "^5.0.8",
     "markdown-it": "^14.1.1",
     "picomatch": "^4.0.4",
     "rollup": "^4.59.0",


### PR DESCRIPTION
updated brace-expansion to version 5.0.8 because of High vulnerability.

## Description

Fixes #{issue number}

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] Any components that you've modified are accessible.
- [ ] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
