### PR TITLE
fix(deps): bump undici and fast-uri past their high-severity advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2321,7 +2321,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
@@ -3623,7 +3623,7 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "minimatch": "^10.2.5",
     "rollup": "^4.61.1",
     "storybook": "^10.4.4",
-    "undici": "^7.27.2"
+    "undici": "^7.29.0"
   },
   "overrides": {
     "sharp": "^0.35.3",
@@ -73,7 +73,7 @@
     "lodash-es": "^4.17.24",
     "js-yaml": "^4.3.0",
     "esbuild": "^0.28.1",
-    "fast-uri": "^3.1.3",
+    "fast-uri": "^3.1.5",
     "minimatch": "^10.2.3",
     "brace-expansion": "^5.0.8",
     "markdown-it": "^14.1.1",
@@ -82,7 +82,7 @@
     "basic-ftp": "^5.3.1",
     "tar": "^7.5.19",
     "dompurify": "3.3.2",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "vite": "^7.3.5",
     "protobufjs": "^7.6.1",
     "@grpc/grpc-js": "^1.14.4",


### PR DESCRIPTION
## Description

Clears the two high-severity findings that are currently failing `Security Audit` on every PR. Diagnosis and context in #1053.

### What was failing

Two advisories were published between Aug 1 and Aug 3 covering versions the lockfile still pinned. `main` is only green because the workflow hasn't re-run since Aug 1 — any push to it fails the same way.

| Package | Advisory | Locked | Patched | Kind |
|---|---|---|---|---|
| `fast-uri` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | `3.1.4` | `3.1.5` | transitive, via `ajv` |
| `undici` | [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) | `7.28.0` | `7.29.0` | direct, plus `jsdom`, `newrelic`, `sanity` |

### What changed

Three version ranges in the root `package.json`, and the two matching `bun.lock` entries:

```
overrides.fast-uri     ^3.1.3  →  ^3.1.5
overrides.undici       ^7.28.0 →  ^7.29.0
dependencies.undici    ^7.27.2 →  ^7.29.0
```

Both old ranges technically already admitted the patched releases, so the ranges alone weren't the problem — the lockfile resolutions were stale. Raising the floors is what makes those resolutions stop satisfying their declared range, which is the condition under which `bun i` re-resolves an entry. The lockfile is updated to match so a fresh checkout is deterministic.

Both packages stay on their current major: `fast-uri` on 3.x (4.x exists) and `undici` on 7.x (8.x exists). Nothing else was touched — no `bun update`, no unrelated bumps.

### Verification

Ran the security workflow's own two steps against a clean checkout of this branch:

```
bun i                          → undici@7.29.0, fast-uri@3.1.5
bun audit --audit-level=high   → exit 0, no findings
```

`bun validate` passes locally.

### One thing worth knowing

`bun i` on this repo rewrites `bun.lock` by more than these four lines — `next`, `@vitest/*`, `eslint-config-next` and `brace-expansion` also move. That drift is pre-existing and reproduces on an untouched `main` checkout: those entries are pinned below what their own declared ranges require, so bun re-resolves them on any install. It's unrelated to this change and left alone deliberately, but it does mean a local `bun i` will show a larger diff than what's committed here. Probably worth its own cleanup.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
