### PR TITLE
fix(site): restore two hidden paragraphs of the privacy policy

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/privacy/page.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/privacy/page.test.tsx
@@ -1,9 +1,12 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import privacyMessages from '@/messages/privacy/en.json';
 import { renderWithNextIntl, screen } from '@/test/test-utils';
 import '@testing-library/jest-dom';
 import { describe, expect, it } from 'vitest';
 import PrivacyPage from './page';
+
+const { california } = privacyMessages.privacy;
 
 describe('PrivacyPage', () => {
   it('renders the page', () => {
@@ -32,6 +35,68 @@ describe('PrivacyPage', () => {
         'Should you wish to lodge a complaint with regards to how your personal data has been processed by us:'
       )
     ).toBeInTheDocument();
+  });
+
+  it('states the legal bases for processing under EU-UK law', () => {
+    renderWithNextIntl(<PrivacyPage />);
+
+    // This paragraph shared the `legal` message key with the disclosure
+    // paragraph below it. JSON keeps the last of two duplicate keys, so it
+    // reached no visitor and the disclosure text printed in both slots.
+    expect(
+      screen.getByText(/^We rely on various legal bases under the EU-UK/)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getAllByText(
+        /^We reserve the right to disclose your personal information/
+      )
+    ).toHaveLength(1);
+  });
+
+  it('introduces the list of information a disclosure request covers', () => {
+    renderWithNextIntl(<PrivacyPage />);
+
+    // Rendered in place of an empty `content` key that left the CCPA list
+    // standing under a blank paragraph with nothing to introduce it.
+    expect(
+      screen.getByText(california.rights.disclosure.intro)
+    ).toBeInTheDocument();
+  });
+
+  it('labels whether each category of personal information is collected', () => {
+    renderWithNextIntl(<PrivacyPage />);
+
+    // Counted from the message file rather than restated here, so the two
+    // cannot drift apart.
+    expect(screen.getAllByText(/^Collected: (YES|NO)$/)).toHaveLength(
+      Object.keys(california.categories).length
+    );
+  });
+
+  it('points the Japanese contact sentence at the contact page', () => {
+    renderWithNextIntl(<PrivacyPage />);
+
+    // 此方 means "here" — the link belongs on that word, which the sentence
+    // already points at, not trailing the sentence as an English fragment.
+    const link = screen.getByRole('link', { name: '此方' });
+    expect(link).toHaveAttribute('href', expect.stringContaining('/contact'));
+  });
+
+  it('keeps the heading outline from skipping a level', () => {
+    const { container } = renderWithNextIntl(<PrivacyPage />);
+
+    // The category cards used to jump straight from the supplement's h2 to an
+    // h4, leaving screen reader users a hole in the outline.
+    const levels = Array.from(
+      container.querySelectorAll('h1, h2, h3, h4, h5, h6')
+    ).map((heading) => Number(heading.tagName[1]));
+
+    const skipped = levels.filter(
+      (level, index) => index > 0 && level > levels[index - 1] + 1
+    );
+
+    expect(skipped).toEqual([]);
   });
 
   it('has correct margins', () => {

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/privacy/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/privacy/page.tsx
@@ -11,8 +11,8 @@ import {
   PolicySubheading,
   TermsPoliciesPage,
 } from '@/components/common/terms-policies-page';
+import { Link } from '@/i18n/config';
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
 
 /** Personal-information categories listed in the California supplement. */
 const CALIFORNIA_CATEGORIES = [
@@ -30,13 +30,21 @@ const CALIFORNIA_CATEGORIES = [
   'sensitiveInfo',
 ] as const;
 
-/** Consumer rights listed in the California supplement. */
+/**
+ * Consumer rights listed in the California supplement, each paired with the
+ * message key that carries its prose. `disclosure` and `exercise` do not use a
+ * `content` key: the first introduces its list through `intro`, the second says
+ * everything in `verification`.
+ */
 const CALIFORNIA_RIGHTS = [
-  'deletion',
-  'disclosure',
-  'correction',
-  'noDiscrimination',
-  'exercise',
+  { key: 'deletion', body: 'california.rights.deletion.content' },
+  { key: 'disclosure', body: 'california.rights.disclosure.intro' },
+  { key: 'correction', body: 'california.rights.correction.content' },
+  {
+    key: 'noDiscrimination',
+    body: 'california.rights.noDiscrimination.content',
+  },
+  { key: 'exercise', body: 'california.rights.exercise.verification' },
 ] as const;
 
 /** Border shared by the regional supplement sections. */
@@ -135,14 +143,16 @@ export default function PrivacyPage() {
               <div className="grid gap-4">
                 {CALIFORNIA_CATEGORIES.map((category) => (
                   <div key={category} className="py-4">
-                    <PolicyItemHeading className="mb-4">
+                    {/* h3, not the default h4: these hang straight off the
+                        supplement's h2, so h4 would skip a level. */}
+                    <PolicyItemHeading level={3} className="mb-4">
                       {t(`california.categories.${category}.title`)}
                     </PolicyItemHeading>
                     <PolicyBody className="mb-4">
                       {t(`california.categories.${category}.description`)}
                     </PolicyBody>
                     <PolicyBody>
-                      Collected:{' '}
+                      {t('california.collectedLabel')}:{' '}
                       {t(`california.categories.${category}.collected`)}
                     </PolicyBody>
                   </div>
@@ -174,7 +184,6 @@ export default function PrivacyPage() {
 
             {/* Disclosure */}
             <div>
-              <PolicySubheading>Disclosure of Information</PolicySubheading>
               <PolicyBody className="mb-2">
                 {t('california.disclosure.intro')}
               </PolicyBody>
@@ -190,24 +199,17 @@ export default function PrivacyPage() {
                 {t('california.rights.title')}
               </PolicySubheading>
               <div className="space-y-4">
-                {CALIFORNIA_RIGHTS.map((right) => (
-                  <div key={right} className="py-4">
+                {CALIFORNIA_RIGHTS.map(({ key, body }) => (
+                  <div key={key} className="py-4">
                     <PolicyItemHeading className="mb-2 leading-relaxed">
-                      {t(`california.rights.${right}.title`)}
+                      {t(`california.rights.${key}.title`)}
                     </PolicyItemHeading>
-                    <PolicyBody>
-                      {t(`california.rights.${right}.content`)}
-                    </PolicyBody>
-                    {right === 'disclosure' && (
+                    <PolicyBody>{t(body)}</PolicyBody>
+                    {key === 'disclosure' && (
                       <PolicyList
                         className="mt-2"
                         items={listFrom('california.rights.disclosure.list', 6)}
                       />
-                    )}
-                    {right === 'exercise' && (
-                      <PolicyBody className="mt-2">
-                        {t('california.rights.exercise.verification')}
-                      </PolicyBody>
                     )}
                   </div>
                 ))}
@@ -251,11 +253,13 @@ export default function PrivacyPage() {
               items={listFrom('japan.informationRequest.info', 7)}
             />
             <PolicySubheading>{t('japan.questions.title')}</PolicySubheading>
+            {/* The sentence points at 此方 ("here") as the place to get in
+                touch, so the link goes there rather than trailing off the end
+                as an English fragment. */}
             <PolicyBody>
-              {t('japan.questions.content')}
-              <Link href={'/contact'} className="inline-block">
-                : Contact us.
-              </Link>
+              {t.rich('japan.questions.content', {
+                link: (chunks) => <Link href="/contact">{chunks}</Link>,
+              })}
             </PolicyBody>
           </div>
         </PolicySection>
@@ -286,7 +290,10 @@ export default function PrivacyPage() {
                 <PolicyBody>{t('euUk.processing.automated')}</PolicyBody>
                 <PolicyBody>{t('euUk.processing.disclosure')}</PolicyBody>
                 <PolicyBody>{t('euUk.processing.links')}</PolicyBody>
-                <PolicyBody>{t('euUk.processing.legal')}</PolicyBody>
+                {/* Restored: this shared the `legal` key with the paragraph
+                    above, so JSON's last-wins rule hid it and printed that one
+                    twice. */}
+                <PolicyBody>{t('euUk.processing.legalDisclosure')}</PolicyBody>
               </div>
             </div>
 

--- a/apps/site/src/components/common/terms-policies-page/components/policy-item-heading.tsx
+++ b/apps/site/src/components/common/terms-policies-page/components/policy-item-heading.tsx
@@ -1,21 +1,31 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
 import { cn } from '@/lib/utils';
-import type { PolicyBlockProps } from '../types';
+import type { PolicyItemHeadingProps } from '../types';
 
 /**
- * Fourth-level heading for repeated entries inside a section, such as the
- * California data categories and rights lists in the privacy policy. Carries the
- * prose type scale rather than a heading scale.
+ * Heading for repeated entries inside a section, such as the California data
+ * categories and rights lists in the privacy policy. Carries the prose type
+ * scale rather than a heading scale.
  *
- * @param {PolicyBlockProps} props - Heading content and optional extra classes
+ * The level is a prop because the visual size is fixed while the right level
+ * depends on where the entries sit: the rights list is nested under an `h3` and
+ * so takes the default `h4`, whereas the categories grid hangs straight off the
+ * supplement's `h2` and would skip a level at `h4`.
+ *
+ * @param {PolicyItemHeadingProps} props - Heading content, level, and optional extra classes
  * @returns {JSX.Element} - The heading
  */
 export default function PolicyItemHeading({
   children,
   className,
-}: PolicyBlockProps) {
+  level = 4,
+}: PolicyItemHeadingProps) {
+  const Heading = `h${level}` as const;
+
   return (
-    <h4 className={cn('text-[13px] font-normal', className)}>{children}</h4>
+    <Heading className={cn('text-[13px] font-normal', className)}>
+      {children}
+    </Heading>
   );
 }

--- a/apps/site/src/components/common/terms-policies-page/index.ts
+++ b/apps/site/src/components/common/terms-policies-page/index.ts
@@ -8,6 +8,7 @@ export { default as PolicySection } from './components/policy-section';
 export { default as PolicySubheading } from './components/policy-subheading';
 export type {
   PolicyBlockProps,
+  PolicyItemHeadingProps,
   PolicyListProps,
   PolicySectionProps,
   TermsPoliciesPageProps,

--- a/apps/site/src/components/common/terms-policies-page/terms-policies-page.stories.tsx
+++ b/apps/site/src/components/common/terms-policies-page/terms-policies-page.stories.tsx
@@ -2,6 +2,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import PolicyBody from './components/policy-body';
+import PolicyItemHeading from './components/policy-item-heading';
 import PolicyList from './components/policy-list';
 import PolicySection from './components/policy-section';
 import PolicySubheading from './components/policy-subheading';
@@ -77,6 +78,38 @@ export const OrderedList: Story = {
           ordered
           items={['Your full name', 'Your address', 'Your contact details']}
         />
+      </PolicySection>
+    ),
+  },
+};
+
+/**
+ * Repeated entries carry one type scale at two heading levels. The categories
+ * grid hangs off the supplement's `h2` and so takes `level={3}`, while the
+ * rights list sits under an `h3` and keeps the default `h4`. The two look
+ * identical on purpose: the level describes the outline, not the size.
+ */
+export const ItemHeadingLevels: Story = {
+  args: {
+    title: 'Privacy Policy',
+    children: (
+      <PolicySection title="Supplement for California Residents">
+        <PolicyBody>
+          Categories of Personal Information We Collect: we collect limited
+          types of personal information through our website.
+        </PolicyBody>
+        <PolicyItemHeading level={3} className="mb-4">
+          Identifiers
+        </PolicyItemHeading>
+        <PolicyBody>Name, contact details and address.</PolicyBody>
+
+        <PolicySubheading className="mt-8 mb-4">
+          Rights under the CCPA
+        </PolicySubheading>
+        <PolicyItemHeading className="mb-2">
+          How to Exercise Your Rights
+        </PolicyItemHeading>
+        <PolicyBody>We will contact you to confirm receipt.</PolicyBody>
       </PolicySection>
     ),
   },

--- a/apps/site/src/components/common/terms-policies-page/terms-policies-page.test.tsx
+++ b/apps/site/src/components/common/terms-policies-page/terms-policies-page.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@/test/test-utils';
 import '@testing-library/jest-dom';
 import { describe, expect, it } from 'vitest';
 import PolicyBody from './components/policy-body';
+import PolicyItemHeading from './components/policy-item-heading';
 import PolicyList from './components/policy-list';
 import PolicySection from './components/policy-section';
 import PolicySubheading from './components/policy-subheading';
@@ -72,6 +73,35 @@ describe('PolicySubheading', () => {
     expect(
       screen.getByRole('heading', { level: 3, name: 'Rights' })
     ).toBeInTheDocument();
+  });
+});
+
+describe('PolicyItemHeading', () => {
+  it('renders a level four heading by default', () => {
+    render(<PolicyItemHeading>Identifiers</PolicyItemHeading>);
+
+    expect(
+      screen.getByRole('heading', { level: 4, name: 'Identifiers' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders a level three heading when asked', () => {
+    // The level is a prop so entries that hang straight off a section's h2 can
+    // sit at h3 without skipping a level, while keeping the prose type scale.
+    render(<PolicyItemHeading level={3}>Identifiers</PolicyItemHeading>);
+
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Identifiers' })
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the prose type scale at either level', () => {
+    render(<PolicyItemHeading level={3}>Identifiers</PolicyItemHeading>);
+
+    expect(screen.getByRole('heading', { level: 3 })).toHaveClass(
+      'text-[13px]',
+      'font-normal'
+    );
   });
 });
 

--- a/apps/site/src/components/common/terms-policies-page/types.ts
+++ b/apps/site/src/components/common/terms-policies-page/types.ts
@@ -33,6 +33,16 @@ export interface PolicySectionProps extends PolicyBlockProps {
 }
 
 /**
+ * Props for a repeated entry heading.
+ * @property level - Heading level to render; defaults to `h4`
+ * @property children - Heading content
+ * @property className - Optional extra classes merged onto the heading
+ */
+export interface PolicyItemHeadingProps extends PolicyBlockProps {
+  level?: 3 | 4;
+}
+
+/**
  * Props for a list of policy items.
  * @property items - Rendered list entries, in order
  * @property ordered - Renders an `ol` instead of the default `ul`

--- a/apps/site/src/messages/privacy/en.json
+++ b/apps/site/src/messages/privacy/en.json
@@ -95,7 +95,7 @@
       },
       "questions": {
         "title": "ご質問・ご意見・苦情等について",
-        "content": "当社は、お客様からいただいた個人情報に関するご質問、ご意見、苦情等に対し、迅速かつ誠実に対応するよう努めます。ご質問、ご意見、苦情等が ございましたら、此方 までご連絡ください"
+        "content": "当社は、お客様からいただいた個人情報に関するご質問、ご意見、苦情等に対し、迅速かつ誠実に対応するよう努めます。ご質問、ご意見、苦情等が ございましたら、<link>此方</link> までご連絡ください"
       }
     },
     "california": {
@@ -103,6 +103,7 @@
       "lastUpdated": "Last Updated: June 23, 2024",
       "intro": "This California Website Privacy Policy supplements the Website Privacy Policy with respect to specific rights granted under the California Consumer Privacy Act of 2018, as amended (the \"CCPA\"), to natural person California residents and provides information regarding how such California residents can exercise their rights under the CCPA. This supplement is only relevant to you if you are a resident of California as determined in accordance with the CCPA. Information required to be disclosed to California residents under the CCPA regarding the collection of their personal information that is not set forth in this supplement is otherwise set forth above in the Website Privacy Policy. To the extent there is any conflict with the privacy requirements under the Gramm-Leach-Bliley Act and/or Regulation S-P (collectively, the \"GLB Rights\"), the GLB Rights shall apply.",
       "categoriesIntro": "Categories of Personal Information We Collect: We collect limited types of personal information through our website and grower reporting portals, as well as through other electronic communications (e.g., emails), as applicable (collectively, the \"Website\"). The types of personal information we collect about you depends on the nature of your interaction with us. The categories of personal information we have collected from individuals on this Website over the last twelve (12) months include the following:",
+      "collectedLabel": "Collected",
       "categories": {
         "identifiers": {
           "title": "Identifiers",
@@ -207,7 +208,6 @@
         "disclosure": {
           "title": "Disclosure and Access Rights",
           "intro": "You have the right to request that we disclose to you certain information regarding our collection, use, disclosure and sale of personal information specific to you over the last twelve (12) months. Such information includes:",
-          "content": "",
           "list": [
             "The categories of personal information we collected about you;",
             "The categories of sources from which the personal information is collected;",
@@ -227,7 +227,6 @@
         },
         "exercise": {
           "title": "How to Exercise Your Rights",
-          "content": "",
           "verification": "We will contact you to confirm receipt of your request under the CCPA and request any additional information necessary to verify your request. We verify requests by matching information provided in connection with your request to information contained in our records. Depending on the sensitivity of the request and the varying levels of risk in responding to such requests (for example, the risk of responding to fraudulent or malicious requests), we may request further information or your investor portal access credentials, if applicable in order to verify your request. You may designate an authorized agent to make a request under the CCPA on your behalf, provided that you provide a signed agreement verifying such authorized agent's authority to make requests on your behalf, and we may verify such authorized person's identity using the procedures above. If we request you verify your request and we do not receive your response, we will pause processing your request until such verification is received."
         }
       }
@@ -251,7 +250,7 @@
         "automated": "No automated decision-making, including profiling, is used when processing your personal data.",
         "disclosure": "Disclosure and Transfer of Personal Data If collected, your personal information may be shared with and processed by our affiliates, agents, and certain service providers, as necessary, to fulfill the purposes set out this Privacy Policy, including professional advisors and data hosting providers.",
         "links": "Our website contains links to other websites which are not hosted or operated by us. These websites may use automated means to collect information regarding your use of the websites. This information is subject to the privacy policies or notices of the provider's website.",
-        "legal": "We reserve the right to disclose your personal information as required by law or legal process, or when we believe that disclosure is necessary or appropriate to protect our rights, prevent physical harm or financial loss, and/or comply with a judicial proceeding, court order, request from a regulator, national security, for the purposes of public importance or any other legal or investigatory process involving us. Should we, or any of our affiliated entities, be the subject of a takeover, divestment or acquisition, or otherwise sell or transfer all or a portion of our business or assets (including in the event of a reorganization, dissolution, or liquidation), we may disclose your personal information to the new owner of the relevant business and their advisors on the basis of our legitimate interest."
+        "legalDisclosure": "We reserve the right to disclose your personal information as required by law or legal process, or when we believe that disclosure is necessary or appropriate to protect our rights, prevent physical harm or financial loss, and/or comply with a judicial proceeding, court order, request from a regulator, national security, for the purposes of public importance or any other legal or investigatory process involving us. Should we, or any of our affiliated entities, be the subject of a takeover, divestment or acquisition, or otherwise sell or transfer all or a portion of our business or assets (including in the event of a reorganization, dissolution, or liquidation), we may disclose your personal information to the new owner of the relevant business and their advisors on the basis of our legitimate interest."
       },
       "sharing": {
         "title": "SHARING AND TRANSFERS OF PERSONAL DATA",

--- a/apps/site/src/messages/privacy/es.json
+++ b/apps/site/src/messages/privacy/es.json
@@ -95,7 +95,7 @@
       },
       "questions": {
         "title": "ご質問・ご意見・苦情等について",
-        "content": "当社は、お客様からいただいた個人情報に関するご質問、ご意見、苦情等に対し、迅速かつ誠実に対応するよう努めます。ご質問、ご意見、苦情等が ございましたら、此方 までご連絡ください"
+        "content": "当社は、お客様からいただいた個人情報に関するご質問、ご意見、苦情等に対し、迅速かつ誠実に対応するよう努めます。ご質問、ご意見、苦情等が ございましたら、<link>此方</link> までご連絡ください"
       }
     },
     "california": {
@@ -103,6 +103,7 @@
       "lastUpdated": "Last Updated: June 23, 2024",
       "intro": "This California Website Privacy Policy supplements the Website Privacy Policy with respect to specific rights granted under the California Consumer Privacy Act of 2018, as amended (the \"CCPA\"), to natural person California residents and provides information regarding how such California residents can exercise their rights under the CCPA. This supplement is only relevant to you if you are a resident of California as determined in accordance with the CCPA. Information required to be disclosed to California residents under the CCPA regarding the collection of their personal information that is not set forth in this supplement is otherwise set forth above in the Website Privacy Policy. To the extent there is any conflict with the privacy requirements under the Gramm-Leach-Bliley Act and/or Regulation S-P (collectively, the \"GLB Rights\"), the GLB Rights shall apply.",
       "categoriesIntro": "Categories of Personal Information We Collect: We collect limited types of personal information through our website and grower reporting portals, as well as through other electronic communications (e.g., emails), as applicable (collectively, the \"Website\"). The types of personal information we collect about you depends on the nature of your interaction with us. The categories of personal information we have collected from individuals on this Website over the last twelve (12) months include the following:",
+      "collectedLabel": "Collected",
       "categories": {
         "identifiers": {
           "title": "Identifiers",
@@ -207,7 +208,6 @@
         "disclosure": {
           "title": "Disclosure and Access Rights",
           "intro": "You have the right to request that we disclose to you certain information regarding our collection, use, disclosure and sale of personal information specific to you over the last twelve (12) months. Such information includes:",
-          "content": "",
           "list": [
             "The categories of personal information we collected about you;",
             "The categories of sources from which the personal information is collected;",
@@ -227,7 +227,6 @@
         },
         "exercise": {
           "title": "How to Exercise Your Rights",
-          "content": "",
           "verification": "We will contact you to confirm receipt of your request under the CCPA and request any additional information necessary to verify your request. We verify requests by matching information provided in connection with your request to information contained in our records. Depending on the sensitivity of the request and the varying levels of risk in responding to such requests (for example, the risk of responding to fraudulent or malicious requests), we may request further information or your investor portal access credentials, if applicable in order to verify your request. You may designate an authorized agent to make a request under the CCPA on your behalf, provided that you provide a signed agreement verifying such authorized agent's authority to make requests on your behalf, and we may verify such authorized person's identity using the procedures above. If we request you verify your request and we do not receive your response, we will pause processing your request until such verification is received."
         }
       }
@@ -251,7 +250,7 @@
         "automated": "No automated decision-making, including profiling, is used when processing your personal data.",
         "disclosure": "Disclosure and Transfer of Personal Data If collected, your personal information may be shared with and processed by our affiliates, agents, and certain service providers, as necessary, to fulfill the purposes set out this Privacy Policy, including professional advisors and data hosting providers.",
         "links": "Our website contains links to other websites which are not hosted or operated by us. These websites may use automated means to collect information regarding your use of the websites. This information is subject to the privacy policies or notices of the provider's website.",
-        "legal": "We reserve the right to disclose your personal information as required by law or legal process, or when we believe that disclosure is necessary or appropriate to protect our rights, prevent physical harm or financial loss, and/or comply with a judicial proceeding, court order, request from a regulator, national security, for the purposes of public importance or any other legal or investigatory process involving us. Should we, or any of our affiliated entities, be the subject of a takeover, divestment or acquisition, or otherwise sell or transfer all or a portion of our business or assets (including in the event of a reorganization, dissolution, or liquidation), we may disclose your personal information to the new owner of the relevant business and their advisors on the basis of our legitimate interest."
+        "legalDisclosure": "We reserve the right to disclose your personal information as required by law or legal process, or when we believe that disclosure is necessary or appropriate to protect our rights, prevent physical harm or financial loss, and/or comply with a judicial proceeding, court order, request from a regulator, national security, for the purposes of public importance or any other legal or investigatory process involving us. Should we, or any of our affiliated entities, be the subject of a takeover, divestment or acquisition, or otherwise sell or transfer all or a portion of our business or assets (including in the event of a reorganization, dissolution, or liquidation), we may disclose your personal information to the new owner of the relevant business and their advisors on the basis of our legitimate interest."
       },
       "sharing": {
         "title": "SHARING AND TRANSFERS OF PERSONAL DATA",

--- a/apps/site/vitest.setup.intl.js
+++ b/apps/site/vitest.setup.intl.js
@@ -34,24 +34,61 @@ const loadMessagesSync = (locale) => {
 
 const enMessages = loadMessagesSync('en');
 
+// Use actual message structure from loaded messages
+const nestedGet = (obj, path) =>
+  path.split('.').reduce((current, segment) => current?.[segment], obj);
+
+/**
+ * Builds a translator shaped closely enough to the real one for component
+ * tests: callable for plain messages, with `.rich` for a message that wraps
+ * part of its text in a tag, e.g. `<link>here</link>`.
+ */
+const createTranslator = (namespace) => {
+  const lookup = (key) => {
+    if (enMessages[namespace]) {
+      const translation = nestedGet(enMessages[namespace], key);
+      if (translation) return translation;
+    }
+
+    return `[${namespace}.${key}]`;
+  };
+
+  const translate = vitest.fn(lookup);
+
+  translate.rich = vitest.fn((key, values = {}) => {
+    const message = lookup(key);
+    const parts = [];
+    const tag = /<(\w+)>([\s\S]*?)<\/\1>/g;
+    let cursor = 0;
+    let match;
+    let index = 0;
+
+    while ((match = tag.exec(message)) !== null) {
+      if (match.index > cursor) parts.push(message.slice(cursor, match.index));
+
+      const render = values[match[1]];
+      parts.push(
+        render
+          ? React.createElement(
+              React.Fragment,
+              { key: index++ },
+              render(match[2])
+            )
+          : match[2]
+      );
+      cursor = tag.lastIndex;
+    }
+
+    if (cursor < message.length) parts.push(message.slice(cursor));
+
+    return parts;
+  });
+
+  return translate;
+};
+
 vitest.mock('next-intl', () => ({
-  useTranslations: vitest.fn((namespace) => {
-    return vitest.fn((key) => {
-      // Use actual message structure from loaded messages
-      const nestedGet = (obj, path) => {
-        return path.split('.').reduce((current, segment) => {
-          return current?.[segment];
-        }, obj);
-      };
-
-      if (enMessages[namespace]) {
-        const translation = nestedGet(enMessages[namespace], key);
-        if (translation) return translation;
-      }
-
-      return `[${namespace}.${key}]`;
-    });
-  }),
+  useTranslations: vitest.fn(createTranslator),
   useLocale: vitest.fn(() => 'en'),
   NextIntlClientProvider: ({ children }) => children,
 }));


### PR DESCRIPTION
## Description

Fixes #1109

Five defects in `/privacy`, all pre-existing and all surviving #1107, which refactored these pages onto the shared template but touched no message file. Two of them meant legal copy that exists in the message files had never been shown to a visitor.

### 1. A duplicate JSON key hid a paragraph of the EU-UK policy

`euUk.processing` declared `"legal"` twice: once for the legal-bases paragraph and once for the lawful-disclosure paragraph. JSON keeps the last of two duplicate keys, so `t('euUk.processing.legal')` only ever resolved to the second — and the page rendered that key **twice** (previously lines 282 and 289). The disclosure text printed in both slots and the legal-bases text appeared nowhere on the site.

The second paragraph now has its own key, `legalDisclosure`, and both render once each.

### 2. The CCPA disclosure list had no introduction

`california.rights.disclosure.content` and `california.rights.exercise.content` were empty strings that rendered blank paragraphs, while `california.rights.disclosure.intro` — the sentence that introduces the six-item list — was never rendered.

`CALIFORNIA_RIGHTS` now pairs each right with the message key that carries its prose, so `disclosure` introduces its list, `exercise` says everything through `verification`, and the two empty keys are gone. This also removed the `right === 'exercise'` special case.

### 3. Three strings bypassed next-intl

- `Collected:` is now `california.collectedLabel`.
- The hard-coded `<PolicySubheading>Disclosure of Information</PolicySubheading>` is **removed** rather than translated: `california.disclosure.intro` already opens with those exact words, the same convention `categoriesIntro` follows with no heading above it. The words appeared twice in a row on the page.
- The Japanese notice no longer trails an English `: Contact us.`. The sentence ends in 此方までご連絡ください — "please contact us **here**" — so the link now sits on 此方 via `t.rich`, where the sentence itself points.

### 4. The heading outline skipped a level

The twelve category cards hung an `h4` straight off the supplement's `h2`. `PolicyItemHeading` now takes `level` as a prop, defaulting to the `h4` every other caller wants, and the categories pass `level={3}`.

**No visual change**: the rendered classes are identical, only the tag differs.

```
before: <h4 class="text-[13px] font-normal mb-4">Identifiers</h4>
after:  <h3 class="text-[13px] font-normal mb-4">Identifiers</h3>
```

### 5. The contact link lost the locale

The page imported `Link` from `next/link`, which emits a literal `/contact` regardless of locale. It now uses the locale-aware helper from `@/i18n/config`, like the other 15 files under `(marketing)`. Verified against a production build under the repo's `as-needed` prefixing:

| Page | `href` |
| --- | --- |
| `/en/privacy` | `/contact` — correct, English is the unprefixed default |
| `/es/privacy` | `/es/contact` — previously `/contact`, sending Spanish readers out of their locale |

## Verified against a production build

`next build` + `next start`, reading the served HTML rather than the source:

| Check | Before | After |
| --- | --- | --- |
| "We rely on various legal bases…" | absent | renders once |
| "We reserve the right to disclose…" | rendered twice | renders once |
| "You have the right to request…" | absent | renders once |
| `": Contact us."` | present | absent |
| "Disclosure of Information" | twice (heading + paragraph) | once (paragraph) |
| Heading-level skips | `h2 → h4` | none |
| Message keys never rendered | 1 | 0 |

Eight tests were added: five on the page, covering each defect and asserting the outline never skips a level, and three on `PolicyItemHeading`, which had no coverage at all. The category count in the test is read from the message file rather than restated, so the two cannot drift.

`bun validate` passes (687 tests). Storybook builds, with a new `ItemHeadingLevels` story documenting that the two levels share one type scale.

### One shared file touched

`vitest.setup.intl.js` mocks `next-intl` wholesale and its translator had no `.rich`, which the Japanese link needs. `useTranslations` now returns a translator carrying it. The change is additive — the plain-lookup behaviour is byte-for-byte what it was — but it is loaded by all 131 test files, so it is worth a look.

### Noticed, not changed

`listFrom('…', 6)` hard-codes each list's length, so an entry added to a message file would render nowhere. Out of scope here, but worth an issue.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible. — the heading-outline fix and its regression test are part of this change.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
