### PR TITLE
fix(site): stop invalid dates and NaN coordinates reaching the zone update

### DIFF
--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/actions.test.ts
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/actions.test.ts
@@ -239,6 +239,46 @@ describe('updateManagementZone', () => {
     expect(written).toHaveProperty('name', 'North field');
   });
 
+  it('drops a location whose coordinates are not both finite', async () => {
+    // Clearing a coordinate box reaches the action as NaN, because
+    // react-hook-form's getFieldValueAs maps '' to NaN under valueAsNumber.
+    // PgPointTuple renders that as the literal "(NaN,NaN)", which Postgres
+    // accepts as float8 NaN and stores over the zone's real position.
+    await updateManagementZone(
+      ZONE_ID,
+      makeFormPayload({ location: [Number.NaN, Number.NaN] })
+    );
+
+    const written = capturedUpdateData.value as Record<string, unknown>;
+
+    expect(written).not.toHaveProperty('location');
+    expect(written).toHaveProperty('name', 'North field');
+  });
+
+  it('drops a half-filled location rather than writing a partial point', async () => {
+    await updateManagementZone(
+      ZONE_ID,
+      makeFormPayload({ location: [12.5, Number.NaN] })
+    );
+
+    expect(capturedUpdateData.value).not.toHaveProperty('location');
+  });
+
+  it('rejects an invalid date without touching the db', async () => {
+    // An emptied <input type="date"> becomes new Date('') under valueAsDate.
+    // Writing it would reach PgDate.mapToDriverValue and throw
+    // "RangeError: Invalid time value" from .toISOString(), after the action
+    // had already been accepted.
+    await expect(
+      updateManagementZone(
+        ZONE_ID,
+        makeFormPayload({ npkLastUsed: new Date('') })
+      )
+    ).rejects.toThrow();
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it('keeps the update scoped to the zone and the caller’s farm', async () => {
     // The client id diverges from the session id, so a WHERE built from
     // `input.farmId` instead of the session would bind 99 and fail below.

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/actions.ts
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/actions.ts
@@ -25,7 +25,13 @@ import { revalidatePath } from 'next/cache';
  * places no constraint on *what* is written to it.
  *
  * `undefined` values are dropped so untouched fields keep their stored value,
- * while `null` is preserved — it is how the form clears an optional date.
+ * while `null` is preserved — it is how the form clears an optional date, and
+ * drizzle emits it as a NULL parameter.
+ *
+ * `location` is dropped unless it is a complete pair of finite coordinates. An
+ * emptied coordinate box reaches this action as `NaN`, and `PgPointTuple`
+ * renders that as `(NaN,NaN)`, which Postgres accepts as float8 `NaN` and
+ * stores — silently corrupting the zone's position.
  *
  * @param input - Raw management zone payload from the client
  * @returns The subset of columns that are safe to write
@@ -35,7 +41,12 @@ function pickEditableManagementZoneFields(
 ): Partial<ManagementZoneInsert> {
   const editable: Partial<ManagementZoneInsert> = {
     name: input.name,
-    location: input.location,
+    location:
+      Array.isArray(input.location) &&
+      input.location.length === 2 &&
+      input.location.every((coordinate) => Number.isFinite(coordinate))
+        ? input.location
+        : undefined,
     rotationYear: input.rotationYear,
     npk: input.npk,
     npkLastUsed: input.npkLastUsed,
@@ -78,6 +89,17 @@ export async function updateManagementZone(
     }
 
     assertCanEditFarm(currentUser, 'update-management-zone');
+
+    // An emptied `<input type="date">` reaches react-hook-form as '', and
+    // `getFieldValueAs` turns that into `new Date('')`. Writing an Invalid Date
+    // would reach `PgDate.mapToDriverValue` and throw a RangeError from
+    // `.toISOString()`, so reject it by name instead.
+    for (const field of ['rotationYear', 'npkLastUsed'] as const) {
+      const value = input[field];
+      if (value instanceof Date && Number.isNaN(value.getTime())) {
+        throwActionError(`Invalid date supplied for ${field}`);
+      }
+    }
 
     const updates = pickEditableManagementZoneFields(input);
 

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/management-zone-form.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/management-zone-form.tsx
@@ -90,7 +90,9 @@ export default function ManagementZoneForm({
             type="number"
             step="any"
             disabled={!canEdit}
-            {...register('location.0', { valueAsNumber: true })}
+            {...register('location.0', {
+              setValueAs: (value) => (value === '' ? undefined : Number(value)),
+            })}
           />
         </div>
         <div>
@@ -106,7 +108,9 @@ export default function ManagementZoneForm({
             type="number"
             step="any"
             disabled={!canEdit}
-            {...register('location.1', { valueAsNumber: true })}
+            {...register('location.1', {
+              setValueAs: (value) => (value === '' ? undefined : Number(value)),
+            })}
           />
         </div>
       </div>
@@ -124,7 +128,9 @@ export default function ManagementZoneForm({
             id="rotationYear"
             type="date"
             disabled={!canEdit}
-            {...register('rotationYear', { valueAsDate: true })}
+            {...register('rotationYear', {
+              setValueAs: (value) => (value === '' ? null : new Date(value)),
+            })}
             defaultValue={zone.rotationYear?.toISOString().split('T')[0]}
           />
         </div>
@@ -141,7 +147,7 @@ export default function ManagementZoneForm({
             type="date"
             disabled={!canEdit}
             {...register('npkLastUsed', {
-              valueAsDate: true,
+              setValueAs: (value) => (value === '' ? null : new Date(value)),
             })}
             defaultValue={zone.npkLastUsed?.toISOString().split('T')[0]}
           />


### PR DESCRIPTION
## Description

Stacked on #1069 — merge into `fix/management-zone-field-allowlist` before that PR lands.

#1069's core fix is correct: `.set({ ...input })` really did let a farm Admin
rewrite `id`, `farmId`, `createdAt` and `updatedAt`, and the allowlist closes it.
Two input-coercion problems remain on the same code path.

### Root cause — verified, not inferred

react-hook-form **7.72.1**, `getFieldValueAs` (`dist/index.esm.mjs:974-986`):

```js
: valueAsNumber
    ? value === "" ? NaN : value ? +value : value
: valueAsDate && isString(value)
    ? new Date(value)
```

So an emptied input on this form yields `NaN` (coordinates) or `new Date("")`
(dates). Both then reach drizzle:

| Cleared input | Value | Result at the DB layer |
| --- | --- | --- |
| Latitude / Longitude | `NaN` | `PgPointTuple` renders `"(NaN,NaN)"`; Postgres accepts float8 `NaN` and **stores it**, silently overwriting the zone position |
| Rotation year / NPK last used | `Invalid Date` | `PgDate.mapToDriverValue` calls `.toISOString()` → **`RangeError: Invalid time value`** |

Confirmed by generating real SQL with drizzle `.toSQL()` against the actual
schema (no database required):

```
NaN location   -> set "location" = $1 ... PARAMS: ["(NaN,NaN)", ...]
Invalid Date   -> THREW RangeError: Invalid time value
```

### Fixes

1. Both coordinate inputs and both date inputs now use `setValueAs`, so an
   emptied box yields `undefined` (leave the stored value alone) or `null`
   (clear the date) rather than `NaN` / `Invalid Date`.
2. The action drops `location` unless it is a complete pair of finite
   coordinates, so a half-filled point cannot overwrite a stored one.
3. The action rejects an `Invalid Date` by name, instead of being accepted and
   then failing inside the driver.

### One correction to the review of #1069

It was suggested that `.set({ npkLastUsed: null })` throws a `TypeError`, and
that the `preserves null so an optional date can be cleared` test therefore
asserts something untrue. **That is not the case** — `.toSQL()` shows a bare
`null` emitting a clean NULL parameter:

```
set "npk_last_used" = $1, "updated_at" = $2   PARAMS: [null, "2026-…Z", …]
```

That test is correct as written and needs no change. Also confirmed in the same
run: `updated_at` still auto-refreshes via `$onUpdate` when absent from the set,
and identity columns stay out of the statement.

## Verification

- `tsc --noEmit` in `apps/site`: clean
- Full site suite: **623 tests / 125 files pass** (3 new)
- Drizzle `.toSQL()` used to prove both failure modes and both fixes

## Merge-order notes

- #1069's base is `fix/vitest-localstorage-shim` (#1068), so it currently targets
  that branch rather than `main`. Its diff contains none of #1068's work and its
  tests do not need the storage shim, so it can be retargeted to `main` directly.
- `management-zone-form.tsx` is also rewritten by #1035 (shadcn calendar), which
  keeps `location: [0, 0]` and does not address the coordinate clobber — so this
  guard is still needed after #1035, and whichever lands second needs a manual
  rebase.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate