### PR TITLE
fix(db): stop a missing embeddings key from blocking staging migrations

### DIFF
--- a/packages/db/src/utils/get-embedding.test.ts
+++ b/packages/db/src/utils/get-embedding.test.ts
@@ -1,0 +1,37 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const savedKey = process.env.OPENAI_EMBEDDINGS_KEY;
+
+beforeEach(() => {
+  vi.resetModules();
+  delete process.env.OPENAI_EMBEDDINGS_KEY;
+});
+
+afterEach(() => {
+  if (savedKey === undefined) {
+    delete process.env.OPENAI_EMBEDDINGS_KEY;
+  } else {
+    process.env.OPENAI_EMBEDDINGS_KEY = savedKey;
+  }
+});
+
+describe('get-embedding', () => {
+  it('imports without a key configured', async () => {
+    // The regression this guards: a module-scope throw here took down every
+    // script that merely sits downstream of this import. `migrate-remote-db`
+    // reaches it through `importer-lib` for a CLI-flag helper and never embeds
+    // anything, so importing must stay free of side effects.
+    await expect(import('./get-embedding')).resolves.toHaveProperty(
+      'getEmbedding'
+    );
+  });
+
+  it('still fails by name when an embedding is actually requested', async () => {
+    const { getEmbedding } = await import('./get-embedding');
+    await expect(getEmbedding('some text')).rejects.toThrow(
+      /OPENAI_EMBEDDINGS_KEY/
+    );
+  });
+});

--- a/packages/db/src/utils/get-embedding.ts
+++ b/packages/db/src/utils/get-embedding.ts
@@ -2,20 +2,43 @@
 
 import OpenAI from 'openai';
 
-const OPENAI_API_KEY = process.env.OPENAI_EMBEDDINGS_KEY;
+let client: OpenAI | undefined;
 
-if (!OPENAI_API_KEY) {
-  throw new Error(
-    'Missing OPENAI_EMBEDDINGS_KEY. Set it in apps/site/.env.local for local development and in Vercel environment variables for deployed environments.'
-  );
+/**
+ * The embeddings client, built on first use.
+ *
+ * Resolved here rather than at module load because this module sits on the
+ * import path of scripts that never embed anything: `migrate-remote-db.ts`
+ * reaches it through `importer-lib` for nothing more than a CLI-flag helper.
+ * A module-scope throw took those scripts down wherever no embeddings key is
+ * configured — including the Database Compatibility Check, which applies
+ * staging migrations and has no reason to hold an OpenAI key.
+ *
+ * The check itself is unchanged, only its timing: anything that actually asks
+ * for an embedding without a key still fails, and fails by name.
+ */
+function embeddingsClient(): OpenAI {
+  const apiKey = process.env.OPENAI_EMBEDDINGS_KEY;
+
+  if (!apiKey) {
+    throw new Error(
+      'Missing OPENAI_EMBEDDINGS_KEY. Set it in apps/site/.env.local for local development and in Vercel environment variables for deployed environments.'
+    );
+  }
+
+  client ??= new OpenAI({ apiKey });
+  return client;
 }
 
-const openai = new OpenAI({
-  apiKey: OPENAI_API_KEY,
-});
-
+/**
+ * Embeds a string with OpenAI's `text-embedding-3-large` model.
+ *
+ * @param text - Text to embed
+ * @returns The embedding vector
+ * @throws If OPENAI_EMBEDDINGS_KEY is not set, or the API returns no vector
+ */
 export async function getEmbedding(text: string): Promise<number[]> {
-  const response = await openai.embeddings.create({
+  const response = await embeddingsClient().embeddings.create({
     model: 'text-embedding-3-large',
     input: text,
     encoding_format: 'float',


### PR DESCRIPTION
## The problem

**The Database Compatibility Check has failed on every push to `main` since #1054 merged, so staging has not been migrated since 11 Aug.** That workflow is what applies committed migrations to staging; while it is red, staging drifts behind `main` — the exact failure mode the workflow's own comments were written to prevent.

It is not caused by any individual PR. It fires on `push: main`, which is why PR checks stay green and the failure only appears after a merge.

## Root cause

`migrate-remote-db.ts` imports `importer-lib` for `getArg`, a CLI-flag helper. `importer-lib` imports `getEmbedding`. And #1054 added a module-scope throw to `get-embedding.ts`:

```
migrate-remote-db.ts → lib/importer-lib.ts → src/utils/get-embedding.ts → throws at import
```

The workflow's env block has no `OPENAI_EMBEDDINGS_KEY`, and correctly so — applying migrations has nothing to do with embeddings. So a migration job dies on a key it will never use, before it reaches a line of its own code.

## The fix

Move the check into the client factory. The rule is unchanged and still fails by name; only its timing moves, from *anything imports this module* to *something asked for an embedding*.

## Verification

Both directions, against the real import chain:

- With this change, importing exactly what `migrate-remote-db.ts` imports resolves with `OPENAI_EMBEDDINGS_KEY` unset.
- Stashing it reproduces the CI error verbatim from the same import.

Two tests pin it: the module must import cleanly with no key, and `getEmbedding()` must still reject by name when called without one.

`format:check`, `lint`, `type-check`, and the full suite pass.

## Note for #1007

#1007 is still open and proposes this same module-scope throw. Its base already has it (#1054 landed the identical change), so merging it as written would reintroduce this failure. It can be closed as superseded, or rebased onto this.

## After merge

The first push to `main` should turn the Database Compatibility Check green and apply the migrations staging has been missing. Worth watching that run rather than assuming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)