### PR TITLE
fix(ci): remove the duplicate lockfile key that made bun ignore bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2758,8 +2758,6 @@
     "knip": ["knip@6.32.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.1", "jiti": "^2.7.0", "oxc-parser": "^0.143.0", "oxc-resolver": "11.24.2", "picomatch": "^4.0.5", "smol-toml": "^1.7.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.9", "yaml": "^2.9.0", "zod": "^4.4.3" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg=="],
     "knip/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "knip/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
     "lambda-runtimes": ["lambda-runtimes@2.0.5", "", {}, "sha512-6BoLX9xuvr+B/f05MOhJnzRdF8Za5YYh82n45ndun9EU3uhJv9kIwnYrOrvuA7MoGwZgCMI7RUhBRzfw/l63SQ=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],


### PR DESCRIPTION
## Description

Fixes #1115

`bun.lock` carried two byte-identical `"knip/zod"` entries. Bun's parser rejects the second:

```
InvalidPackageKey: failed to parse lockfile: 'bun.lock' at bun.lock:2761:5
```

Bun does not treat that as fatal. It warns `Ignoring lockfile` and re-resolves **every** dependency from the semver ranges in `package.json`. CI runs `bun i`, so it has been installing whatever satisfies those ranges at that moment rather than the pinned versions — silently, with no diff and no review.

Observed drift on `main` (pinned → actually installed):

| Package | Pinned in bun.lock | Installed by `bun i` |
| --- | --- | --- |
| `zod` | 4.3.6 | 4.4.3 |
| `@hookform/resolvers` | 5.2.2 | 5.9.1 |
| `react-hook-form` | 7.72.1 | 7.86.0 |

This is not theoretical. The zod drift is what broke `type-check` on `main` with no source change — 4.4.x types `z.preprocess()` differently. That symptom is fixed in #1116; this PR removes the cause.

The duplicate came in with #1090, the commit that added knip, most likely from a lockfile merge resolution.

## Change

Deletes the duplicated line (and the blank line it left behind). Two deletions, no version changes — every pin stays exactly as it was.

## Verification

- `bun install --frozen-lockfile` now succeeds. Before this change it failed outright, so it could not be used at all.
- Confirmed it restores the pins: with the fixed lockfile, a frozen install brings `zod` back to **4.3.6** from the drifted 4.4.3.
- `bun run validate` exits 0 on this branch — format, type-check across all 4 packages, lint, 742 site tests + 55 db tests, build.

## Note for reviewers

Merge order does not matter; the two PRs are independent and each is green on its own. #1116 makes the phone schema correct under both zod versions, so it does not re-break when zod is legitimately upgraded — worth having both.

CI's install step is `bun i`, which will keep masking this class of problem. Moving it to `bun install --frozen-lockfile` would make a corrupt or stale lockfile fail loudly instead of drifting. Left out of this PR deliberately and noted in #1115 so it can be decided on its own.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate

<sub>Lockfile-only change — no application code, so no unit tests or accessibility surface apply. It is verified instead by `bun install --frozen-lockfile` succeeding and restoring the pinned versions, as described above. Rationale is recorded in the commit message and in #1115.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mgA7GjEeuiQ1jBSgdUGth