### PR TITLE
fix(site): key the rate limiter on a trustworthy client IP

### DIFF
--- a/apps/site/env.example
+++ b/apps/site/env.example
@@ -98,8 +98,10 @@ NEW_RELIC_APP_NAME="TODD_SITE_TESTING"
 NEW_RELIC_LICENSE_KEY="secret"
 
 # Upstash Redis for IP-based rate limiting on public write endpoints (contact
-# form, CMS forms). Optional — when unset, rate limiting fails open (allows
-# requests) so local dev / CI / preview keep working. Provision via the Vercel
+# form, CMS forms). REQUIRED IN PRODUCTION. When unset, rate limiting fails
+# open (allows every request) with a single warn per cold start, so a
+# production deploy without these has no rate limiting at all. Unset is
+# intended only for local dev / CI / preview. Provision via the Vercel
 # Marketplace Upstash integration, which injects these automatically.
 UPSTASH_REDIS_REST_URL="https://your-db.upstash.io"
 UPSTASH_REDIS_REST_TOKEN="your-token"

--- a/apps/site/src/lib/rate-limit.ts
+++ b/apps/site/src/lib/rate-limit.ts
@@ -148,6 +148,12 @@ export const publicWriteRateLimit = createRateLimiter({
  * limiter, and throws an action error when the limit is exceeded. This is the
  * one-line guard server actions should call before doing any work.
  *
+ * When no trustworthy IP is available the check is skipped rather than keyed on
+ * a shared placeholder, which would put every such request into a single global
+ * bucket and rate-limit the whole world to `requests` per window collectively.
+ * On Vercel the edge always sets a forwarding header, so this is effectively
+ * unreachable in production and matches the limiter's existing fail-open stance.
+ *
  * @param check - Limiter to enforce. Defaults to {@link publicWriteRateLimit}.
  * @param message - Error surfaced to the client when rate limited.
  */
@@ -156,6 +162,11 @@ export async function enforceRateLimit(
   message = 'Too many requests. Please try again shortly.'
 ): Promise<void> {
   const ip = getClientIp(await headers());
+  if (!ip) {
+    logger.warn('[rate-limit] No trustworthy client IP; skipping check.');
+    return;
+  }
+
   const { success } = await check(ip);
   if (!success) {
     throwActionError(message);

--- a/apps/site/src/lib/utils/get-client-ip.test.ts
+++ b/apps/site/src/lib/utils/get-client-ip.test.ts
@@ -4,9 +4,27 @@ import { describe, expect, it } from 'vitest';
 import { getClientIp } from './get-client-ip';
 
 describe('getClientIp', () => {
-  it('returns the first IP from a comma-separated x-forwarded-for header', () => {
+  it('prefers the edge-set x-vercel-forwarded-for over a client-supplied header', () => {
+    const headers = new Headers({
+      'x-vercel-forwarded-for': '9.9.9.9',
+      'x-forwarded-for': '1.1.1.1, 2.2.2.2',
+    });
+    expect(getClientIp(headers)).toBe('9.9.9.9');
+  });
+
+  it('takes the right-most x-forwarded-for hop, not the client-controlled left-most', () => {
+    // x-forwarded-for is append-style, so the left-most entry is whatever the
+    // client sent. Keying on it would let an attacker rotate the header and get
+    // a fresh bucket per request, making the limiter a no-op.
     const headers = new Headers({ 'x-forwarded-for': '1.1.1.1, 2.2.2.2' });
-    expect(getClientIp(headers)).toBe('1.1.1.1');
+    expect(getClientIp(headers)).toBe('2.2.2.2');
+  });
+
+  it('ignores a spoofed left-most entry even when the client sends many', () => {
+    const headers = new Headers({
+      'x-forwarded-for': 'evil-1, evil-2, evil-3, 203.0.113.7',
+    });
+    expect(getClientIp(headers)).toBe('203.0.113.7');
   });
 
   it('returns the single IP when only one is present', () => {
@@ -14,13 +32,25 @@ describe('getClientIp', () => {
     expect(getClientIp(headers)).toBe('3.3.3.3');
   });
 
-  it('falls back to "unknown" when the header is absent', () => {
-    const headers = new Headers();
-    expect(getClientIp(headers)).toBe('unknown');
+  it('falls back to x-real-ip when no forwarding header is set', () => {
+    const headers = new Headers({ 'x-real-ip': '4.4.4.4' });
+    expect(getClientIp(headers)).toBe('4.4.4.4');
   });
 
-  it('falls back to "unknown" when the header is empty', () => {
+  it('returns null when no header is present', () => {
+    // Deliberately null rather than a sentinel string: a shared constant would
+    // put every header-less request into one bucket and rate-limit the whole
+    // world collectively.
+    expect(getClientIp(new Headers())).toBeNull();
+  });
+
+  it('returns null when the header is blank', () => {
     const headers = new Headers({ 'x-forwarded-for': '   ' });
-    expect(getClientIp(headers)).toBe('unknown');
+    expect(getClientIp(headers)).toBeNull();
+  });
+
+  it('returns null when the header is only separators', () => {
+    const headers = new Headers({ 'x-forwarded-for': ' , , ' });
+    expect(getClientIp(headers)).toBeNull();
   });
 });

--- a/apps/site/src/lib/utils/get-client-ip.ts
+++ b/apps/site/src/lib/utils/get-client-ip.ts
@@ -1,33 +1,48 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-/** Fallback identifier used when no client IP can be determined. */
-const UNKNOWN_CLIENT_IP = 'unknown';
-
 /**
- * Extracts the originating client IP address from request headers.
+ * Resolves the originating client IP for use as a rate-limit key.
  *
- * Reads the `x-forwarded-for` header (set by Vercel / upstream proxies), which
- * may contain a comma-separated list of IPs; the first entry is the original
- * client. Accepts a `Headers` object so callers can pass the result of
- * `await headers()` and so it is trivially unit-testable.
+ * Prefers `x-vercel-forwarded-for`, which the Vercel edge sets and a client
+ * cannot write. Falls back to the **right-most** entry of `x-forwarded-for`,
+ * then `x-real-ip`.
  *
- * Trust note: `x-forwarded-for` is client-supplied and only trustworthy because
- * the hosting proxy (Vercel) sets it. Used here as a rate-limit key for
- * defense-in-depth — not for auth — and the limiter fails open, so a spoofed
- * header cannot deny service to legitimate users. Do not rely on this value for
- * any security-critical decision without a trusted-proxy guarantee.
+ * The right-most entry matters. `x-forwarded-for` is append-style: each proxy
+ * adds the address it received the connection from, so the left-most element is
+ * whatever the *client* sent. Keying on it lets an attacker rotate
+ * `x-forwarded-for: <random>` and get a fresh bucket every request, which makes
+ * the limiter a no-op. The right-most entry is the one our own proxy appended.
  *
- * @param headerList - Request headers to read from.
- * @returns The trimmed client IP, or `'unknown'` when unavailable.
+ * Returns `null` rather than a sentinel string when nothing trustworthy is
+ * available. A shared constant would put every header-less request worldwide
+ * into one bucket, making the limit N requests per minute *in total* — a
+ * self-inflicted denial of service rather than a defence. Callers skip the
+ * limiter instead; on Vercel these headers are always present, so this path is
+ * effectively unreachable in production.
+ *
+ * Still not an authentication signal — defence in depth for public write
+ * endpoints only.
+ *
+ * @param headerList - Request headers to read from
+ * @returns The client IP, or `null` when none can be trusted
  */
-export function getClientIp(headerList: Headers): string {
-  const forwardedFor = headerList.get('x-forwarded-for');
-  if (!forwardedFor) {
-    return UNKNOWN_CLIENT_IP;
+export function getClientIp(headerList: Headers): string | null {
+  const vercelForwardedFor = headerList.get('x-vercel-forwarded-for')?.trim();
+  if (vercelForwardedFor) {
+    return vercelForwardedFor;
   }
 
-  const [first] = forwardedFor.split(',');
-  const ip = first?.trim();
+  const forwardedFor = headerList.get('x-forwarded-for');
+  if (forwardedFor) {
+    const hops = forwardedFor
+      .split(',')
+      .map((hop) => hop.trim())
+      .filter(Boolean);
+    const nearest = hops[hops.length - 1];
+    if (nearest) {
+      return nearest;
+    }
+  }
 
-  return ip ? ip : UNKNOWN_CLIENT_IP;
+  return headerList.get('x-real-ip')?.trim() || null;
 }


### PR DESCRIPTION
## Description

Stacked on #960 — merge into `fix/936-rate-limiting` before that PR lands.

The store choice in #960 is right and worth saying plainly: `Ratelimit` over `Redis.fromEnv()` with a sliding window means counters live in Upstash, so **this survives multi-instance serverless deployment**. No module-global `Map`. Two defects in how the key is derived, plus a docs fix.

### 1. The limiter keyed on the client-controlled end of `x-forwarded-for`

`get-client-ip.ts` took `forwardedFor.split(',')[0]` — the **left-most** entry.

`x-forwarded-for` is append-style: each proxy appends the address it received the connection from, so the left-most element is whatever the *client* sent. An attacker rotating `x-forwarded-for: <random>` gets a fresh Redis bucket on every request, and the limiter becomes a no-op.

Now, in order:

1. `x-vercel-forwarded-for` — set by the Vercel edge, not client-writable
2. the **right-most** `x-forwarded-for` hop — the one our own proxy appended
3. `x-real-ip`

### 2. All header-less traffic shared one global bucket

`getClientIp` returned the literal string `'unknown'`, passed straight to `check(ip)`. Every request lacking the header worldwide therefore shared `site:public-write:unknown` — **5 requests per minute in total, globally**. That is a self-inflicted denial of service, not a defence.

It now returns `null`, and `enforceRateLimit` skips the check with a `logger.warn` rather than keying on a placeholder. Skipping matches the limiter's existing deliberate fail-open stance, and on Vercel a forwarding header is always present, so this path is effectively unreachable in production.

### 3. `env.example` described the Upstash vars as "Optional"

Combined with `getRedis()` returning `null` on missing config, a production deploy without them yields **no rate limiting at all**, silently, with one warn per cold start. Reworded to "REQUIRED IN PRODUCTION", making clear that unset is for local dev / CI / preview only.

## Verification

`@upstash/ratelimit` and `@upstash/redis` are added by this branch, so I ran a real `bun install --frozen-lockfile` in an isolated worktree — otherwise every check is a false negative on unresolved modules.

- `tsc --noEmit`: clean
- Full site suite, run serially: **461 tests / 103 files pass**
- `get-client-ip` tests rewritten for the new contract, including a case asserting a spoofed left-most entry is ignored:

```ts
'x-forwarded-for': 'evil-1, evil-2, evil-3, 203.0.113.7'  →  '203.0.113.7'
```

## Not addressed here — still worth doing before this ships

**Coverage.** This guards `submitPublicInquiry` and `submitFormSubmission` (which does cover careers and platform-access applications). Still unguarded:

| Path | Risk |
| --- | --- |
| `signup/actions.ts:211` `resendApprovedApplicantActivationEmail` | Unauthenticated, **sends a real email** per call. Loopable → email-bombing an applicant and burning the Supabase invite quota. Highest-severity gap. |
| `signup/actions.ts:295` `signUp` | Unauthenticated; writes `farm` + `user` rows and creates a Supabase auth user, behind a token whose `applicationId` is a sequential integer — brute-forceable with no limit. |
| `api/revalidate/route.ts:45` | Non-constant-time secret compare, no limit; success purges the whole site cache. |
| `auth/confirm/route.ts:14` | Unauthenticated OTP verification, unlimited attempts. |

Correctly excluded: `api/stripe/webhook/route.ts:30-50` verifies the Stripe signature first.

**Fail-open on Redis errors.** `getRedis()` returning `null` and the `catch` around `limiter.limit` both return `{ success: true }`, so a missing config and an outage are indistinguishable from being under the limit. Consider throwing at module init in production when the vars are absent.

**Log level.** `enforceRateLimit` → `throwActionError` → `lib/utils/actions.ts:63` `logger.error`. Being rate limited is expected, so under attack each blocked request becomes an error-level line. `warn` would be better.

## Rebase note

Two of the eleven files patch `(contact)/contact/actions.ts` and its test, both **deleted on `main`** by the Sanity form-builder migration (`submitPublicInquiry` has zero occurrences repo-wide). Those hunks are a modify/delete conflict — drop them. The `forms/[slug]/actions.ts` call site still applies and already covers contact via `DynamicForm`.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
