### PR TITLE
fix(site): use react-vite storybook framework and finish the socials cut-over

### DIFF
--- a/apps/site/src/app/not-found.tsx
+++ b/apps/site/src/app/not-found.tsx
@@ -9,36 +9,7 @@ import { Link } from '@/i18n/config';
 import { createClient } from '@/lib/supabase/server';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
-import {
-  FaInstagram,
-  FaLinkedinIn,
-  FaXTwitter,
-  FaYoutube,
-} from 'react-icons/fa6';
-
-/** Social media links displayed at the bottom of the 404 page. */
-const socialMediaIcons = [
-  {
-    icon: <FaInstagram aria-hidden="true" />,
-    href: 'https://www.instagram.com/toddagriscience/',
-    ariaLabel: 'Visit our Instagram page',
-  },
-  {
-    icon: <FaLinkedinIn aria-hidden="true" />,
-    href: 'https://www.linkedin.com/company/toddagriscience/',
-    ariaLabel: 'Visit our LinkedIn page',
-  },
-  {
-    icon: <FaXTwitter aria-hidden="true" />,
-    href: 'https://x.com/toddagriscience',
-    ariaLabel: 'Visit our X (Twitter) page',
-  },
-  {
-    icon: <FaYoutube aria-hidden="true" />,
-    href: 'https://www.youtube.com/@toddagriscience',
-    ariaLabel: 'Visit our YouTube channel',
-  },
-];
+import SocialLinks from '@/components/common/social-links/social-links';
 
 /**
  * Async server component that fetches locale data and auth state.
@@ -83,17 +54,9 @@ async function NotFoundContent() {
               </div>
             </div>
             <div className="flex justify-center">
-              <div className="flex flex-row flex-wrap gap-6">
-                {socialMediaIcons.map((val) => (
-                  <Link
-                    key={val.href}
-                    href={val.href}
-                    aria-label={val.ariaLabel}
-                  >
-                    {val.icon}
-                  </Link>
-                ))}
-              </div>
+              <SocialLinks
+                platforms={['instagram', 'linkedin', 'x', 'youtube']}
+              />
             </div>
           </div>
         </FadeIn>

--- a/apps/site/src/components/common/social-links/social-links.stories.tsx
+++ b/apps/site/src/components/common/social-links/social-links.stories.tsx
@@ -1,6 +1,6 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import SocialLinks from './social-links';
 
 const meta: Meta<typeof SocialLinks> = {


### PR DESCRIPTION
## Description

Stacked on #1018 — merge into `feat/786-socials-link-component` before that PR lands.

### 1. The storybook import is why Build and Code Quality fail

`social-links.stories.tsx:3` imported `@storybook/nextjs-vite`. `main` migrated to `@storybook/react-vite` in `bca54ad`; `nextjs-vite` is absent from `apps/site/package.json` and has **zero occurrences in `bun.lock`**.

`apps/site/tsconfig.json:25-33` includes `**/*.tsx`, so `tsc --noEmit` (`code-quality.yml:33`) and `next build` / `build-storybook` (`build.yml:32,35`) both resolve it and fail with TS2307. `eslint.config.mjs:49` ignores `*.stories.*`, so `lint` stays green — which is what makes the failure look odd.

### 2. Completing the cut-over — `not-found.tsx` was a third copy

The PR's stated goal is that social URLs, labels and icons "never duplicate them". But `not-found.tsx:20-41` still declared its own array of the same four links and rendered them at `:86-93`, so a URL change would still have needed two edits.

Migrated it to `<SocialLinks platforms={['instagram', 'linkedin', 'x', 'youtube']} />`, which also drops the now-unused `react-icons/fa6` import block. `SOCIAL_LINKS` is now genuinely the only place these URLs live.

The order and accessible labels are preserved exactly, so the existing 404 assertions are unaffected.

## Still needs the author — the marketing footer hunk no longer applies

I did not touch this, because it needs re-authoring rather than patching.

`main` restructured `footer.tsx`. The PR's pre-image expects `import Image from 'next/image'`, `socialMediaIcons` at ~line 52, and the socials in a standalone `<div className="flex flex-row flex-wrap gap-6">` at ~line 211. On `main`: no `next/image` import in that file, `socialMediaIcons` at 27-47, and the socials at ~139-145 inside `<div className="flex flex-wrap items-center gap-8 md:justify-end">` — **shared with the language switcher**. All three hunks fail.

That last point matters beyond the rebase: `SocialLinks` hard-codes `flex flex-row flex-wrap gap-6`, which is the `/go` footer's spacing. Dropping it into `main`'s bottom bar nests a `gap-6` row inside a `gap-8` row with nothing passed to compensate, so the marketing footer's spacing shifts. When re-authoring, either pass the existing classes through (`className="items-center gap-8"`) or make the wrapper class-free and let callers own layout.

## One behaviour change worth a decision

Marketing social links move from `<Link href>` (same tab) to `<a target="_blank" rel="noopener noreferrer">`. `rel` is correct, but the accessible names (`Visit our Instagram page`) do not announce the new tab. Either keep same-tab behaviour behind a prop, or append "(opens in a new tab)" to the labels.

## Worth keeping through the rebase

The `/go` Discord href had a trailing space (`'https://discord.gg/rFY3kc4deK '`). `SOCIAL_LINKS.discord.href` drops it — a genuine bug fix hiding in the refactor.

## Verification

- `tsc --noEmit`: clean
- Full site suite: **553 tests / 117 files pass**

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
