### PR TITLE
fix(ci): pin sync-imps-to-staging actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/sync-imps-to-staging.yml
+++ b/.github/workflows/sync-imps-to-staging.yml
@@ -26,15 +26,15 @@ jobs:
       STAGING_DATABASE_PEM_CERT: ${{ secrets.STAGING_DATABASE_PEM_CERT || secrets.DATABASE_PEM_CERT }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: projects/609771777761/locations/global/workloadIdentityPools/github-actions/providers/nightcrawler-github
           service_account: nightcrawler-sheets@cs-poc-2f95m8o39tibkpwhorfifd3.iam.gserviceaccount.com
           create_credentials_file: true
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun i


### PR DESCRIPTION
## Description

Targets `main` directly — independent of #1022.

`sync-imps-to-staging.yml` is the **only workflow still using mutable action tags**, and it is the most privileged one in the repo.

### Why it was missed

It is not an oversight in #1022. The file was added to `main` by `2f2060a` (#1026) **after** that PR's branch was cut, so it was never in scope. When #1022 merges, this file arrives unpinned regardless — hence a separate PR.

### Why it matters most

| | |
| --- | --- |
| `google-github-actions/auth@v3` | GCP **Workload Identity Federation** → `projects/609771777761/…/nightcrawler-github`, service account `nightcrawler-sheets@…`, `create_credentials_file: true` |
| Job `env` | `OPENAI_EMBEDDINGS_KEY`, `STAGING_DATABASE_HOST/PORT/USER/PASSWORD/DATABASE`, `DATABASE_PEM_CERT`, `STAGING_DATABASE_PEM_CERT` |

A hijacked `v3` tag mints live GCP credentials **inside a job already holding the staging database password and PEM cert**. `google-github-actions/auth` appears nowhere else in the repo, so this is its only pin anywhere.

### SHAs — resolved mechanically, not by hand

Every value came from the GitHub API at time of writing:

```
gh api repos/actions/checkout/git/ref/tags/v6            -> d23441a48e516b6c34aea4fa41551a30e30af803
gh api repos/google-github-actions/auth/git/ref/tags/v3  -> 7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
gh api repos/oven-sh/setup-bun/git/ref/tags/v2           -> 0c5077e51419868618aeaa5fe8019c62421857d6
```

All three refs are of type `commit` (no annotated-tag dereference needed).

### Verified while here

I also mechanically checked every pin already proposed in #1022 — **all seven are correct**:

| Action | Pinned SHA | Verified |
| --- | --- | --- |
| `actions/checkout` | `df4cb1c0` | real commit, v6.0.3 |
| `actions/setup-node` | `24997072` | matches `tags/v6` |
| `actions/upload-artifact` | `043fb46d` | matches `tags/v7` |
| `oven-sh/setup-bun` | `0c5077e5` | matches `tags/v2` |
| `dependabot/fetch-metadata` | `21025c70` | matches `tags/v2` |
| `codecov/codecov-action` | `0fb71748` | matches `tags/v5` after annotated-tag deref |
| `lewagon/wait-on-check-action` | `eb1f8d8f` | real, but pins **v1.8.0** while `main` runs v1.9.0 — see #1022 |

### Note

`.github/dependabot.yml:89-101` already tracks the `github-actions` ecosystem with a `patterns: [*]` group, so these pins will not rot.

## Verification

YAML parses cleanly (`yaml-lint`). No logic, step ordering, permissions or `with:` values changed — only the three `uses:` refs.

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate