### PR TITLE
fix(ci): re-pin wait-on-check-action to v1.9.0 and normalise pin comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 #v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '20'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 'latest'
 
@@ -38,7 +38,7 @@ jobs:
         run: bun run build-storybook
 
       - name: Upload Next.js build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: nextjs-build
@@ -48,7 +48,7 @@ jobs:
           retention-days: 7
 
       - name: Upload Storybook build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: storybook-build

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 #v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '20'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 'latest'
 

--- a/.github/workflows/db-reconcile.yml
+++ b/.github/workflows/db-reconcile.yml
@@ -53,7 +53,7 @@ jobs:
       STAGING_DATABASE_PEM_CERT: ${{ secrets.STAGING_DATABASE_PEM_CERT || secrets.DATABASE_PEM_CERT }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install PostgreSQL 18 client
         run: |

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -43,7 +43,7 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Wait for status checks to complete
-        uses: lewagon/wait-on-check-action@eb1f8d8fb8af5d2d3c1978a3fae7ef38eaa587e8 # v1.8.0
+        uses: lewagon/wait-on-check-action@2271c86c146b96545b4e871b855e10ffa6f50773 # v1.9.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-regexp: '^(Code Quality Checks|Unit Tests|Build Application|Security Audit)$'

--- a/.github/workflows/release-database-compatibility-check.yml
+++ b/.github/workflows/release-database-compatibility-check.yml
@@ -40,10 +40,10 @@ jobs:
       LOCAL_DATABASE_DATABASE: nightcrawler_validation
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install PostgreSQL 18 client
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 'latest'
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 #v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '20'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 'latest'
 

--- a/.github/workflows/vercel-deploy-on-hotfix-push.yml
+++ b/.github/workflows/vercel-deploy-on-hotfix-push.yml
@@ -13,8 +13,8 @@ jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - name: Install Vercel CLI
         run: bun install --global vercel@latest
       - name: Pull Vercel Environment Information

--- a/.github/workflows/vercel-deploy-on-release.yml
+++ b/.github/workflows/vercel-deploy-on-release.yml
@@ -18,8 +18,8 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 #v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - name: Install Vercel CLI
         run: bun i --global vercel@latest
       - name: Pull Vercel Environment Information


### PR DESCRIPTION
## Description

Stacked on #1022 — merge into `fix/pin-action-shas` before that PR lands.

### 1. The `wait-on-check-action` pin is a downgrade

`dependabot-auto-approve.yml:46` pinned the **v1.8.0** commit, but `main` already runs `@v1.9.0`. Merging as-is rolls the action back a minor version — and this is the hunk causing the conflict, so pre-resolving it here removes that conflict too.

Re-pinned to the v1.9.0 commit. Note `v1.9.0` is an **annotated** tag, so it needs dereferencing:

```
git/ref/tags/v1.9.0  -> fa4138d3…  (type: tag)
git/tags/fa4138d3    -> 2271c86c146b96545b4e871b855e10ffa6f50773  (commit)
```

Pinning `fa4138d3` directly would have been wrong — that is the tag object, not a commit.

### 2. Comment style was inconsistent within single files

`build.yml` used `# v6` on checkout but `#v6` on setup-node and setup-bun. Dependabot's `github-actions` updater parses that trailing comment to decide what to bump, so an unparseable one risks a pin silently never being updated. Normalised all to `# vX`.

## Your SHAs are correct — I verified all seven mechanically

This was the one property that could not be checked by eye, so I resolved each against the GitHub API:

| Action | Pinned | Result |
| --- | --- | --- |
| `actions/checkout` | `df4cb1c0` | real commit — **v6.0.3** (`v6` now points at `d23441a4`, so this is slightly behind but valid) |
| `actions/setup-node` | `24997072` | matches `tags/v6` |
| `actions/upload-artifact` | `043fb46d` | matches `tags/v7` |
| `oven-sh/setup-bun` | `0c5077e5` | matches `tags/v2` |
| `dependabot/fetch-metadata` | `21025c70` | matches `tags/v2` |
| `codecov/codecov-action` | `0fb71748` | matches `tags/v5` after annotated-tag deref |
| `lewagon/wait-on-check-action` | `eb1f8d8f` | real, but v1.8.0 — fixed here |

No SHA other than `wait-on-check-action` is changed by this PR.

## Correction to my earlier review comment

I previously wrote that this PR "skips" `sync-imps-to-staging.yml`. **That was unfair** — that file was added to `main` by `2f2060a` (#1026) *after* this branch was cut, so it was never in scope. Apologies.

The gap is real but independent, so I pinned it against `main` in #1075 (it is the only workflow using `google-github-actions/auth`, in a job holding the staging DB password and PEM cert).

## Suggested follow-up

Nothing in CI enforces pinning, so this can regress silently. Adding `zizmor` or `pin-github-action` to `code-quality.yml` would make it a standing gate rather than a one-time cleanup.

## Verification

All 11 workflow files parse as valid YAML. No logic, step ordering, `permissions` or `with:` values changed — only `uses:` refs and trailing comments.

## Checklist

- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate