### PR TITLE
feat(site): refactor about page partners section

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/partner.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/partner.tsx
@@ -1,10 +1,17 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import { StaticImport } from 'next/dist/shared/lib/get-img-props';
+import { cn } from '@/lib/utils';
 import Image from 'next/image';
+import type { PartnerProps } from './types';
 
 /** A single partner logo
  * @returns {JSX.Element} - The logo for a given partner, formatted to fit in the Partners component correctly. */
-export default function Partner({ src }: { src: StaticImport }) {
-  return <Image src={src} alt="" className="w-25 object-scale-down" />;
+export default function Partner({ src, alt, className }: PartnerProps) {
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      className={cn('h-auto w-20 object-scale-down sm:w-22 md:w-24', className)}
+    />
+  );
 }

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/partners.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/partners.tsx
@@ -42,7 +42,7 @@ export default function Partners() {
         <h2 className="text-3xl leading-tight font-normal md:text-4xl">
           {t('partners.title')}
         </h2>
-        <p className="max-w-xl px-4 pt-4 text-base leading-relaxed font-normal md:text-lg">
+        <p className="max-w-xl px-4 pt-4 text-base leading-relaxed font-normal">
           {t('partners.description')}
         </p>
       </div>

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/partners.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/partners.tsx
@@ -2,20 +2,20 @@
 
 'use client';
 
-import USDA from '@public/marketing/partners/usda.png';
 import BDA from '@public/marketing/partners/bda.png';
 import CCOF from '@public/marketing/partners/ccof.png';
 import CenterForFoodSafety from '@public/marketing/partners/centerforfoodsafety.png';
+import CornellCals from '@public/marketing/partners/cornellcals.png';
 import FarmLink from '@public/marketing/partners/farmlink.png';
 import NMState from '@public/marketing/partners/nmstate.png';
 import OFA from '@public/marketing/partners/ofa.png';
+import USDA from '@public/marketing/partners/usda.png';
 import WholeFoods from '@public/marketing/partners/wholefoods.png';
 import WhyRegenerative from '@public/marketing/partners/whyregenerative.png';
-import CornellCals from '@public/marketing/partners/cornellcals.png';
-import Partner from './partner';
-import { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+import Partner from './partner';
 
 /** The partners section of the About page
  * @returns {JSX.Element} - The partners section */
@@ -37,12 +37,14 @@ export default function Partners() {
   };
 
   return (
-    <div className="space-y-4 mb-20">
-      <div className="flex sm:flex-row flex-col gap-8 sm:gap-16 max-w-[80vw] mx-auto">
-        <h2 className="text-nowrap text-3xl md:text-4xl lg:text-5xl max-w-[200px] md:max-w-[250px] lg:max-w-[350px] leading-tight font-light md:basis-5/8">
+    <div className="mb-20 space-y-8 pt-12 md:pt-16">
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-4 text-center">
+        <h2 className="text-3xl leading-tight font-normal md:text-4xl">
           {t('partners.title')}
         </h2>
-        <p className="font-light">{t('partners.description')}</p>
+        <p className="max-w-xl px-4 pt-4 text-base leading-relaxed font-normal md:text-lg">
+          {t('partners.description')}
+        </p>
       </div>
       <div className="relative overflow-hidden min-h-50 gap-8 flex items-center justify-center">
         <AnimatePresence mode="wait">
@@ -54,14 +56,22 @@ export default function Partners() {
               animate="animate"
               exit="exit"
               transition={{ duration: 0.5 }}
-              className="flex flex-row flex-wrap gap-4 max-w-[90vw] mx-auto justify-center items-center"
+              className="mx-auto grid w-full max-w-sm grid-cols-2 place-items-center gap-x-6 gap-y-8 sm:gap-10 md:flex md:max-w-[90vw] md:flex-row md:flex-wrap md:items-center md:justify-center md:gap-12"
             >
-              <Partner src={USDA} />
-              <Partner src={FarmLink} />
-              <Partner src={WholeFoods} />
-              <Partner src={BDA} />
-              <Partner src={CCOF} />
-              <Partner src={NMState} />
+              <Partner src={USDA} alt="USDA" />
+              <Partner src={FarmLink} alt="The Farmlink Project" />
+              <Partner src={WholeFoods} alt="Whole Foods Market" />
+              <Partner src={NMState} alt="New Mexico State University" />
+              <Partner
+                src={BDA}
+                alt="Biodynamic Demeter Alliance"
+                className="w-32 sm:w-38 md:w-45"
+              />
+              <Partner
+                src={CCOF}
+                alt="CCOF Foundation"
+                className="w-14 sm:w-16 md:-ml-4 md:w-18"
+              />
             </motion.div>
           ) : (
             <motion.div
@@ -71,12 +81,15 @@ export default function Partners() {
               animate="animate"
               exit="exit"
               transition={{ duration: 0.5 }}
-              className="flex flex-row flex-wrap gap-4 max-w-[90vw] mx-auto justify-center items-center"
+              className="mx-auto grid w-full max-w-sm grid-cols-2 place-items-center gap-x-6 gap-y-8 sm:gap-10 md:flex md:max-w-[90vw] md:flex-row md:flex-wrap md:items-center md:justify-center md:gap-12"
             >
-              <Partner src={OFA} />
-              <Partner src={WhyRegenerative} />
-              <Partner src={CenterForFoodSafety} />
-              <Partner src={CornellCals} />
+              <Partner src={OFA} alt="Organic Farming Association" />
+              <Partner
+                src={WhyRegenerative}
+                alt="Why Regenerative Agriculture"
+              />
+              <Partner src={CenterForFoodSafety} alt="Center for Food Safety" />
+              <Partner src={CornellCals} alt="Cornell CALS" />
               <span className="font-bold">And Other</span>
               <span className="font-bold">Notable Partners</span>
             </motion.div>

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/types.ts
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/types.ts
@@ -1,0 +1,13 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import type { StaticImport } from 'next/dist/shared/lib/get-img-props';
+
+/** Properties used to render a partner logo. */
+export interface PartnerProps {
+  /** The statically imported partner logo. */
+  src: StaticImport;
+  /** Accessible name of the partner represented by the logo. */
+  alt: string;
+  /** Optional Tailwind classes for logo-specific sizing. */
+  className?: string;
+}

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/types.ts
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/types.ts
@@ -1,11 +1,11 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
-import type { StaticImport } from 'next/dist/shared/lib/get-img-props';
+import type { ImageProps } from 'next/image';
 
 /** Properties used to render a partner logo. */
 export interface PartnerProps {
   /** The statically imported partner logo. */
-  src: StaticImport;
+  src: ImageProps['src'];
   /** Accessible name of the partner represented by the logo. */
   alt: string;
   /** Optional Tailwind classes for logo-specific sizing. */

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/page.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/page.test.tsx
@@ -109,7 +109,11 @@ describe('WhoWeArePage', () => {
     renderWithNextIntl(<WhoWeArePage />);
 
     expect(
-      screen.getByRole('heading', { name: 'Our Partners' })
+      screen.getByRole('heading', { name: 'Backed by incredible partners' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'USDA' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: 'Biodynamic Demeter Alliance' })
     ).toBeInTheDocument();
   });
 

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/page.tsx
@@ -78,12 +78,6 @@ export default function WhoWeArePage() {
             />
           </div>
         </motion.div>
-      </div>
-      {/* Competencies Section */}
-      <CompetenciesSection t={t} />
-      {/* Responsibilities Section */}
-      <ResponsibilitiesSection t={t} />
-      <div className="flex flex-col mx-auto max-w-[1200px]">
         {/* Partners Section */}
         <motion.div
           className="w-full flex flex-col h-fit px-12 md:px-20 lg:px-26 py-16 lg:py-6"
@@ -94,7 +88,12 @@ export default function WhoWeArePage() {
         >
           <Partners />
         </motion.div>
-
+      </div>
+      {/* Competencies Section */}
+      <CompetenciesSection t={t} />
+      {/* Responsibilities Section */}
+      <ResponsibilitiesSection t={t} />
+      <div className="flex flex-col mx-auto max-w-[1200px]">
         <div className="w-full h-fit mb-16 md:mb-32 py-12 md:py-16">
           <Link
             href="/research"

--- a/apps/site/src/messages/about/en.json
+++ b/apps/site/src/messages/about/en.json
@@ -45,8 +45,8 @@
       }
     },
     "partners": {
-      "title": "Our Partners",
-      "description": "We’re fortunate to be supported by investors and industry partners who share our vision. Their backing will help us grow our team, scale our firm, and develop the first generation of generative farms."
+      "title": "Backed by incredible partners",
+      "description": "We’re fortunate to be supported by partners who share our vision. Their backing helps us advance sustainable agriculture."
     },
     "navigation": {
       "whatWeDo": "What we do"

--- a/apps/site/src/messages/about/es.json
+++ b/apps/site/src/messages/about/es.json
@@ -45,8 +45,8 @@
       }
     },
     "partners": {
-      "title": "Nuestros socios",
-      "description": "Tenemos la fortuna de contar con el apoyo de inversores y socios estratégicos que comparten nuestra visión. Su respaldo nos permitirá ampliar nuestro equipo, escalar la empresa y desarrollar la primera generación de granjas generativas."
+      "title": "Respaldado por socios increíbles",
+      "description": "Tenemos la suerte de contar con el apoyo de socios que comparten nuestra visión. Su respaldo nos ayuda a impulsar la agricultura sostenible."
     },
     "navigation": {
       "whatWeDo": "Qué hacemos"


### PR DESCRIPTION
## Description

Fixes #1103

Updates the About page partner section to match the issue reference. Preserves the existing rotating partner groups.

### What changed

- Updates the localized partner heading and description text.
- Centers the heading and description and adjusts their weight, wrapping, and spacing.
- Reorders the first partner-logo group to match the reference.
- Resizes the logos to match the reference, with tailored BDA and CCOF sizing.
- Uses a two-column, three-row mobile grid and a centered desktop row.
- Adds accessible partner names and feature-local typed logo props.
- NOTE: es.json was updated using Google Translate

### Testing

- Updates the About-page test for the new heading and accessible logo names.
- bun run validate passes formatting, types, lint, 651 tests, and builds.

## Checklist

- [x] Tests included where applicable.
- [x] Inline docs included where applicable.
- [x] Modified components are accessible.
- [x] Conventional commit format used.