### PR TITLE
ci: scope the github token to least privilege in every workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Application

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     name: Code Quality Checks

--- a/.github/workflows/db-reconcile.yml
+++ b/.github/workflows/db-reconcile.yml
@@ -33,6 +33,9 @@ on:
           - verify
           - apply
 
+permissions:
+  contents: read
+
 jobs:
   reconcile:
     name: Reconcile ${{ inputs.environment }} schema (${{ inputs.mode }})

--- a/.github/workflows/pr-database-compatibility-check.yml
+++ b/.github/workflows/pr-database-compatibility-check.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   staging-db-push-dry-run:
     name: Staging Clone + Drizzle Push Check

--- a/.github/workflows/release-database-compatibility-check.yml
+++ b/.github/workflows/release-database-compatibility-check.yml
@@ -8,6 +8,9 @@ on:
       - created
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   production-db-release-push:
     name: Production Drizzle Push Check

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   security:
     name: Security Audit

--- a/.github/workflows/sync-imps-to-staging.yml
+++ b/.github/workflows/sync-imps-to-staging.yml
@@ -8,6 +8,11 @@ on:
         type: boolean
         default: false
 
+# Default for the whole file, so a job added later cannot silently fall back
+# to the repository default. The job below widens this with `id-token`.
+permissions:
+  contents: read
+
 jobs:
   sync-imps-to-staging:
     name: Sync General IMPs to Staging

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Unit Tests

--- a/.github/workflows/vercel-deploy-on-hotfix-push.yml
+++ b/.github/workflows/vercel-deploy-on-hotfix-push.yml
@@ -9,6 +9,11 @@ on:
       - hotfixes
   workflow_dispatch:
 
+# Vercel is authenticated with repository secrets, not GITHUB_TOKEN, so
+# scoping the token down does not affect the deployment.
+permissions:
+  contents: read
+
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest

--- a/.github/workflows/vercel-deploy-on-release.yml
+++ b/.github/workflows/vercel-deploy-on-release.yml
@@ -13,6 +13,11 @@ on:
     types:
       - completed
 
+# Vercel is authenticated with repository secrets, not GITHUB_TOKEN, so
+# scoping the token down does not affect the deployment.
+permissions:
+  contents: read
+
 jobs:
   Deploy-Production:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release' }}


### PR DESCRIPTION
## Description

Fixes #1014

Nine workflows declared no `permissions:` block, so `GITHUB_TOKEN` fell back to the repository default. Where that default is still read-write, every job ran with write access to contents, packages and deployments in order to check out code and run tests.

Each of the nine now declares `contents: read` at the file level. `dependabot-auto-approve.yml` is left untouched, as the issue asks.

### Audit behind the grant

Every third-party action in the repo was checked against the scopes it needs:

| Action | Needs | Where |
| --- | --- | --- |
| `actions/checkout@v6` | `contents: read` | all ten touched workflows |
| `actions/setup-node@v6`, `oven-sh/setup-bun@v2` | reads public releases only | build, code-quality, testing, others |
| `actions/upload-artifact@v7` | none — uses the Actions runtime token, not `GITHUB_TOKEN` | `build.yml` |
| `codecov/codecov-action@v5` | none — no OIDC and no token configured, and `fail_ci_if_error: false` | `testing.yml` |
| `google-github-actions/auth@v3` | `id-token: write` | `sync-imps-to-staging.yml`, already declared |
| `dependabot/fetch-metadata@v2`, `lewagon/wait-on-check-action` | `contents: write`, `pull-requests: write` | `dependabot-auto-approve.yml`, untouched |

**Of the ten workflows touched, none calls the GitHub API.** The only workflow that does is `dependabot-auto-approve.yml`, which already declares the scopes its auto-merge needs.

### On the three the issue singled out

The issue asks for per-job scopes on `db-reconcile` and the two `vercel-deploy-*` workflows. Auditing them found nothing needing more than `contents: read`:

- The two Vercel deployments authenticate with repository secrets, not `GITHUB_TOKEN`, so no `deployments: write` is required. A comment in each file records this so the next reader does not have to re-derive it.
- `db-reconcile` reaches its database over `psql` with secrets.

Each of the three has a **single job**, so a file-level default grants exactly what a per-job block would, and additionally covers any job added later. A per-job block on top of it would be duplication.

### `sync-imps-to-staging.yml`

Not in the issue's list because it was added on 2026-07-21, five days after the issue was filed. It declared its scopes inside its job, so a job added later would have inherited the repository default. It now carries a file-level default as well; its job still widens that with the `id-token: write` it needs for Google Cloud.

### Verified

- All eleven workflows parse as valid YAML, and all eleven now declare a file-level `permissions` block (previously two did, one of them only per-job).
- **No `name:` field was modified.** `vercel-deploy-on-release.yml` matches its upstream workflow by display name, so a rename there would silently stop production deploys.
- `prettier` reports all eleven unchanged; `bun validate` passes.

### Out of scope, worth a follow-up

- Setting the repository/organization default `GITHUB_TOKEN` permission to read-only. This PR makes the workflows independent of that setting but cannot change it from the repo.
- `persist-credentials: false` on `actions/checkout`, which would stop the token being written into `.git/config` for later steps. Related hardening, but a behaviour change the issue does not ask for.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable. — not applicable; workflow configuration is not unit-testable, so the change was verified by parsing every workflow and auditing each action's required scopes.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible. — not applicable, no UI changes.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
