### PR TITLE
fix(site): add popover data-slot, fix v4 origin syntax and the inert label

### DIFF
--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/management-zone-form.test.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/management-zone-form.test.tsx
@@ -76,6 +76,35 @@ describe('ManagementZoneForm date pickers', () => {
     );
   });
 
+  it('marks the open panel with data-slot so the calendar renders transparent', async () => {
+    const user = userEvent.setup();
+    render(<ManagementZoneForm zone={zone} canEdit />);
+
+    await user.click(screen.getByRole('button', { name: ROTATION_TRIGGER }));
+
+    // calendar.tsx styles itself with
+    // `[[data-slot=popover-content]_&]:bg-transparent`. Without this attribute
+    // on the panel the selector never matches and the calendar keeps
+    // `bg-background` inside a `bg-popover` panel — a silent visual bug no
+    // other assertion would catch.
+    const panel = document.querySelector('[data-slot="popover-content"]');
+    expect(panel).not.toBeNull();
+    expect(panel).toContainElement(
+      screen.getByRole('button', { name: /july 15th, 2026/i })
+    );
+  });
+
+  it('does not point a label at the trigger button', async () => {
+    render(<ManagementZoneForm zone={zone} canEdit />);
+
+    // A `<label for>` cannot name a button, so the association was inert and
+    // clicking the text did nothing. The trigger owns its accessible name.
+    expect(document.querySelector('label[for="rotationYear"]')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: ROTATION_TRIGGER })
+    ).toBeInTheDocument();
+  });
+
   it('disables both pickers for read only accounts', () => {
     render(<ManagementZoneForm zone={zone} canEdit={false} />);
 

--- a/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/management-zone-form.tsx
+++ b/apps/site/src/app/(authenticated)/(no-sidebar)/account/(with-shell)/management-zones/[zone]/management-zone-form.tsx
@@ -99,12 +99,19 @@ function DateField({
 
   return (
     <div>
-      <Label
-        htmlFor={name}
+      {/*
+        A `<label for>` cannot name a `<button>`, so this is a plain span: the
+        association was inert and clicking it did nothing, unlike the native
+        date input it replaced. The trigger below carries the accessible name
+        via aria-label, so this copy is hidden from assistive tech to avoid
+        announcing the label twice.
+      */}
+      <span
+        aria-hidden="true"
         className="block text-sm font-medium leading-tight mb-1"
       >
         {label}
-      </Label>
+      </span>
       <Controller
         control={control}
         name={name}

--- a/apps/site/src/components/ui/popover.tsx
+++ b/apps/site/src/components/ui/popover.tsx
@@ -7,10 +7,32 @@ import * as PopoverPrimitive from '@radix-ui/react-popover';
 
 import { cn } from '@/lib/utils';
 
-const Popover = PopoverPrimitive.Root;
+/**
+ * Popover root.
+ */
+const Popover = ({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) => (
+  <PopoverPrimitive.Root data-slot="popover" {...props} />
+);
 
-const PopoverTrigger = PopoverPrimitive.Trigger;
+/**
+ * Element that toggles the popover.
+ */
+const PopoverTrigger = ({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) => (
+  <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+);
 
+/**
+ * Floating popover panel.
+ *
+ * `data-slot="popover-content"` is load-bearing, not decoration: `calendar.tsx`
+ * styles itself with `[[data-slot=popover-content]_&]:bg-transparent`, which
+ * silently does nothing without this attribute — the calendar keeps
+ * `bg-background` inside a `bg-popover` panel.
+ */
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
@@ -18,10 +40,11 @@ const PopoverContent = React.forwardRef<
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
+      data-slot="popover-content"
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)',
         className
       )}
       {...props}


### PR DESCRIPTION
## Description

Stacked on #1035 — merge into `feat/748-shadcn-calendar` before that PR lands.

The calendar swap itself is good — in particular the timezone round-trip (`toCalendarDate` / `fromCalendarDate` against `toDisplayDate`'s `timeZone: 'UTC'`) is **strictly better** than the `toISOString().split('T')[0]` + `valueAsDate` pairing it replaces. Three defects in the vendored files.

### 1. `popover.tsx` omits `data-slot`, so the calendar's own styling hook is dead

`calendar.tsx:34` styles itself with:

```
[[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent
```

…but the vendored `PopoverContent` rendered no `data-slot` attribute. The selector never matched, so the calendar kept `bg-background` inside a `bg-popover` panel.

Added `data-slot` to `popover`, `popover-trigger` and `popover-content`, matching the convention already established in `dialog.tsx:13-14,41,63`.

**This is now covered by a test** that opens the picker and asserts the panel carries the attribute. I verified it genuinely catches the bug — removing the attribute again fails exactly that test and nothing else:

```
× marks the open panel with data-slot so the calendar renders transparent
  Tests  1 failed | 4 passed
```

### 2. Tailwind v3 syntax in a v4 project

```diff
-origin-[--radix-popover-content-transform-origin]
+origin-(--radix-popover-content-transform-origin)
```

This repo runs `tailwindcss ^4.2.2`. The bare `[--var]` shorthand is v3; v4 requires parentheses for a CSS-variable value. As written the utility emitted nothing, so the zoom/slide animations pivoted from the element centre instead of from the trigger. The rest of the vendored code already uses v4 syntax correctly (`h-(--cell-size)` in `calendar.tsx`), so this line was simply stale.

### 3. `<Label htmlFor>` pointed at a `<button>`, which is inert

A `<label for>` cannot label a button, so clicking the label did nothing — a regression against the native `<input type="date">` it replaced, which was focusable that way.

The code already compensated for screen readers with `aria-label={`${label}: ${displayValue}`}` on the trigger, which is correct. But the visible label kept a false association. It is now a plain `<span aria-hidden="true">`, so:

- no misleading `for` relationship
- the trigger remains the single source of the accessible name (no double announcement)

Also covered by a test asserting no `label[for="rotationYear"]` exists.

## Verification

Because this branch adds `@radix-ui/react-popover` and `react-day-picker`, I ran a real `bun install --frozen-lockfile` in an isolated worktree rather than relying on the root `node_modules` — otherwise every check is a false negative on unresolved modules.

- `tsc --noEmit`: **clean**
- Full site suite: **560 tests / 118 files pass** (2 new)
- New `data-slot` test confirmed to fail when the fix is reverted

## Not fixed here

- **`bun.lock` will conflict.** The lock hunk re-bumps `brace-expansion ^5.0.7 → ^5.0.8`, but `main` already pins `^5.0.8` at `package.json:80`. Regenerate the lock on top of current `main` rather than resolving by hand.
- **`DateField` is inline in the page-local form file.** It is generic (`control` + `name` + `label` + `disabled`) and the farm-profile and IMP forms will want it; feature-sliced design argues for its own module. Left alone to keep this diff reviewable.
- The test hand-rolls `globalThis.ResizeObserver ??= class {}` even though `resize-observer-polyfill` is already an `apps/site` devDependency. Worth moving into `vitest.setup.ts` once, since every future Radix-popover test needs it.

## Interaction with #1069

`management-zone-form.tsx` is also touched by #1069 (identity-column allowlist). #1035 keeps `location: [0, 0]` and does not address the coordinate clobber, so #1069's guard is still required after this lands. Whichever merges second needs a manual rebase on that file.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
