### PR TITLE
feat(site): add back navigation to account subpages

### DIFF
--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/farm/profile/page.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/farm/profile/page.tsx
@@ -24,6 +24,7 @@ export default async function FarmProfilePage() {
       <AccountInfo
         title="Farm profile"
         description="Edit farm profile details."
+        backHref="/account"
       >
         <p className="text-sm text-[#ff4d00]">
           User is not associated with a farm.
@@ -57,7 +58,7 @@ export default async function FarmProfilePage() {
     .limit(1);
 
   return (
-    <AccountInfo title="Farm profile">
+    <AccountInfo title="Farm profile" backHref="/account">
       <AccountInfoSection title="Overview">
         <AccountInfoRow
           label="Management date"

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/page.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/page.tsx
@@ -45,6 +45,7 @@ export default async function ManagementZonePage({
           ? 'Edit management zone details.'
           : 'View management zone details.'
       }
+      backHref="/account/management-zones"
     >
       <ManagementZoneForm
         zone={curManagementZone}

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/page.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/page.tsx
@@ -12,7 +12,7 @@ export default async function AccountManagementPage() {
   const managementZones = await getManagementZones();
 
   return (
-    <AccountInfo title="Management Zones">
+    <AccountInfo title="Management Zones" backHref="/account">
       {managementZones.length === 0 ? (
         <AccountInfoSection title={toDisplayValue()}>
           <AccountInfoRow label="Nickname" value={toDisplayValue()} />

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/privacy/page.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/privacy/page.tsx
@@ -7,7 +7,11 @@ import AccountInfo, {
 
 export default function AccountPrivacyPage() {
   return (
-    <AccountInfo title="Privacy" description="Manage how your data is used.">
+    <AccountInfo
+      title="Privacy"
+      description="Manage how your data is used."
+      backHref="/account"
+    >
       <div className="border-t border-[#D9D9D9]">
         <AccountInfoRow label="Personal Information Sharing" value="Disabled" />
         <AccountInfoRow

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/security/page.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/security/page.tsx
@@ -10,6 +10,7 @@ export default function AccountSecurityPage() {
     <AccountInfo
       title="Security"
       description="Keep your Todd account secure with additional layers of protection."
+      backHref="/account"
     >
       <div className="border-t border-black/20">
         <div className="flex min-h-11 items-center justify-between gap-4 border-b border-black/20 py-1">

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/users/page.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/users/page.tsx
@@ -12,7 +12,7 @@ export default async function AccountUsersPage() {
   const ownerData = accountUsersData.owner;
 
   return (
-    <AccountInfo title="User information">
+    <AccountInfo title="User information" backHref="/account">
       <AccountInfoSection title="Principal operator">
         <AccountInfoRow label="Name" value={principalOperator.firstName} />
         <AccountInfoRow label="Email Address" value={principalOperator.email} />

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.stories.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.stories.tsx
@@ -1,0 +1,70 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import AccountInfo, {
+  AccountInfoRow,
+  AccountInfoSection,
+} from './account-info';
+
+const meta: Meta<typeof AccountInfo> = {
+  title: 'Account/AccountInfo',
+  component: AccountInfo,
+  parameters: {
+    layout: 'padded',
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/account/privacy',
+      },
+    },
+    docs: {
+      description: {
+        component:
+          'Section wrapper shared by every /account page. Subpages pass `backHref` to render a link back to their parent section; the /account index omits it, since the account header already links home.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AccountInfo>;
+
+export const WithBackLink: Story = {
+  args: {
+    title: 'Privacy',
+    description: 'Manage how your data is used.',
+    backHref: '/account',
+    children: (
+      <div className="border-t border-[#D9D9D9]">
+        <AccountInfoRow label="Personal Information Sharing" value="Disabled" />
+        <AccountInfoRow label="Privacy Policy" value="View" href="/privacy" />
+      </div>
+    ),
+  },
+};
+
+export const WithoutBackLink: Story = {
+  args: {
+    title: 'Account',
+    description: 'The /account index needs no back link.',
+    children: (
+      <AccountInfoSection title="Overview">
+        <AccountInfoRow label="Farm" value="Example Farm" />
+      </AccountInfoSection>
+    ),
+  },
+};
+
+export const CustomBackLabel: Story = {
+  args: {
+    title: 'North field',
+    description: 'View management zone details.',
+    backHref: '/account/management-zones',
+    backLabel: 'Management zones',
+    children: (
+      <AccountInfoSection title="Overview">
+        <AccountInfoRow label="Acreage" value="42" />
+      </AccountInfoSection>
+    ),
+  },
+};

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.test.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.test.tsx
@@ -1,0 +1,62 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import AccountInfo from './account-info';
+
+describe('AccountInfo', () => {
+  it('renders a back link to the parent route when backHref is set', () => {
+    render(
+      <AccountInfo title="Privacy" backHref="/account">
+        <p>content</p>
+      </AccountInfo>
+    );
+
+    expect(screen.getByRole('link', { name: 'Back' })).toHaveAttribute(
+      'href',
+      '/account'
+    );
+  });
+
+  it('omits the back link when backHref is not set', () => {
+    render(
+      <AccountInfo title="Account">
+        <p>content</p>
+      </AccountInfo>
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('uses a custom backLabel when provided', () => {
+    render(
+      <AccountInfo
+        title="Zone detail"
+        backHref="/account/management-zones"
+        backLabel="Management zones"
+      >
+        <p>content</p>
+      </AccountInfo>
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Management zones' })
+    ).toHaveAttribute('href', '/account/management-zones');
+    expect(
+      screen.queryByRole('link', { name: 'Back' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the title and optional description', () => {
+    render(
+      <AccountInfo title="Security" description="Keep your account secure.">
+        <p>content</p>
+      </AccountInfo>
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Security', level: 2 })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Keep your account secure.')).toBeInTheDocument();
+  });
+});

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.test.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.test.tsx
@@ -25,6 +25,9 @@ describe('AccountInfo', () => {
       </AccountInfo>
     );
 
+    expect(
+      screen.queryByRole('link', { name: 'Back' })
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
@@ -45,6 +48,19 @@ describe('AccountInfo', () => {
     expect(
       screen.queryByRole('link', { name: 'Back' })
     ).not.toBeInTheDocument();
+  });
+
+  it('falls back to the default label when backLabel is blank', () => {
+    render(
+      <AccountInfo title="Privacy" backHref="/account" backLabel="   ">
+        <p>content</p>
+      </AccountInfo>
+    );
+
+    expect(screen.getByRole('link', { name: 'Back' })).toHaveAttribute(
+      'href',
+      '/account'
+    );
   });
 
   it('renders the title and optional description', () => {

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.tsx
@@ -45,7 +45,7 @@ export default function AccountInfo({
           className="text-muted-foreground mb-4 inline-flex items-center gap-2 text-sm hover:opacity-70"
         >
           <BiArrowBack className="size-4" aria-hidden="true" />
-          <span>{backLabel}</span>
+          <span>{backLabel?.trim() || 'Back'}</span>
         </Link>
       ) : null}
       <h2 className="text-foreground text-3xl leading-none">{title}</h2>

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.tsx
@@ -20,7 +20,8 @@ const statusStyles: Record<AccountInfoStatusTone, string> = {
  * @param props.title - Heading rendered at the top of the section
  * @param props.description - Optional italic subtitle below the heading
  * @param props.backHref - Optional parent route; renders a back link when set
- * @param props.backLabel - Visible text for the back link, defaults to `Back`
+ * @param props.backLabel - Visible text for the back link. Falls back to `Back`
+ *   when omitted or blank, so the link always has an accessible name
  * @param props.children - Section body content
  * @returns The account section wrapper
  */

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import type { ReactNode } from 'react';
+import { BiArrowBack } from 'react-icons/bi';
 
 type AccountInfoStatusTone = 'success' | 'warning';
 
@@ -10,17 +11,43 @@ const statusStyles: Record<AccountInfoStatusTone, string> = {
   warning: 'text-[#ff4d00]',
 };
 
+/**
+ * Section wrapper shared by every `/account` page.
+ *
+ * Pass `backHref` on subpages to render a link back to their parent section;
+ * the `/account` index omits it, since the account header already links home.
+ *
+ * @param props.title - Heading rendered at the top of the section
+ * @param props.description - Optional italic subtitle below the heading
+ * @param props.backHref - Optional parent route; renders a back link when set
+ * @param props.backLabel - Visible text for the back link, defaults to `Back`
+ * @param props.children - Section body content
+ * @returns The account section wrapper
+ */
 export default function AccountInfo({
   title,
   description,
+  backHref,
+  backLabel = 'Back',
   children,
 }: {
   title: string;
   description?: string;
+  backHref?: string;
+  backLabel?: string;
   children: ReactNode;
 }) {
   return (
     <section className="w-full max-w-[568px]">
+      {backHref ? (
+        <Link
+          href={backHref}
+          className="text-muted-foreground mb-4 inline-flex items-center gap-2 text-sm hover:opacity-70"
+        >
+          <BiArrowBack className="size-4" aria-hidden="true" />
+          <span>{backLabel}</span>
+        </Link>
+      ) : null}
       <h2 className="text-foreground text-3xl leading-none">{title}</h2>
       {description ? (
         <p className="text-foreground mt-6 text-sm font-light italic">


### PR DESCRIPTION
## Description

Fixes #763

Adds optional `backHref` and `backLabel` props to `AccountInfo`, the wrapper shared by every `/account` page. Each subpage passes its parent route; the `/account` index omits the prop, since the account header already links home.

Reuses the existing back-arrow pattern from `account-header.tsx` (`BiArrowBack` from react-icons). The icon is marked `aria-hidden` since the adjacent text carries the meaning.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used conventional commits where appropriate