### PR TITLE
fix(site): restore the Next.js integration Storybook lost in the framework swap

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,6 @@
 **/out
 **/build
 **/next-env.d.ts
-**/.storybook
 **/storybook-static
 **/package-lock.json
 **/.sanity

--- a/apps/site/.storybook/decorators/withFonts.tsx
+++ b/apps/site/.storybook/decorators/withFonts.tsx
@@ -1,3 +1,5 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
 import React from 'react';
 import { neueHaasUnica, utahWGLCondensed } from '../../src/lib/fonts';
 

--- a/apps/site/.storybook/decorators/withNextNavigation.tsx
+++ b/apps/site/.storybook/decorators/withNextNavigation.tsx
@@ -1,0 +1,34 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import React from 'react';
+import { __setNavigation } from '../mocks/next-navigation';
+
+/** The `parameters.nextjs` block stories use to describe their route. */
+interface NextParameters {
+  nextjs?: {
+    navigation?: {
+      pathname?: string;
+      query?: Record<string, string>;
+      segments?: Record<string, string | string[]>;
+    };
+  };
+}
+
+/**
+ * Feeds each story's `parameters.nextjs.navigation` to the `next/navigation`
+ * mock before the story renders, so components calling `usePathname()` see the
+ * route the story declared rather than an empty default.
+ *
+ * @param Story - The story being rendered
+ * @param context - Storybook context carrying the story's parameters
+ * @returns The story, with navigation state applied
+ */
+export const withNextNavigation = (
+  Story: React.ComponentType,
+  context: { parameters: NextParameters }
+) => {
+  // Applied during render rather than in an effect: the hooks are read on the
+  // first pass, so an effect would land a frame too late.
+  __setNavigation(context.parameters?.nextjs?.navigation ?? {});
+  return <Story />;
+};

--- a/apps/site/.storybook/decorators/withStorybookProvider.tsx
+++ b/apps/site/.storybook/decorators/withStorybookProvider.tsx
@@ -1,4 +1,6 @@
-import { Decorator } from '@storybook/react';
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { Decorator } from '@storybook/react-vite';
 import { NextIntlClientProvider } from 'next-intl';
 import React from 'react';
 import '../../src/app/globals.css';

--- a/apps/site/.storybook/main.ts
+++ b/apps/site/.storybook/main.ts
@@ -1,8 +1,37 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
 import type { StorybookConfig } from '@storybook/react-vite';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Vite permits `resolve.alias` as an object or as `{find, replacement}[]`. */
+type ViteAlias =
+  | Record<string, string>
+  | readonly { find: string | RegExp; replacement: string }[]
+  | undefined;
+
+/**
+ * Flattens either alias form into the object form this config merges into.
+ * Regex `find` entries have no object equivalent and are dropped rather than
+ * silently mangled; nothing in this project uses them.
+ *
+ * @param alias - Whatever Vite handed us
+ */
+function normalizeAlias(alias: ViteAlias): Record<string, string> {
+  if (!alias) return {};
+  if (Array.isArray(alias)) {
+    return Object.fromEntries(
+      alias
+        .filter((entry) => typeof entry.find === 'string')
+        .map((entry) => [entry.find as string, entry.replacement])
+    );
+  }
+  // `Array.isArray` narrows out `T[]` but not `readonly T[]`, so the object
+  // form has to be asserted rather than inferred.
+  return alias as Record<string, string>;
+}
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -32,16 +61,30 @@ const config: StorybookConfig = {
     // (intermittent `EEXIST` on storybook-static/fonts during build-storybook).
     // Disable Vite's copy so only the staticDirs copy runs.
     config.publicDir = false;
-    // Add support for local fonts and path aliases matching tsconfig
+    // Add path aliases matching tsconfig, plus stand-ins for the Next.js
+    // modules the React Vite builder cannot resolve on its own. Each mock
+    // explains in its own header what breaks without it.
     config.resolve ??= {};
     config.resolve.alias = {
-      ...config.resolve.alias,
-      '@': path.resolve(rootDir, 'src'),
+      // Vite also accepts `alias` as an array of `{ find, replacement }`, and
+      // spreading that into an object literal would turn every inherited entry
+      // into numeric junk keys. Normalize before merging.
+      ...normalizeAlias(config.resolve.alias),
+      // Order matters: Vite matches object aliases in insertion order by
+      // prefix, so the broader '@' must come last or it swallows '@/storybook'
+      // and resolves it to a src path that does not exist.
       '@/storybook': path.resolve(rootDir, '.storybook'),
       '@public': path.resolve(rootDir, 'public'),
+      '@': path.resolve(rootDir, 'src'),
       'next/font/local': path.resolve(
         rootDir,
-        '.storybook/mocks/next-font-local.ts',
+        '.storybook/mocks/next-font-local.ts'
+      ),
+      'next/image': path.resolve(rootDir, '.storybook/mocks/next-image.tsx'),
+      'next/link': path.resolve(rootDir, '.storybook/mocks/next-link.tsx'),
+      'next/navigation': path.resolve(
+        rootDir,
+        '.storybook/mocks/next-navigation.ts'
       ),
     };
     return config;

--- a/apps/site/.storybook/mocks/next-font-local.ts
+++ b/apps/site/.storybook/mocks/next-font-local.ts
@@ -1,24 +1,129 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * @fileoverview
+ * Stands in for `next/font/local` under the React Vite builder, which has no
+ * Next.js font pipeline of its own.
+ *
+ * The contract that matters is `variable`: the real loader returns a generated
+ * *class name* whose rule declares the custom property, not the property name
+ * itself. Returning the property name leaves `var(--font-neue-haas)` undefined
+ * and silently drops every story to the fallback face — invisible in CI, and a
+ * whole-suite diff in Chromatic.
+ *
+ * So this mock does what the loader does: emit `@font-face` rules for the real
+ * files under `public/` (served at `/fonts` via `staticDirs`) and a class that
+ * binds the custom property to them.
+ */
+
+/** One `src` entry, matching the real loader's array form. */
+interface LocalFontSource {
+  path: string;
+  weight?: string;
+  style?: string;
+}
+
 interface LocalFontOptions {
-  /** CSS variable name emitted by the Next font loader. */
+  src: string | LocalFontSource[];
+  /** Custom property the app expects this font to be reachable through. */
   variable?: string;
+  display?: string;
+  fallback?: string[];
+  preload?: boolean;
+  weight?: string;
+  style?: string;
 }
 
 interface LocalFontResult {
-  /** Stable class name used by components that consume Next local fonts. */
+  /** Class that applies the family directly. */
   className: string;
-  /** Optional CSS variable class name used by the app font setup. */
+  /** Class that declares `options.variable`, exactly as Next returns it. */
   variable: string;
-  /** Inline style object returned by the real Next font loader. */
-  style: Record<string, string>;
+  style: { fontFamily: string };
+}
+
+/** Distinguishes families when a page loads more than one. */
+let familyCount = 0;
+
+/** `src` paths are relative to the importing module; the files are served from `public`. */
+function toServedUrl(srcPath: string): string {
+  const fromPublic = srcPath.split(/\/?public\//).pop() ?? srcPath;
+  return `/${fromPublic.replace(/^\/+/, '')}`;
+}
+
+function formatFor(url: string): string {
+  if (url.endsWith('.woff2')) return 'woff2';
+  if (url.endsWith('.woff')) return 'woff';
+  if (url.endsWith('.otf')) return 'opentype';
+  return 'truetype';
+}
+
+function injectCss(css: string): void {
+  // The preview runs in a browser, but portable stories run under vitest's
+  // node environment, where there is no document to attach a stylesheet to.
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const style = document.createElement('style');
+  style.setAttribute('data-storybook-local-font', '');
+  style.textContent = css;
+  document.head.appendChild(style);
 }
 
 /**
  * Mocks Next's local font loader for Storybook's React Vite builder.
+ *
+ * @param options - The same options object the real loader takes
+ * @returns Class names and inline style mirroring the real loader's result
  */
-const localFont = (options: LocalFontOptions = {}): LocalFontResult => ({
-  className: 'storybook-local-font',
-  variable: options.variable ?? '',
-  style: {},
-});
+const localFont = (options: LocalFontOptions): LocalFontResult => {
+  familyCount += 1;
+  const family = `sb-local-font-${familyCount}`;
+  const className = `${family}-class`;
+  const variableClass = `${family}-variable`;
+
+  const sources: LocalFontSource[] =
+    typeof options.src === 'string'
+      ? [{ path: options.src, weight: options.weight, style: options.style }]
+      : options.src;
+
+  const faces = sources
+    .map((source) => {
+      const url = toServedUrl(source.path);
+      return [
+        '@font-face {',
+        `  font-family: '${family}';`,
+        `  src: url('${url}') format('${formatFor(url)}');`,
+        source.weight ? `  font-weight: ${source.weight};` : '',
+        source.style ? `  font-style: ${source.style};` : '',
+        `  font-display: ${options.display ?? 'swap'};`,
+        '}',
+      ]
+        .filter(Boolean)
+        .join('\n');
+    })
+    .join('\n');
+
+  const stack = [`'${family}'`, ...(options.fallback ?? [])].join(', ');
+
+  injectCss(
+    [
+      faces,
+      `.${className} { font-family: ${stack}; }`,
+      options.variable
+        ? `.${variableClass} { ${options.variable}: ${stack}; }`
+        : '',
+    ]
+      .filter(Boolean)
+      .join('\n')
+  );
+
+  return {
+    className,
+    // Next returns a class here, not the property name — see the file comment.
+    variable: options.variable ? variableClass : '',
+    style: { fontFamily: stack },
+  };
+};
 
 export default localFont;

--- a/apps/site/.storybook/mocks/next-image.tsx
+++ b/apps/site/.storybook/mocks/next-image.tsx
@@ -1,0 +1,102 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * @fileoverview
+ * Stands in for `next/image` under the React Vite builder.
+ *
+ * Without it, `next/image` resolves to the real component and routes every
+ * `src` through Next's optimizer as `/_next/image?url=...`. Storybook serves
+ * `public` and nothing else, so there is no such endpoint and every image in
+ * every story breaks. The real component also reads `process.env` at module
+ * scope, which the Vite preview does not define.
+ *
+ * Vite hands static imports back as plain URL strings rather than the
+ * `StaticImageData` object the Next loader builds, so `src` is accepted in
+ * both shapes.
+ */
+
+import React from 'react';
+
+/** The object shape Next's static image import produces. */
+interface StaticImageData {
+  src: string;
+  height?: number;
+  width?: number;
+  blurDataURL?: string;
+}
+
+type NextImageProps = Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  'src' | 'placeholder'
+> & {
+  src: string | StaticImageData;
+  alt: string;
+  width?: number | string;
+  height?: number | string;
+  /** Next-only props, accepted so stories type-check, then dropped. */
+  fill?: boolean;
+  priority?: boolean;
+  quality?: number;
+  placeholder?: string;
+  blurDataURL?: string;
+  unoptimized?: boolean;
+  loader?: unknown;
+  overrideSrc?: string;
+};
+
+/**
+ * Renders a plain `<img>` pointing at the asset's real served URL.
+ *
+ * @param props - `next/image` props; Next-only ones are dropped
+ * @returns An `img` element
+ */
+export default function NextImageMock({
+  src,
+  alt,
+  width,
+  height,
+  fill,
+  priority: _priority,
+  quality: _quality,
+  placeholder: _placeholder,
+  blurDataURL: _blurDataURL,
+  unoptimized: _unoptimized,
+  loader: _loader,
+  overrideSrc,
+  style,
+  ...rest
+}: NextImageProps) {
+  const resolved = overrideSrc ?? (typeof src === 'string' ? src : src.src);
+
+  // `fill` positions the image against its nearest positioned ancestor, which
+  // layouts here depend on for cropping.
+  const fillStyle: React.CSSProperties = fill
+    ? {
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+      }
+    : // Dimensions go inline, not just on the attributes: Tailwind's preflight
+      // sets `img { max-width: 100%; height: auto }`, and inside a
+      // shrink-to-fit parent whose own width comes from this image, that
+      // resolves circularly to 0×0. `maxWidth: none` breaks the cycle, which
+      // is what lets the wordmark appear at all.
+      {
+        ...(width === undefined ? {} : { width, maxWidth: 'none' }),
+        ...(height === undefined ? {} : { height }),
+      };
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      {...rest}
+      width={width}
+      height={height}
+      src={resolved}
+      alt={alt}
+      style={{ ...fillStyle, ...style }}
+    />
+  );
+}

--- a/apps/site/.storybook/mocks/next-link.tsx
+++ b/apps/site/.storybook/mocks/next-link.tsx
@@ -1,0 +1,73 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * @fileoverview
+ * Stands in for `next/link` under the React Vite builder.
+ *
+ * The real module pulls in Next's client router helpers, which read `process`
+ * at module scope. Vite's preview defines no such global, so merely importing
+ * a component that links anywhere throws `ReferenceError: process is not
+ * defined` and blanks the story — including via next-intl's `Link`, which
+ * wraps this module.
+ *
+ * Navigation has no meaning inside the preview iframe, so an anchor is the
+ * whole of the behavior worth reproducing.
+ */
+
+import React from 'react';
+
+/** Next accepts an object href; stories only ever use `pathname` and `query`. */
+interface UrlObject {
+  pathname?: string;
+  query?: Record<string, string | number>;
+}
+
+type NextLinkProps = Omit<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  'href'
+> & {
+  href: string | UrlObject;
+  /** Next-only props, accepted so stories type-check, then dropped. */
+  prefetch?: boolean | null;
+  replace?: boolean;
+  scroll?: boolean;
+  shallow?: boolean;
+  passHref?: boolean;
+  legacyBehavior?: boolean;
+  locale?: string | false;
+};
+
+function toHref(href: string | UrlObject): string {
+  if (typeof href === 'string') {
+    return href;
+  }
+  const query = new URLSearchParams(
+    Object.entries(href.query ?? {}).map(([key, value]) => [key, String(value)])
+  ).toString();
+  return `${href.pathname ?? ''}${query ? `?${query}` : ''}`;
+}
+
+/**
+ * Renders a plain anchor in place of Next's client-side link.
+ *
+ * @param props - `next/link` props; Next-only ones are dropped
+ * @returns An `a` element
+ */
+export default function NextLinkMock({
+  href,
+  children,
+  prefetch: _prefetch,
+  replace: _replace,
+  scroll: _scroll,
+  shallow: _shallow,
+  passHref: _passHref,
+  legacyBehavior: _legacyBehavior,
+  locale: _locale,
+  ...rest
+}: NextLinkProps) {
+  return (
+    <a {...rest} href={toHref(href)}>
+      {children}
+    </a>
+  );
+}

--- a/apps/site/.storybook/mocks/next-navigation.ts
+++ b/apps/site/.storybook/mocks/next-navigation.ts
@@ -1,0 +1,96 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+/**
+ * @fileoverview
+ * Stands in for `next/navigation` under the React Vite builder.
+ *
+ * The real hooks read App Router context, which nothing mounts in Storybook:
+ * `usePathname()` returns null and `useRouter()` throws "invariant expected app
+ * router to be mounted". Components that call them unguarded take the story
+ * down with them.
+ *
+ * State comes from `parameters.nextjs.navigation`, the same block the previous
+ * Next.js-aware builder honored, so existing stories keep working unchanged.
+ * `withNextNavigation` pushes each story's parameters in before it renders.
+ */
+
+/** The subset of `parameters.nextjs.navigation` stories actually set. */
+export interface NavigationState {
+  pathname: string;
+  query: Record<string, string>;
+  segments: Record<string, string | string[]>;
+}
+
+const DEFAULTS: NavigationState = { pathname: '/', query: {}, segments: {} };
+
+let state: NavigationState = DEFAULTS;
+
+/**
+ * Points the mocked hooks at a story's navigation parameters.
+ *
+ * @param next - Partial navigation state; omitted keys fall back to defaults
+ */
+export function __setNavigation(next: Partial<NavigationState> = {}): void {
+  state = { ...DEFAULTS, ...next };
+}
+
+/** @returns The pathname the current story declared */
+export function usePathname(): string {
+  return state.pathname;
+}
+
+/** @returns The dynamic route segments the current story declared */
+export function useParams<T = Record<string, string | string[]>>(): T {
+  return state.segments as T;
+}
+
+/** @returns The query string the current story declared */
+export function useSearchParams(): URLSearchParams {
+  return new URLSearchParams(state.query);
+}
+
+/** @returns The selected layout segment, or null */
+export function useSelectedLayoutSegment(): string | null {
+  return state.pathname.split('/').filter(Boolean)[0] ?? null;
+}
+
+/** @returns The selected layout segments */
+export function useSelectedLayoutSegments(): string[] {
+  return state.pathname.split('/').filter(Boolean);
+}
+
+/**
+ * A router whose methods record the pathname rather than navigating — the
+ * preview iframe has nowhere to navigate to.
+ *
+ * @returns A router with the App Router surface
+ */
+export function useRouter() {
+  return {
+    push: (href: string) => {
+      state = { ...state, pathname: href };
+    },
+    replace: (href: string) => {
+      state = { ...state, pathname: href };
+    },
+    back: () => {},
+    forward: () => {},
+    refresh: () => {},
+    prefetch: () => Promise.resolve(),
+  };
+}
+
+/** No-op stand-in; redirecting inside a story would blank the preview. */
+export function redirect(_url: string): void {}
+
+/** No-op stand-in; see {@link redirect}. */
+export function permanentRedirect(_url: string): void {}
+
+/** No-op stand-in: stories render the component, not its 404 boundary. */
+export function notFound(): void {}
+
+/** No-op stand-in for the auth error helpers. */
+export function forbidden(): void {}
+
+/** No-op stand-in for the auth error helpers. */
+export function unauthorized(): void {}

--- a/apps/site/.storybook/preview.ts
+++ b/apps/site/.storybook/preview.ts
@@ -1,10 +1,15 @@
-import type { Preview } from '@storybook/nextjs';
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import type { Preview } from '@storybook/react-vite';
 import { withFonts } from './decorators/withFonts';
+import { withNextNavigation } from './decorators/withNextNavigation';
 import { withStorybookProvider } from './decorators/withStorybookProvider';
 import '../src/app/globals.css';
 
 const preview: Preview = {
-  decorators: [withStorybookProvider, withFonts],
+  // withNextNavigation renders above the story, so the next/navigation mock
+  // holds this story's route by the time a component reads it.
+  decorators: [withNextNavigation, withStorybookProvider, withFonts],
   globalTypes: {
     locale: {
       name: 'Locale',
@@ -16,7 +21,6 @@ const preview: Preview = {
           { value: 'en', title: '🇺🇸 English' },
           { value: 'es', title: '🇪🇸 Español' },
         ],
-        showName: true,
       },
     },
   },

--- a/apps/site/.storybook/vitest.setup.ts
+++ b/apps/site/.storybook/vitest.setup.ts
@@ -1,5 +1,7 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
 import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview';
-import { setProjectAnnotations } from '@storybook/nextjs';
+import { setProjectAnnotations } from '@storybook/react-vite';
 import * as projectAnnotations from './preview';
 
 // This is an important step to apply the right configuration when testing your stories.

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -28,7 +28,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".storybook/utils/storybookControls.ts",
+    ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
     ".next/dev/types/**/*.ts",
     "./public/*"
   ],


### PR DESCRIPTION
Targets **#1064** rather than `main`, so it can merge into that branch before it ships.

Swapping `@storybook/nextjs-vite` → `@storybook/react-vite` removes the entire Next.js module layer, but only `next/font/local` was replaced. Three things regress at once. All were reproduced in a running Storybook, and all are fixed and re-verified there.

## What was broken

**`next/navigation` — a story crashed outright.** With no App Router mounted, `usePathname()` returns `null`, and `account-side-menu.tsx` calls `.replace()` on it. Account/AccountSideMenu rendered a red error boundary. The `parameters.nextjs.navigation` block stories already declare had become a silent no-op.

**`next/image` and `next/link` — blank and broken stories.** `next/image` fell back to Next's optimizer, pointing every image at a `/_next/image` route Storybook does not serve. `next/link` was worse: it reads `process` at module scope, which Vite's preview does not define, so *any story containing a link* died with `ReferenceError: process is not defined` — next-intl's `Link` included. That is what left UI/Header blank.

**The font mock — every story silently on Arial.** The real loader returns `variable` as a *generated class name* whose rule declares the custom property. The mock returned the property name itself, so `--font-neue-haas` was never defined anywhere. Invisible in CI, and a whole-suite diff in Chromatic.

## The fixes

- Mocks for `next/navigation`, `next/image`, and `next/link`, each documenting what breaks without it. The navigation mock reads `parameters.nextjs.navigation`, so existing stories work unchanged.
- The font mock now emits real `@font-face` rules against the files under `public/` (already served at `/fonts`) plus a class binding the custom property — so Storybook shows the actual brand faces.
- Alias ordering: `'@'` matched `'@/storybook'` first by prefix, making that entry dead. Reordered, and Vite's array alias form is normalized before merging rather than object-spread into junk keys.
- `preview.ts`, `vitest.setup.ts`, and `withStorybookProvider.tsx` imported `@storybook/nextjs` and `@storybook/react` — neither in `package.json` nor the lockfile. All now use `@storybook/react-vite`.

## Why CI could not have caught any of it

`.storybook` sits outside type-check, lint, and format. It is now type-checked and format-checked, which immediately surfaced two real errors fixed here: a `readonly` alias mismatch and an unsupported `showName` toolbar property.

## Verification

Reproduced and confirmed fixed in a live Storybook, not just by reading:

| Story | Before | After |
|---|---|---|
| Account/AccountSideMenu | threw on `usePathname()` | renders, `/account` correctly active |
| UI/Header | blank (`process is not defined`) | renders, TODD wordmark visible |
| Common/NewsCard | image broken | renders |
| Fonts | `--font-neue-haas` undefined | resolves to the real family |

`build-storybook`, `build`, `type-check`, `lint`, `format:check`, and the full test suite all pass.

## Out of scope, but worth knowing

Stories render raw i18n keys (`header.navigation.whoWeAre`). `withStorybookProvider` loads messages with `require()`, which does not exist in a Vite browser bundle. This predates #1064 and is unrelated to the audit work, so I left it alone — happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)