### PR TITLE
fix(db): finish the verify-full escalation and name the right cert var

### DIFF
--- a/.github/workflows/pr-database-compatibility-check.yml
+++ b/.github/workflows/pr-database-compatibility-check.yml
@@ -67,8 +67,12 @@ jobs:
             > /tmp/staging-db-ca.pem
           openssl x509 -in /tmp/staging-db-ca.pem -noout -subject
 
+          # sslmode=verify-full also validates the server certificate's hostname
+          # against STAGING_DATABASE_HOST (verify-ca only validates the CA
+          # chain), matching db-reconcile.yml. Keep this in step with the TLS
+          # posture the app pool and drizzle configs use.
           PGPASSWORD="$STAGING_DATABASE_PASSWORD" /usr/lib/postgresql/18/bin/pg_dump \
-            "host=$STAGING_DATABASE_HOST port=$STAGING_DATABASE_PORT user=$STAGING_DATABASE_USER dbname=$STAGING_DATABASE_DATABASE sslmode=verify-ca sslrootcert=/tmp/staging-db-ca.pem" \
+            "host=$STAGING_DATABASE_HOST port=$STAGING_DATABASE_PORT user=$STAGING_DATABASE_USER dbname=$STAGING_DATABASE_DATABASE sslmode=verify-full sslrootcert=/tmp/staging-db-ca.pem" \
             --clean \
             --if-exists \
             --no-owner \

--- a/.github/workflows/release-database-compatibility-check.yml
+++ b/.github/workflows/release-database-compatibility-check.yml
@@ -65,8 +65,12 @@ jobs:
           printf '%s\n' "$DATABASE_PEM_CERT" | sed -e 's/\r$//' > /tmp/prod-db-ca.pem
           openssl x509 -in /tmp/prod-db-ca.pem -noout -subject
 
+          # sslmode=verify-full also validates the server certificate's hostname
+          # against PROD_DATABASE_HOST (verify-ca only validates the CA chain),
+          # matching db-reconcile.yml. Keep this in step with the TLS posture
+          # the app pool and drizzle configs use.
           PGPASSWORD="$PROD_DATABASE_PASSWORD" /usr/lib/postgresql/18/bin/pg_dump \
-            "host=$PROD_DATABASE_HOST port=$PROD_DATABASE_PORT user=$PROD_DATABASE_USER dbname=$PROD_DATABASE_DATABASE sslmode=verify-ca sslrootcert=/tmp/prod-db-ca.pem" \
+            "host=$PROD_DATABASE_HOST port=$PROD_DATABASE_PORT user=$PROD_DATABASE_USER dbname=$PROD_DATABASE_DATABASE sslmode=verify-full sslrootcert=/tmp/prod-db-ca.pem" \
             --clean \
             --if-exists \
             --no-owner \

--- a/packages/db/src/utils/db-ssl.ts
+++ b/packages/db/src/utils/db-ssl.ts
@@ -231,20 +231,45 @@ export function stagingCaCert(): string | undefined {
 export function caCertForConnection(
   connectionString: string | undefined
 ): string | undefined {
+  return caCertSourceForConnection(connectionString).cert;
+}
+
+/**
+ * The certificate for a connection *and* the env var that supplied it.
+ *
+ * Split out so a missing certificate is reported against the variable the
+ * lookup actually consulted. `resolveDbPoolConfig` previously let
+ * `remoteDbSslConfig` fall back to its `DATABASE_PEM_CERT` default, which named
+ * the wrong variable for a staging host — where `stagingCaCert()` reads
+ * `STAGING_DATABASE_PEM_CERT` first.
+ *
+ * @param connectionString - Postgres URL the certificate must verify
+ * @returns The certificate, if configured, and the variable to name on failure
+ */
+function caCertSourceForConnection(connectionString: string | undefined): {
+  cert: string | undefined;
+  varName: string;
+} {
   const stagingHost = process.env.STAGING_DATABASE_HOST;
 
   if (connectionString && stagingHost) {
     try {
       const host = normalizeDbHost(new URL(connectionString).hostname);
       if (host && host === normalizeDbHost(stagingHost)) {
-        return stagingCaCert();
+        return {
+          cert: stagingCaCert(),
+          varName: 'STAGING_DATABASE_PEM_CERT (or DATABASE_PEM_CERT)',
+        };
       }
     } catch {
       // Unparseable URL — fall through to the shared certificate.
     }
   }
 
-  return process.env.DATABASE_PEM_CERT || undefined;
+  return {
+    cert: process.env.DATABASE_PEM_CERT || undefined,
+    varName: 'DATABASE_PEM_CERT',
+  };
 }
 
 /**
@@ -320,13 +345,13 @@ export function resolveDbPoolConfig(
     return { connectionString: sanitized, ssl: false };
   }
 
-  const rawCert = caCertForConnection(sanitized);
+  const { cert: rawCert, varName } = caCertSourceForConnection(sanitized);
 
   return {
     connectionString: sanitized,
     ssl:
       rawCert || options.requireCaCert
-        ? remoteDbSslConfig(rawCert)
+        ? remoteDbSslConfig(rawCert, varName)
         : { rejectUnauthorized: true },
   };
 }


### PR DESCRIPTION
## Description

Stacked on #1061 — merge into `fix/932-tls-verification` before that PR lands.

#1061 closes a real hole (`connection.ts:14` disables TLS entirely whenever
`NODE_TLS_REJECT_UNAUTHORIZED` is set, and both drizzle configs ship
`rejectUnauthorized: false`). Two gaps remain.

### 1. The verify-full escalation stops short of CI

`db-reconcile.yml` already dials both clusters at `verify-full` (lines 116, 250,
308) with a comment saying a downgrade needs explicit justification. #1061 drops
the `checkServerIdentity: () => undefined` override in `db-target.ts`, moving the
app pool and the migration scripts to verify-full too. But these two were left at
`verify-ca`:

| File | Line | Was |
| --- | --- | --- |
| `.github/workflows/pr-database-compatibility-check.yml` | 71 | `sslmode=verify-ca` (staging) |
| `.github/workflows/release-database-compatibility-check.yml` | 69 | `sslmode=verify-ca` (prod) |

That matters beyond consistency: `migrate-remote-db.ts:34` is the CI migration
path and hostname verification is **new** for it under #1061. Raising these two
makes CI prove the posture against staging and prod *before* the app pool starts
depending on it. `db-reconcile.yml` passing today is the evidence the provider
certs can satisfy it.

Local dumps stay `sslmode=disable` — the docker cluster serves no TLS.

### 2. A missing staging cert named the wrong variable

`resolveDbPoolConfig` called `remoteDbSslConfig(rawCert)` with no `certVarName`,
so it fell back to the `DATABASE_PEM_CERT` default. But `caCertForConnection`
host-matches staging and resolves through `stagingCaCert()`, which reads
`STAGING_DATABASE_PEM_CERT` first. A staging URL with no cert therefore threw
telling you to set a variable that was not the one consulted — in the one code
path whose whole purpose is arriving named rather than as an opaque
`SELF_SIGNED_CERT_IN_CHAIN`.

Extracted `caCertSourceForConnection`, returning the cert and the variable that
supplied it, so the host match is not duplicated. `caCertForConnection` keeps its
exported signature and all its existing tests.

## Verification

- `packages/db`: **50 tests / 6 files pass**, including `db-ssl.test.ts`
- `tsc --noEmit -p packages/db/tsconfig.json`: clean

## Not addressed here

`DATABASE_PLAINTEXT_HOSTS` still lets any named host drop to `ssl: false`. Much
narrower than the switch it replaces, but consider ignoring it when
`NODE_ENV === "production"`, or rejecting entries equal to
`STAGING_DATABASE_HOST` / `PROD_DATABASE_HOST`.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate