### PR TITLE
refactor(site): use the shared marketing pill for the view more button

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/article-index/article-index.test.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/article-index/article-index.test.tsx
@@ -171,6 +171,27 @@ describe('ArticleIndex', () => {
     expect(screen.getByText('Evil Row').closest('a')).toBeNull();
     expect(container.querySelector('a[href^="javascript:" i]')).toBeNull();
   });
+
+  it('styles "View more" as the shared 14px outline pill', async () => {
+    // The button only renders past the first page, so overflow PAGE_SIZE (9).
+    renderWithNextIntl(
+      await render({
+        articles: Array.from({ length: 10 }, (_, index) => ({
+          ...ITEMS[0],
+          _id: `r${index}`,
+          title: `Research Row ${index}`,
+          slug: { current: `research-row-${index}` },
+        })),
+      })
+    );
+
+    const viewMore = screen.getByRole('link', { name: 'View more' });
+    expect(viewMore).toHaveAttribute('href', '/research/index?count=10');
+    // Asserts the traits the issue calls for -- an outline pill at 14px --
+    // rather than the shared constant itself, so a palette tweak upstream does
+    // not break this test while hand-written classes still would.
+    expect(viewMore).toHaveClass('rounded-full', 'border', 'text-sm');
+  });
 });
 
 describe('ArticleIndex cursor follower', () => {

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/article-index/article-index.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/article-index/article-index.tsx
@@ -1,5 +1,6 @@
 // Copyright © Todd Agriscience, Inc. All rights reserved.
 
+import { MARKETING_PILL_LINK_CLASSNAME } from '@/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks/marketing-pill-link';
 import { CURSOR_LABEL_ATTRIBUTE } from '@/components/common/cursor-follower/constants';
 import { CursorFollower } from '@/components/common/cursor-follower/cursor-follower';
 import { Link } from '@/i18n/config';
@@ -366,7 +367,7 @@ export function ArticleIndex({
             <Link
               href={viewMoreHref}
               scroll={false}
-              className="rounded-[50px] border-[0.75px] border-[#848484] px-7 py-2.5 text-[14px] leading-none text-[#181818] transition-colors hover:bg-black/5"
+              className={MARKETING_PILL_LINK_CLASSNAME}
             >
               {t('viewMore')}
             </Link>

--- a/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks/marketing-pill-link.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(marketing)/components/marketing-blocks/marketing-pill-link.tsx
@@ -5,9 +5,16 @@ import { isOutboundHref, toSafeHref } from '@/lib/sanity/safe-href';
 import { cn } from '@/lib/utils';
 import type { ReactNode } from 'react';
 
-/** Tailwind classes shared by outline pill CTAs across marketing surfaces */
+/**
+ * Tailwind classes shared by outline pill CTAs across marketing surfaces.
+ *
+ * The hover tint stays at 10%: `--muted` is #2a2727 in this theme (near
+ * black, not the near-white shadcn ships), so a heavier wash drops the
+ * `text-foreground` label to a 2.67:1 contrast ratio against its own
+ * background.
+ */
 export const MARKETING_PILL_LINK_CLASSNAME =
-  'inline-flex items-center justify-center rounded-full border border-neutral-400 bg-background px-7 py-2.5 text-sm font-normal tracking-tight text-foreground outline-offset-2 transition-colors hover:bg-muted/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring';
+  'inline-flex items-center justify-center rounded-full border border-neutral-400 bg-background px-7 py-2.5 text-sm font-normal tracking-tight text-foreground outline-offset-2 transition-colors hover:bg-muted/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring';
 
 /** Props for {@link MarketingPillLink} */
 export interface MarketingPillLinkProps {


### PR DESCRIPTION
## Description

Fixes #1121

The "View more" link at the bottom of `/research/index` and `/news` repeated the outline pill styling by hand instead of reusing `MARKETING_PILL_LINK_CLASSNAME`, so it had drifted from every other pill on the site. Both routes render the same `ArticleIndex`, so pointing that single link at the shared constant covers both pages the issue names.

Adopting the constant exposed a defect inside it, fixed in the second commit.

### 1. `refactor(site)` — adopt the shared pill

|                | Before               | After                                        |
| -------------- | -------------------- | -------------------------------------------- |
| Text           | `text-[14px]`        | `text-sm` — the same 14px the issue asks for  |
| Corner         | `rounded-[50px]`     | `rounded-full` (identical at this height)     |
| Border         | `#848484` at 0.75px  | `neutral-400` at 1px                          |
| Text color     | `text-[#181818]`     | `text-foreground` (`#2a2727`, the brand token)|
| Height         | `leading-none`       | default leading — roughly 6px taller          |
| Keyboard focus | none                 | `focus-visible` outline                       |

`MARKETING_PILL_LINK_CLASSNAME` is used rather than the `MarketingPillLink` component for two reasons: the link needs `scroll={false}` so revealing rows keeps the viewport in place, and the component takes no such prop; and the component routes its href through `toSafeHref`, which exists to sanitize CMS-authored values, while `viewMoreHref` is built locally.

### 2. `fix(site)` — legible hover on the shared pill

`--muted` is `#2a2727` in this theme — near black, where shadcn ships a near-white value — so `hover:bg-muted/70` painted a `#6a6868` background behind a `#2a2727` label.

| Hover state                    | Contrast |                          |
| ------------------------------ | -------- | ------------------------ |
| `bg-muted/70` (before)         | 2.67:1   | fails WCAG AA (4.5:1)    |
| same, without `color-mix()`    | 1.00:1   | label invisible          |
| `bg-muted/10` (after)          | 12.22:1  | passes                   |

Left alone, this PR would have removed a legible hover from the one button that still had one (`bg-black/5`, 15.86:1) and replaced it with a failing one. Dropping the tint to 10% keeps the intent — a subtle darkening — and fixes the five surfaces that already render `MarketingPillLink` instead of propagating the defect to a sixth. No resting state changes.

### Notes for review

- **Absolute import path** — matches the existing precedent in `article-cta-buttons.tsx`, which imports the same module the same way; the repo convention is the `@/` alias over relative paths.
- **No test on the hover change** — it is a Tailwind class value and jsdom applies no stylesheet, so a test could only re-assert the literal string. The reasoning lives in the constant's JSDoc instead. No existing test asserted the old value.
- **Test asserts traits, not the constant** — `rounded-full`/`border`/`text-sm` rather than the whole shared string, so an upstream palette tweak will not break it while hand-written classes still would.
- **Root cause left alone** — `--muted` being inverted relative to shadcn's convention also reaches `skeleton.tsx`, `tabs.tsx`, `select.tsx` and `dropdown-menu.tsx`. That is a theme-level fix well outside this issue; happy to open a separate one for it.

## Checklist

- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] Any components that you've modified are accessible.
- [x] You've used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) where appropriate
