### PR TITLE
fix(site): restore jsdom web storage when node shadows it in tests

### DIFF
--- a/apps/site/vitest.setup.ts
+++ b/apps/site/vitest.setup.ts
@@ -2,3 +2,72 @@
 
 import '@testing-library/jest-dom';
 import 'whatwg-fetch';
+
+/**
+ * Restores a working Web Storage implementation when the host Node build
+ * shadows jsdom's.
+ *
+ * Node 22 shipped a built-in `localStorage`/`sessionStorage`. From Node 24 it
+ * is exposed by default, but it only functions when the process is started
+ * with a valid `--localstorage-file` path; otherwise Node installs a global
+ * with no methods on it and warns. That global takes precedence over the one
+ * jsdom installs, so `localStorage.clear()` throws "is not a function" inside
+ * tests. Because those calls usually live in `beforeEach`/`afterEach`, the
+ * throw aborts the hook chain before Testing Library's `cleanup` runs, leaving
+ * mounted DOM behind and turning a single failure into cascading "Found
+ * multiple elements" errors in unrelated tests.
+ *
+ * The repo targets Node 20 (see `.nvmrc`), where this does not apply and the
+ * guard below is inert. It only engages on newer local toolchains so the suite
+ * behaves the same there as it does in CI.
+ */
+function createMemoryStorage(): Storage {
+  let entries: Record<string, string> = Object.create(null);
+
+  return {
+    get length() {
+      return Object.keys(entries).length;
+    },
+    key(index: number): string | null {
+      return Object.keys(entries)[index] ?? null;
+    },
+    getItem(key: string): string | null {
+      const value = entries[String(key)];
+      return value === undefined ? null : value;
+    },
+    setItem(key: string, value: string): void {
+      entries[String(key)] = String(value);
+    },
+    removeItem(key: string): void {
+      // A plain record plus the `delete` operator, rather than a Map, keeps the
+      // repo-wide drizzle/enforce-delete-with-where rule from firing on a
+      // `.delete()` method call that has nothing to do with the database.
+      delete entries[String(key)];
+    },
+    clear(): void {
+      entries = Object.create(null);
+    },
+  } as Storage;
+}
+
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  const existing = globalThis[name] as Storage | undefined;
+
+  // A healthy Storage exposes the full interface; Node's stub exposes none of it.
+  if (typeof existing?.clear === 'function') {
+    continue;
+  }
+
+  const storage = createMemoryStorage();
+  const descriptor = {
+    value: storage,
+    writable: true,
+    configurable: true,
+  };
+
+  Object.defineProperty(globalThis, name, descriptor);
+
+  if (typeof window !== 'undefined' && window !== (globalThis as unknown)) {
+    Object.defineProperty(window, name, descriptor);
+  }
+}

--- a/apps/site/vitest.setup.ts
+++ b/apps/site/vitest.setup.ts
@@ -7,9 +7,10 @@ import 'whatwg-fetch';
  * Restores a working Web Storage implementation when the host Node build
  * shadows jsdom's.
  *
- * Node 22 shipped a built-in `localStorage`/`sessionStorage`. From Node 24 it
- * is exposed by default, but it only functions when the process is started
- * with a valid `--localstorage-file` path; otherwise Node installs a global
+ * Node 22 shipped a built-in `localStorage`/`sessionStorage` behind
+ * `--experimental-webstorage`, and Node 25 exposes it by default. It only
+ * functions when the process is started with a valid `--localstorage-file`
+ * path; otherwise Node installs a global
  * with no methods on it and warns. That global takes precedence over the one
  * jsdom installs, so `localStorage.clear()` throws "is not a function" inside
  * tests. Because those calls usually live in `beforeEach`/`afterEach`, the
@@ -51,7 +52,21 @@ function createMemoryStorage(): Storage {
 }
 
 for (const name of ['localStorage', 'sessionStorage'] as const) {
-  const existing = globalThis[name] as Storage | undefined;
+  // Web Storage is a DOM API. `@vitest-environment node` files (for example
+  // src/app/robots.test.ts) must keep server semantics, where it is absent.
+  if (typeof window === 'undefined') {
+    break;
+  }
+
+  // Reading the global is not side-effect free: Node 25.2.x, and Node 22-24
+  // under `--experimental-webstorage`, throw from this getter when
+  // `--localstorage-file` is missing. Treat a throw as an unusable Storage.
+  let existing: Storage | undefined;
+  try {
+    existing = globalThis[name] as Storage | undefined;
+  } catch {
+    existing = undefined;
+  }
 
   // A healthy Storage exposes the full interface; Node's stub exposes none of it.
   if (typeof existing?.clear === 'function') {


### PR DESCRIPTION
## Description

No linked issue — found while running `bun validate` on a local checkout.

On Node 22+ the site test suite fails with 19 errors across 6 files, none of
which CI sees. The repo targets Node 20 (`.nvmrc`, and `testing.yml` pins
`node-version: '20'`), so this only bites contributors whose local Node is
newer.

### Root cause

Node 22 shipped a built-in `localStorage`/`sessionStorage`, and from Node 24 it
is exposed by default. It only functions when the process is started with a
valid `--localstorage-file` path; otherwise Node installs a global with no
methods on it and emits:

```
Warning: `--localstorage-file` was provided without a valid path
```

That global takes precedence over the one jsdom installs, so `localStorage` is
present but inert:

```console
$ node -e "console.log(typeof localStorage, typeof localStorage?.clear)"
object undefined
```

### Why one broken global caused 19 failures

`localStorage.clear()` is almost always called from `beforeEach`/`afterEach`.
The throw aborts the hook chain before Testing Library's `cleanup` runs, so
mounted DOM survives into the next test and it fails with `Found multiple
elements with the role "button"`. Only 5 of the 19 failures were storage
assertions; the rest were collateral in `sidebar.test.tsx` and
`sidebar-collapse-toggle.test.tsx`.

### Fix

Install a working in-memory `Storage` in `vitest.setup.ts` when the ambient one
is unusable. The guard is inert on Node 20 and in CI — it only engages on newer
local toolchains, so contributors see the same results locally that CI does.

The helper uses a plain record and the `delete` operator rather than a `Map`,
because `drizzle/enforce-delete-with-where` is configured repo-wide without a
`drizzleObjectName` and flags any `.delete()` method call, database-related or
not. Narrowing that rule would be a reasonable follow-up.

### Verification

- `bun run validate` passes end to end (format:check → type-check → lint → test → build).
- Site suite goes from **6 files / 19 tests failing** to **124 files / 608 tests passing** on Node 25.8.1.
- No production code touched — the change is confined to test setup.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
