### PR TITLE
refactor(site): adopt the shared closing cta across marketing pages

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/about-landing.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/about-landing.test.tsx
@@ -63,7 +63,8 @@ describe('AboutLanding', () => {
       })
     ).toBeInTheDocument();
 
-    const cta = screen.getByRole('link', { name: /Our research/i });
+    // Exact match: the closing CTA label also contains "our research".
+    const cta = screen.getByRole('link', { name: 'Our research' });
     expect(cta).toBeInTheDocument();
     expect(cta.querySelector('svg')).not.toBeNull();
   });
@@ -114,11 +115,14 @@ describe('AboutLanding', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders navigation link to What We Do', () => {
+  it('renders the closing call to action pointing at research', () => {
     renderWithNextIntl(<AboutLanding />);
 
     expect(
-      screen.getByRole('link', { name: /What we do/i })
+      screen.getByRole('heading', { level: 2, name: /What we do/i })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Explore our research/i })
+    ).toHaveAttribute('href', '/research');
   });
 });

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/about-landing.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/about/components/about-landing.tsx
@@ -13,6 +13,7 @@ import { HiArrowLongRight } from 'react-icons/hi2';
 import type { ReactNode } from 'react';
 import CompetenciesSection from './competencies-section/competencies-section';
 import Partners from './partners';
+import { MarketingCenteredPageCta } from '../../components/marketing-blocks';
 import ResponsibilitiesSection from './responsibilities-section/responsibilities-section';
 
 /**
@@ -105,17 +106,13 @@ export default function AboutLanding({
       <div className="flex flex-col mx-auto max-w-[1200px]">
         {/* Highlighted Articles Section */}
         {highlights}
-        <div className="w-full h-fit mb-16 md:mb-32 py-12 md:py-16">
-          <Link
-            href="/research"
-            className="text-3xl md:text-4xl lg:text-4xl leading-tight font-thin flex justify-center items-center gap-5"
-          >
-            {t('navigation.whatWeDo')}
-            <span className="mt-1">
-              <HiArrowLongRight className="size-12" />
-            </span>
-          </Link>
-        </div>
+        <MarketingCenteredPageCta
+          ctaHref="/research"
+          ctaLabel={t('navigation.whatWeDoCta')}
+          heading={t('navigation.whatWeDo')}
+          headingId="about-footer-cta-heading"
+          sectionId="about-footer-cta"
+        />
       </div>
     </main>
   );

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/fixtures/careers-landing-view.fixture.ts
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/fixtures/careers-landing-view.fixture.ts
@@ -43,7 +43,7 @@ export const CAREERS_LANDING_VIEW_FIXTURE: CareersLandingCopy = {
   splitResidency: {
     heading: 'Residency',
     body: 'Body.',
-    ctaLabel: 'Learn more →',
+    ctaLabel: 'Learn more',
     ctaHref: '/careers/search',
     imageSrc: '/marketing/careers-1.webp',
     imageAlt: '',
@@ -51,7 +51,7 @@ export const CAREERS_LANDING_VIEW_FIXTURE: CareersLandingCopy = {
   splitEarlyTalent: {
     heading: 'Talent',
     body: 'Body.',
-    ctaLabel: 'Learn more →',
+    ctaLabel: 'Learn more',
     ctaHref: '/careers/search',
     imageSrc: '/marketing/who-we-are-img.jpg',
     imageAlt: '',
@@ -59,6 +59,6 @@ export const CAREERS_LANDING_VIEW_FIXTURE: CareersLandingCopy = {
   quoteText: 'Quote text.',
   quoteAttribution: 'Author.',
   footerHeading: 'Footer headline',
-  footerCtaLabel: 'View careers →',
+  footerCtaLabel: 'View careers',
   footerCtaHref: '/careers/search',
 };

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/page.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/careers/page.test.tsx
@@ -43,13 +43,12 @@ describe('Careers landing view', () => {
     const h1Element = screen.getByRole('heading', { level: 1 });
     expect(mainLandmark).toContainElement(h1Element);
 
-    const valuesLink = screen.getByRole('link', { name: 'View careers' });
-    expect(valuesLink).toHaveAttribute('href', '/careers/search');
-
-    const listingLink = screen.getByRole('link', {
-      name: 'View careers →',
+    // Hero secondary CTA and the closing pill now share a label (arrows dropped).
+    const careersLinks = screen.getAllByRole('link', { name: 'View careers' });
+    expect(careersLinks).toHaveLength(2);
+    careersLinks.forEach((link) => {
+      expect(link).toHaveAttribute('href', '/careers/search');
     });
-    expect(listingLink).toHaveAttribute('href', '/careers/search');
 
     screen.getAllByRole('heading', { level: 2 }).forEach((heading) => {
       expect(mainLandmark).toContainElement(heading);

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks/marketing-centered-page-cta.stories.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks/marketing-centered-page-cta.stories.tsx
@@ -1,0 +1,52 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MarketingCenteredPageCta } from './marketing-centered-page-cta';
+
+const meta = {
+  title: 'Marketing/CenteredPageCta',
+  component: MarketingCenteredPageCta,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    heading: 'Shape the future of agriculture',
+    ctaLabel: 'View careers',
+    ctaHref: '/careers/search',
+    sectionId: 'careers-footer-cta',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof MarketingCenteredPageCta>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Closing band as used on `/careers`. */
+export const Default: Story = {};
+
+/** Closing band as used on `/about`. */
+export const About: Story = {
+  args: {
+    heading: 'What we do',
+    ctaLabel: 'Explore our research',
+    ctaHref: '/research',
+    sectionId: 'about-footer-cta',
+  },
+};
+
+/** Closing band as used on `/research`. */
+export const Research: Story = {
+  args: {
+    heading: 'Build a better farm',
+    ctaLabel: 'Meet Iris',
+    ctaHref: '/index/introducing-iris',
+    sectionId: 'research-footer-cta',
+  },
+};
+
+/** Longer headline, to check the 48px desktop size wraps cleanly. */
+export const LongHeading: Story = {
+  args: {
+    heading: 'Agriculture that heals the planet and supports communities',
+  },
+};

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks/marketing-centered-page-cta.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks/marketing-centered-page-cta.test.tsx
@@ -1,0 +1,60 @@
+// Copyright © Todd Agriscience, Inc. All rights reserved.
+
+import { renderWithNextIntl, screen } from '@/test/test-utils';
+import '@testing-library/jest-dom';
+import { describe, expect, it } from 'vitest';
+import { MarketingCenteredPageCta } from './marketing-centered-page-cta';
+
+describe('MarketingCenteredPageCta', () => {
+  it('renders the heading as an h2 with the CTA as a separate link', () => {
+    renderWithNextIntl(
+      <MarketingCenteredPageCta
+        ctaHref="/careers/search"
+        ctaLabel="View careers"
+        heading="Shape the future of agriculture"
+        sectionId="test-footer-cta"
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'Shape the future of agriculture',
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View careers' })).toHaveAttribute(
+      'href',
+      '/careers/search'
+    );
+  });
+
+  it('labels the section by its heading for assistive technology', () => {
+    renderWithNextIntl(
+      <MarketingCenteredPageCta
+        ctaHref="/research"
+        ctaLabel="Explore our research"
+        heading="What we do"
+        headingId="about-footer-cta-heading"
+        sectionId="about-footer-cta"
+      />
+    );
+
+    expect(
+      screen.getByRole('region', { name: 'What we do' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the label unlinked when the destination is not root-relative', () => {
+    // `toSafeHref` rejects bare relative paths, so callers must pass `/…`.
+    renderWithNextIntl(
+      <MarketingCenteredPageCta
+        ctaHref="index/introducing-iris"
+        ctaLabel="Meet Iris"
+        heading="Build a better farm"
+      />
+    );
+
+    expect(screen.queryByRole('link', { name: 'Meet Iris' })).toBeNull();
+    expect(screen.getByText('Meet Iris')).toBeInTheDocument();
+  });
+});

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks/marketing-centered-page-cta.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks/marketing-centered-page-cta.tsx
@@ -33,7 +33,7 @@ export function MarketingCenteredPageCta({
     >
       <h2
         id={hid}
-        className="text-3xl font-normal leading-tight tracking-tight text-foreground md:text-[34px] md:leading-tight"
+        className="text-4xl font-normal leading-tight tracking-tight text-foreground md:text-[48px] md:leading-tight"
       >
         {heading}
       </h2>

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/research/components/research-landing.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/research/components/research-landing.test.tsx
@@ -90,8 +90,12 @@ describe('ResearchLanding', () => {
     expect(screen.getByText('Broader Communities')).toBeInTheDocument();
 
     expect(
-      screen.getByRole('link', { name: 'Build a better farm' })
+      screen.getByRole('heading', { level: 2, name: 'Build a better farm' })
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Meet Iris' })).toHaveAttribute(
+      'href',
+      '/index/introducing-iris'
+    );
   });
 
   it('renders exactly one h1 element with the correct title for accessibility', () => {

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/research/components/research-landing.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/research/components/research-landing.tsx
@@ -11,12 +11,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui';
-import { Link } from '@/i18n/config';
 import { motion, useScroll, useTransform } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import { useRef, type ReactNode } from 'react';
-import { HiArrowLongRight } from 'react-icons/hi2';
+import { MarketingCenteredPageCta } from '../../components/marketing-blocks';
 
 /**
  * Research page body (formerly What We Do). Client-side because of the parallax
@@ -222,17 +221,13 @@ export default function ResearchLanding({
             ))}
           </div>
           {/* Build a Better Farm Section */}
-          <div className="w-full h-fit mb-16 md:mb-32 py-12 md:py-16">
-            <Link
-              href="index/introducing-iris"
-              className="text-3xl md:text-4xl lg:text-4xl leading-tight font-thin flex justify-center items-center gap-5"
-            >
-              {t('buildABetterFarm.title')}
-              <span className="mt-1">
-                <HiArrowLongRight className="size-12" />
-              </span>
-            </Link>
-          </div>
+          <MarketingCenteredPageCta
+            ctaHref="/index/introducing-iris"
+            ctaLabel={t('buildABetterFarm.cta')}
+            heading={t('buildABetterFarm.title')}
+            headingId="research-footer-cta-heading"
+            sectionId="research-footer-cta"
+          />
           {/* Highlighted Articles Section */}
           {highlights}
           {/* Disclaimer Section */}

--- a/apps/site/src/messages/about/en.json
+++ b/apps/site/src/messages/about/en.json
@@ -49,7 +49,8 @@
       "description": "We’re fortunate to be supported by partners who share our vision. Their backing helps us advance sustainable agriculture."
     },
     "navigation": {
-      "whatWeDo": "What we do"
+      "whatWeDo": "What we do",
+      "whatWeDoCta": "Explore our research"
     }
   }
 }

--- a/apps/site/src/messages/about/es.json
+++ b/apps/site/src/messages/about/es.json
@@ -49,7 +49,8 @@
       "description": "Tenemos la suerte de contar con el apoyo de socios que comparten nuestra visión. Su respaldo nos ayuda a impulsar la agricultura sostenible."
     },
     "navigation": {
-      "whatWeDo": "Qué hacemos"
+      "whatWeDo": "Qué hacemos",
+      "whatWeDoCta": "Explorar nuestra investigación"
     }
   }
 }

--- a/apps/site/src/messages/careers/en.json
+++ b/apps/site/src/messages/careers/en.json
@@ -52,14 +52,14 @@
         "residency": {
           "heading": "Todd Residency",
           "body": "Our early talent programs offers a chance to make a direct impact at Todd and contribute to Todd's growth journey. We welcome curious, driven people early in their professional journey through.",
-          "cta": "Learn more →",
+          "cta": "Learn more",
           "ctaHref": "/careers/search",
           "imageAlt": "Two Todd teammates talking in a bright office lounge"
         },
         "talent": {
           "heading": "Early talent",
           "body": "We welcome curious, driven people early in their professional journey to make a direct impact at Todd and contribute to Todd's own growth journey.",
-          "cta": "Learn more →",
+          "cta": "Learn more",
           "ctaHref": "/careers/search",
           "imageAlt": "Early-career teammates collaborating in a modern office"
         }
@@ -70,7 +70,7 @@
       },
       "footerCta": {
         "heading": "Shape the future of agriculture",
-        "cta": "View careers →",
+        "cta": "View careers",
         "ctaHref": "/careers/search"
       }
     },
@@ -79,7 +79,7 @@
       "applyNow": "Apply now"
     },
     "jobListings": {
-      "apply": "Apply now →",
+      "apply": "Apply now",
       "toolbarAria": "Filter job postings",
       "searchPlaceholder": "Search",
       "searchAria": "Search job postings",

--- a/apps/site/src/messages/careers/es.json
+++ b/apps/site/src/messages/careers/es.json
@@ -52,14 +52,14 @@
         "residency": {
           "heading": "Residencia Todd",
           "body": "Nuestros programas de talento emergente ofrecen la oportunidad de generar un impacto directo en Todd y contribuir al recorrido de crecimiento de Todd. Damos la bienvenida a personas curiosas y con impulso en una etapa temprana de su trayectoria profesional.",
-          "cta": "Saber más →",
+          "cta": "Saber más",
           "ctaHref": "/careers/search",
           "imageAlt": "Dos compañeros de Todd conversando en una sala luminosa"
         },
         "talent": {
           "heading": "Talento emergente",
           "body": "Damos la bienvenida a personas curiosas y con impulso, en una etapa temprana de su trayectoria profesional, para generar un impacto directo en Todd y contribuir al propio recorrido de crecimiento de Todd.",
-          "cta": "Saber más →",
+          "cta": "Saber más",
           "ctaHref": "/careers/search",
           "imageAlt": "Personas en etapa inicial colaborando en una oficina moderna"
         }
@@ -70,7 +70,7 @@
       },
       "footerCta": {
         "heading": "Da forma al futuro de la agricultura",
-        "cta": "Ver carreras →",
+        "cta": "Ver carreras",
         "ctaHref": "/careers/search"
       }
     },
@@ -79,7 +79,7 @@
       "applyNow": "Aplicar ahora"
     },
     "jobListings": {
-      "apply": "Aplicar ahora →",
+      "apply": "Aplicar ahora",
       "toolbarAria": "Filtrar vacantes",
       "searchPlaceholder": "Buscar",
       "searchAria": "Buscar vacantes",

--- a/apps/site/src/messages/research/en.json
+++ b/apps/site/src/messages/research/en.json
@@ -61,7 +61,8 @@
       }
     },
     "buildABetterFarm": {
-      "title": "Build a better farm"
+      "title": "Build a better farm",
+      "cta": "Meet Iris"
     },
     "disclaimers": {
       "0": "Todd’s advisory and management services should not be considered an assurance that losses will not be incurred. There are risks that are not monitored or controlled by Todd and risks that may be greater than forecasted by Todd, especially in unusual environmental conditions. Significant or complete losses may result from these risks or other reasons despite Todd’s management protocols or any information provided herein.",

--- a/apps/site/src/messages/research/es.json
+++ b/apps/site/src/messages/research/es.json
@@ -61,7 +61,8 @@
       }
     },
     "buildABetterFarm": {
-      "title": "Construir una granja mejor"
+      "title": "Construir una granja mejor",
+      "cta": "Conoce Iris"
     },
     "disclaimers": {
       "0": "Los servicios de asesoría y gestión de Todd no deben considerarse una garantía de que no se producirán pérdidas. Existen riesgos que no son monitoreados ni controlados por Todd y riesgos que pueden ser mayores a los previstos por Todd, especialmente en condiciones ambientales inusuales. Pueden producirse pérdidas significativas o totales como resultado de estos riesgos u otras razones, a pesar de los protocolos de gestión de Todd o de cualquier información proporcionada en el presente documento.",

--- a/bun.lock
+++ b/bun.lock
@@ -2758,8 +2758,6 @@
     "knip": ["knip@6.32.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.1", "jiti": "^2.7.0", "oxc-parser": "^0.143.0", "oxc-resolver": "11.24.2", "picomatch": "^4.0.5", "smol-toml": "^1.7.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.9", "yaml": "^2.9.0", "zod": "^4.4.3" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg=="],
     "knip/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "knip/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
     "lambda-runtimes": ["lambda-runtimes@2.0.5", "", {}, "sha512-6BoLX9xuvr+B/f05MOhJnzRdF8Za5YYh82n45ndun9EU3uhJv9kIwnYrOrvuA7MoGwZgCMI7RUhBRzfw/l63SQ=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],


### PR DESCRIPTION
## Description

Fixes #1112

### Heads-up: the component already existed

The issue says the careers closing band "is not component". It already is —
`MarketingCenteredPageCta` has been in `marketing-blocks` since the careers
rebuild, and its docblock describes it as the bottom-of-page stack. What was
missing is that **only `/careers` used it**. So this PR adopts it on the two
pages still running the old markup rather than building anything new.

### What changed

**`/about` and `/research`** dropped their heading-as-link + `HiArrowLongRight`
blocks in favour of the shared component. Both now render an `<h2>` with a
separate pill link underneath, matching careers.

**Heading size** went from `text-3xl md:text-[34px]` to `text-4xl
md:text-[48px]`, per the 48px in the issue's Figma reference. Note this also
changes the careers closing band, which shipped at 34px — flagging it explicitly
since it wasn't part of the original ask.

**Arrows.** Removed the icon from both pages, and stripped the eight literal `→`
characters that were living inside `messages/careers/{en,es}.json` — including
`"View careers →"`, which fed the very component being adopted.

**New copy needed.** The old pattern had one string doing double duty as heading
and link text; the new one needs a heading *and* a button label. I've proposed:

| Page | Heading (existing) | Button (new) |
| --- | --- | --- |
| `/about` | What we do · Qué hacemos | Explore our research · Explorar nuestra investigación |
| `/research` | Build a better farm · Construir una granja mejor | Meet Iris · Conoce Iris |

**These are my wording, not marketing's** — happy to swap them for whatever copy
you'd prefer.

### Two defects found while moving the code

- `/research` linked to `index/introducing-iris` with **no leading slash**.
  `toSafeHref` rejects bare relative paths, so once routed through
  `MarketingPillLink` the CTA would have silently rendered as an unlinked
  `<span>`. Normalized to `/index/introducing-iris`, which is what
  `menu-items.tsx` and the `/iris` redirect already use. The new component test
  pins this behaviour so it can't regress.
- The about *vision* test matched its link with the substring regex
  `/Our research/i`, which the new closing label also satisfies. Made it exact.

### Unrelated fix included: `bun.lock`

`bun.lock` carried a **duplicate `"knip/zod"` key**, which makes the file
unparseable. Bun responds by printing `Ignoring lockfile` and resolving every
install from the `package.json` ranges instead — so dependency pinning has been
silently off, repo-wide, since that entry appeared. CI runs plain `bun i`, so it
has been resolving fresh on every run; it's green today only because current
releases happen to work. A fresh resolve on my machine picked up newer
`@hookform/resolvers`/`zod` typings and broke `type-check` on `accept-form.tsx`,
on a clean `main` with none of my changes.

The fix is deleting the repeated line. Happy to split it into its own PR if you'd
rather keep this one focused — it's in here because `bun validate` cannot run
locally without it.

### Tests

`marketing-blocks` had no tests and no stories at all; this adds the first of
each. Full `bun validate` passes (745 site + 55 db tests) and `build-storybook`
compiles.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
