### PR TITLE
fix(site): keep the footer location label out of the language button

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/footer/footer.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/footer/footer.test.tsx
@@ -1,6 +1,11 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import { screen, renderWithNextIntl } from '@/test/test-utils';
+import {
+  screen,
+  within,
+  fireEvent,
+  renderWithNextIntl,
+} from '@/test/test-utils';
 import Footer from './footer';
 import '@testing-library/jest-dom';
 import { describe, it, expect } from 'vitest';
@@ -81,6 +86,32 @@ describe('Footer', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'Visit our YouTube channel' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the location as a static label outside the language button', async () => {
+    renderWithNextIntl(<Footer />);
+
+    const location = screen.getByText('United States');
+    expect(location.closest('button')).toBeNull();
+
+    await fireEvent.click(location);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('opens the language menu from the language button', async () => {
+    renderWithNextIntl(<Footer />);
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Change language' })
+    );
+
+    const menu = screen.getByRole('menu');
+    expect(
+      within(menu).getByRole('menuitem', { name: 'English' })
+    ).toBeInTheDocument();
+    expect(
+      within(menu).getByRole('menuitem', { name: 'Español' })
     ).toBeInTheDocument();
   });
 

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/footer/footer.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/footer/footer.tsx
@@ -144,22 +144,27 @@ const Footer = () => {
               {val.icon}
             </Link>
           ))}
-          <div className="relative inline-flex">
+          <div className="relative inline-flex items-center gap-3 md:gap-6">
             <button
               type="button"
               aria-haspopup="menu"
               aria-expanded={langOpen}
               onClick={() => setLangOpen(!langOpen)}
-              className="flex flex-row items-center gap-3 text-[15px] font-normal cursor-pointer focus:outline-none focus:ring-0 md:gap-6"
+              className="text-[15px] font-normal cursor-pointer focus:outline-none focus:ring-0"
               aria-label="Change language"
             >
-              <span className="text-[15px] font-normal">
-                {currentLanguageLabel}
-              </span>
-              <span className="text-[15px] font-normal text-foreground/50">
-                {t('location')}
-              </span>
+              {currentLanguageLabel}
             </button>
+
+            {/*
+              Static label, not a control. The site serves a single region and
+              has no region state, detection or switching, so there is nothing
+              to pick yet. Kept visible as a placeholder for the planned
+              multi-country support.
+            */}
+            <span className="text-[15px] font-normal text-foreground/50">
+              {t('location')}
+            </span>
 
             {langOpen && (
               <>


### PR DESCRIPTION
## Description

Fixes #1052

In the marketing footer, the language label and the location label looked like two separate controls but were a single `<button>` wired to `setLangOpen`. Clicking "Estados Unidos" / "United States" opened the language menu — something its label never promised.

This takes the first of the two resolutions listed in the issue: the location is a static label, so it moves out of the button.

### What changed

`footer.tsx` — the location `<span>` is now a sibling of the button rather than its child:

- The `flex items-center gap-3 md:gap-6` moved from the button to the wrapping `div`, which is now the element with two children. Spacing is visually identical.
- The language label's inner `<span>` is gone; the button has a single text child and already carries `text-[15px] font-normal`.
- The wrapper `div` still contains both elements, so the menu's `absolute right-0` anchors exactly where it did before. No visual change to the dropdown.
- A comment records why the location is not a control and that multi-country support is planned.

`footer.test.tsx` — two tests: the location is not inside a `<button>` and clicking it opens no menu; the language button still opens the menu with English and Español.

### Out of scope

The button keeps `aria-label="Change language"`. The issue notes the accessible name doesn't match the visible text, which is real, but the same `aria-label` is used in `src/components/common/locale-switcher/locale-switcher.tsx` — it's a codebase-wide pattern, and changing it in one place only would create an inconsistency. After this change the label is at least accurate: the button is now solely the language control. Worth a separate issue.

No region selector was built. That was the issue's second resolution and it needs product and design decisions first.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
