### PR TITLE
fix(site): render images embedded in article bodies

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/components/careers-job-posting.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/components/careers-job-posting.tsx
@@ -1,6 +1,7 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import { MarketingPillLink } from '@/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks';
+import SanityBodyImage from '@/components/sanity/news/sanity-body-image';
 import SanityNormal from '@/components/sanity/news/sanity-normal';
 import SanityLink from '@/components/sanity/sanity-link';
 import type { SanityArticle } from '@/lib/sanity/article-types';
@@ -88,6 +89,9 @@ export async function CareersJobPosting({
           {children}
         </h5>
       ),
+    },
+    types: {
+      image: (props) => <SanityBodyImage {...props} />,
     },
     marks: {
       link: (props) => <SanityLink {...props} />,

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/cms-article-page/cms-article-page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/cms-article-page/cms-article-page.tsx
@@ -1,5 +1,6 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import SanityBodyImage from '@/components/sanity/news/sanity-body-image';
 import SanityNormal from '@/components/sanity/news/sanity-normal';
 import SanityLink from '@/components/sanity/sanity-link';
 import { getArticleCtasForPlacement } from '@/lib/sanity/article-cta-utils';
@@ -68,6 +69,9 @@ export function CmsArticlePage({
           {children}
         </h5>
       ),
+    },
+    types: {
+      image: (props) => <SanityBodyImage {...props} />,
     },
     marks: {
       link: (props) => <SanityLink {...props} />,

--- a/apps/site/src/components/sanity/news/sanity-body-image.tsx
+++ b/apps/site/src/components/sanity/news/sanity-body-image.tsx
@@ -1,0 +1,75 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { logger } from '@/lib/logger';
+import { urlFor } from '@/lib/sanity/utils';
+import type { SanityImageObject } from '@sanity/image-url';
+import type { PortableTextTypeComponentProps } from 'next-sanity';
+import Image from 'next/image';
+
+/**
+ * Inline `image` block stored in the shared article Portable Text schema
+ * (`articlePortableContentOf` in `apps/sanity/schemaTypes/article-shared-fields.ts`).
+ */
+export interface SanityBodyImageValue extends Partial<SanityImageObject> {
+  /** Alt text; required by the CMS schema, defaulted to decorative when absent. */
+  alt?: string;
+}
+
+/** Article body column width in CSS pixels; mirrors the `max-w-[685px]` body wrapper. */
+const BODY_COLUMN_WIDTH = 685;
+
+/**
+ * Trailing `-<width>x<height>-<format>` segment of a Sanity image asset id
+ * (`image-<hash>-2016x1342-png`), the only place intrinsic dimensions are
+ * available without an extra `asset->metadata` projection.
+ */
+const ASSET_DIMENSIONS_PATTERN = /-(\d+)x(\d+)-[^-]+$/;
+
+/**
+ * Renders an image embedded in an article body. Registered as the
+ * `components.types.image` renderer for every Portable Text body built from the
+ * shared article schema; without it Portable Text falls back to its hidden
+ * "Unknown block type" placeholder and the image silently disappears.
+ *
+ * Intrinsic dimensions come from the asset id so the reserved box matches the
+ * real aspect ratio and the image contributes no layout shift.
+ *
+ * @param props.value - Sanity `image` block from the article `content` array
+ */
+export default function SanityBodyImage({
+  value,
+}: PortableTextTypeComponentProps<SanityBodyImageValue>) {
+  const { alt, asset, crop, hotspot } = value;
+
+  if (asset === undefined) {
+    logger.warn('Skipping article body image: block has no asset reference');
+    return null;
+  }
+
+  const assetId = '_ref' in asset ? asset._ref : asset._id;
+  const dimensions = ASSET_DIMENSIONS_PATTERN.exec(assetId);
+
+  if (dimensions === null) {
+    logger.warn('Skipping article body image: asset id encodes no dimensions', {
+      assetId,
+    });
+    return null;
+  }
+
+  return (
+    <figure className="my-6 w-full">
+      <Image
+        src={urlFor({ asset, crop, hotspot })
+          .width(BODY_COLUMN_WIDTH * 2)
+          .fit('max')
+          .auto('format')
+          .url()}
+        alt={alt ?? ''}
+        width={Number(dimensions[1])}
+        height={Number(dimensions[2])}
+        sizes={`(max-width: ${BODY_COLUMN_WIDTH}px) 100vw, ${BODY_COLUMN_WIDTH}px`}
+        className="h-auto w-full rounded-sm"
+      />
+    </figure>
+  );
+}


### PR DESCRIPTION
## Description

Images placed inside article bodies never rendered. Reported on [Developing Varieties for Taste and Nutrition](https://toddagriscience.com/index/developing-varieties-for-taste-and-nutrition), which has two `image` blocks in its `content` array (`sunflower`, `dent corn`) that were invisible on the page.

### Root cause

`@portabletext/react` ships `defaultComponents.types = {}`. Any block type without a registered renderer falls through to `unknownType`, which returns a **hidden** node:

```js
unknownType: ({ value, isInline }) => jsx(isInline ? "span" : "div", {
  style: { display: "none" },
  children: `[@portabletext/react] Unknown block type "${value._type}"…`
})
```

Both Portable Text maps built from the shared article schema (`articlePortableContentOf`, which allows `block` **and** `image`) registered only `block` and `marks`. Every editor-placed image was swallowed with no error — confirmed against production HTML, which contained two hidden `Unknown block type "image"` divs.

### Change

- **New** `apps/site/src/components/sanity/news/sanity-body-image.tsx` — server component (no client JS), `next/image` through `urlFor`.
  - Intrinsic `width`/`height` are parsed off the Sanity asset id (`image-<hash>-2016x1342-png`), so the reserved box matches the true aspect ratio and the image contributes **no layout shift** — without paying for an extra `asset->metadata.dimensions` GROQ projection on every article query.
  - Requests `w=1370` (2× the 685px body column) with `fit=max&auto=format`, so a 2016×1342 PNG is no longer shipped at full size.
  - Forwards `crop`/`hotspot` to the URL builder, honoring the `hotspot: true` schema option.
  - Renders inside `<figure>` with the CMS-authored (schema-required) `alt`.
- **Registered** `components.types.image` on both maps consuming the shared schema:
  - `components/cms-article-page/cms-article-page.tsx` — `/index/[slug]` articles
  - `careers/components/careers-job-posting.tsx` — same latent bug, since `news.content` and `career.content` share one schema definition

Fixing only the article template would leave careers postings silently dropping images, so both call sites are handled together.

### Verification

`bun run validate` passes (format:check, type-check, lint, test, build).

Browser-driven against the article route on a local dev server:

| check | before | after |
|---|---|---|
| `Unknown block type` occurrences in HTML | 2 | **0** |
| `<figure><img>` loaded | 0 | **2** |

- `sunflower`: asset 2016×1342 (ratio 1.502) → renders 685×456 (ratio 1.502)
- `dent corn`: asset 1740×1446 (ratio 1.203) → renders 685×570 (ratio 1.202)

Both served via `/_next/image?url=https://cdn.sanity.io/…&w=1370&fit=max&auto=format`. Visually confirmed in place: the sunflower under *Oilseed Sunflower*, the dent-corn ears above *Long-term stewardship remains essential*. Existing tests for the article and careers routes pass (5 files / 16 tests).

### Notes for the reviewer

- **No unit test added.** The regression is "renderer absent from a component map"; the meaningful assertion is that Portable Text emits a visible `<img>` for an `image` block, which the existing route tests don't render deeply enough to cover. Happy to add a focused `sanity-body-image` render test if you'd prefer it gated.
- `apps/site/src/components/sanity/news/sanity-thumbnail-image.tsx` looks like an abandoned earlier attempt at this exact renderer — it has **zero imports repo-wide**, calls `urlFor(value)` on the PortableText props wrapper rather than the image value, hardcodes `alt=""`, and forces `width/height={1000}`. Left untouched here; say the word and I'll delete it in a follow-up.

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
