### PR TITLE
fix(site): use the react-vite storybook framework and drop the duplicate back link

### DIFF
--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/management-zone-form.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/management-zone-form.tsx
@@ -11,9 +11,7 @@ import type {
   ManagementZoneSelect,
 } from '@/lib/types/db';
 import { formatActionResponseErrors } from '@/lib/utils/actions';
-import Link from 'next/link';
 import { useForm } from 'react-hook-form';
-import { BiArrowBack } from 'react-icons/bi';
 import { updateManagementZone } from './actions';
 
 export default function ManagementZoneForm({
@@ -197,12 +195,6 @@ export default function ManagementZoneForm({
               <p className="text-sm text-[#ff4d00]">{errors.root.message}</p>
             </div>
           )}
-          <Link
-            href={'/account/management-zones'}
-            className="flex flex-row items-center gap-2 text-sm font-light hover:text-foreground/70 transition-all duration-300 ease-in-out"
-          >
-            <BiArrowBack className="size-5" /> Back to zones
-          </Link>
         </div>
       </div>
     </form>

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/page.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/page.tsx
@@ -46,6 +46,7 @@ export default async function ManagementZonePage({
           : 'View management zone details.'
       }
       backHref="/account/management-zones"
+      backLabel="Back to zones"
     >
       <ManagementZoneForm
         zone={curManagementZone}

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.stories.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/components/account-info/account-info.stories.tsx
@@ -1,6 +1,6 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import AccountInfo, {
   AccountInfoRow,
   AccountInfoSection,


### PR DESCRIPTION
## Description

Stacked on #1033 — merge into `feat/763-back-in-account-subpages` before that PR lands.

### 1. Storybook framework import will fail CI

`account-info.stories.tsx:3` imported `@storybook/nextjs-vite`. Main migrated to
`@storybook/react-vite` in `bca54ad`, and `nextjs-vite` now has **no entry in
`apps/site/package.json` and zero occurrences in `bun.lock`**.

`apps/site/tsconfig.json:25-33` includes `**/*.tsx`, so both `tsc --noEmit`
(`code-quality.yml:33`) and `next build` / `build-storybook` (`build.yml:32,35`)
resolve story imports and fail on TS2307. `eslint.config.mjs:49` globally ignores
`*.stories.*`, so `lint` stays green — which makes the failure look stranger than
it is.

> Worth flagging: **#1033 currently reports 5/5 green.** Those checks ran
> `2026-07-29`; the storybook migration landed `2026-08-11`. The green status
> predates the breaking change by 13 days and will flip the moment CI re-runs.

This PR only fixes the one story file #1033 adds. The other stories on this branch
still naming `nextjs-vite` are untouched by #1033, so they resolve from `main` on
merge.

### 2. Duplicate back link on the zone detail page

#1033 adds `backHref` to `management-zones/[zone]/page.tsx`, so `AccountInfo`
renders a Back link at the top. But `management-zone-form.tsx:200-205` already
rendered its own `Back to zones` link to the **same route** at the bottom.

Removed the in-form link so `AccountInfo` owns back navigation everywhere, and
carried its more specific wording onto the page as `backLabel="Back to zones"` —
which also avoids adding one more link whose accessible name is just `Back`. In a
screen-reader link list across the account area those are indistinguishable;
consider destination-specific labels on the other five call sites too.

`Link` and `BiArrowBack` were only used by the removed block, so both imports go
with it.

## Verification

- `tsc --noEmit` in `apps/site`: clean
- `vitest run` over the account subtree: **13 tests / 7 files pass**

## Note

`management-zone-form.tsx` is also rewritten by #1035 (shadcn calendar). Landing
#1033 first keeps that rebase to the import block.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate