### PR TITLE
fix(site): type the phone schema input as string for the form resolver

### DIFF
--- a/apps/site/src/lib/zod-schemas/onboarding.ts
+++ b/apps/site/src/lib/zod-schemas/onboarding.ts
@@ -8,25 +8,32 @@ export const userInfo = z.object({
   lastName: z.string().min(1, 'Last name is required').max(100),
   farmName: z.string().min(1, 'Farm name is required').max(100),
   email: z.email('Invalid email address').max(100),
-  // Very basic phone number handling
-  phone: z.preprocess((phone: string) => {
-    const withoutDashes = phone.replaceAll('-', '');
-    const digits = withoutDashes.replace(/\D/g, '');
+  // Very basic phone number handling. Uses `.transform().pipe()` rather than
+  // `z.preprocess()` because preprocess types its input as `unknown`, which
+  // leaks into `z.input<>` and makes `zodResolver` incompatible with a form
+  // typed on `z.infer<>`. Leading with `z.string()` also turns a non-string
+  // into a validation error instead of a TypeError inside the callback.
+  phone: z
+    .string()
+    .transform((phone) => {
+      const withoutDashes = phone.replaceAll('-', '');
+      const digits = withoutDashes.replace(/\D/g, '');
 
-    if (withoutDashes.startsWith('+')) {
-      return withoutDashes;
-    }
+      if (withoutDashes.startsWith('+')) {
+        return withoutDashes;
+      }
 
-    if (digits.length === 10) {
-      return `+1${digits}`;
-    }
+      if (digits.length === 10) {
+        return `+1${digits}`;
+      }
 
-    if (digits.length === 11 && digits.startsWith('1')) {
-      return `+${digits}`;
-    }
+      if (digits.length === 11 && digits.startsWith('1')) {
+        return `+${digits}`;
+      }
 
-    return phone;
-  }, z.e164('Invalid phone number')),
+      return phone;
+    })
+    .pipe(z.e164('Invalid phone number')),
   // Yes, this is stupid. See: https://github.com/colinhacks/zod/discussions/2801
   website: z.string().url().or(z.literal('')).optional(),
   instagramHandle: z.string().max(100).optional(),


### PR DESCRIPTION
## Description

Fixes #1114

`type-check` is failing on `main` at a file nobody changed:

```
src/app/(unauthenticated)/accept/components/accept-form.tsx(36,5): error TS2322:
Type 'Resolver<{ ...; phone: unknown; ... }>' is not assignable to
type 'Resolver<{ ...; phone: string; ... }>'.
  Type 'unknown' is not assignable to type 'string'.
```

`userInfo.phone` was built with `z.preprocess()`, which zod types as accepting `unknown` no matter what the callback's parameter is annotated as. That `unknown` propagates into `z.input<typeof acceptInviteSchema>`, while `AcceptInvite` is `z.infer<>` — the output type, where `phone` is `string`. `zodResolver` is typed on the *input* type, so it could not satisfy `useForm<AcceptInvite>`.

The fix swaps `z.preprocess(fn, z.e164())` for `z.string().transform(fn).pipe(z.e164())`. The normalization body is unchanged; what changes is that the input type is now pinned at `string`, so input and output agree and the resolver lines up with the form type.

Leading with `z.string()` also closes a latent runtime hole. Under `preprocess`, a non-string value reached the callback and threw a `TypeError` on `.replaceAll` instead of failing validation. It now reports `expected string, received number`.

### Why this is the right layer to fix it

The breakage is version-sensitive — `zod: "^4.3.6"` resolves to `4.4.3` today, and 4.4.x types `preprocess` differently:

| Dependencies | Code | Result |
| --- | --- | --- |
| zod 4.4.3 / resolvers 5.9.1 (what CI installs) | `preprocess` | fails — the CI error |
| zod 4.4.3 / resolvers 5.9.1 | this PR | passes |
| zod 4.3.6 / resolvers 5.2.2 | `preprocess` | passes |

The underlying reason CI installs 4.4.3 at all is a corrupt `bun.lock`, handled separately in #1115. That one restores the pins; this one makes the schema correct under **both** versions, so it does not re-break when zod is legitimately upgraded. They are complementary — this PR is the one that unblocks `main`.

## Verification

- `bun run validate` exits 0 — format, `type-check` across all 4 packages, lint, 742 tests, build.
- Normalization confirmed unchanged against `555-123-4567`, `5551234567`, `15551234567`, `1-555-123-4567`, `+15551234567`, `+447911123456` — all still produce the same E.164 output — with `123`, `""` and `abc` still rejected.
- Verified passing under both the pinned and the drifted dependency sets.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate

<sub>Existing coverage exercises this path (742 tests pass); the change is a type-level correction to a shared schema with behavior held constant, and the reasoning is documented inline above the field. No component or accessibility surface is touched.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mgA7GjEeuiQ1jBSgdUGth