### PR TITLE
fix(deps): override smol-toml to 1.8.0 to clear audit failure

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -231,6 +231,7 @@
     "protobufjs": "^7.6.1",
     "rollup": "^4.62.4",
     "sharp": "^0.35.3",
+    "smol-toml": "^1.8.0",
     "tar": "^7.5.22",
     "undici": "^7.29.0",
     "vite": "^7.3.5",
@@ -3964,8 +3965,6 @@
     "@sanity/cli/react-is": ["react-is@19.2.5", "", {}, "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ=="],
 
     "@sanity/cli/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "@sanity/cli/smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "@sanity/cli/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "ws": "^8.21.0",
     "nodemailer": "^9.0.1",
     "linkify-it": "^5.0.2",
-    "adm-zip": "^0.6.0"
+    "adm-zip": "^0.6.0",
+    "smol-toml": "^1.8.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
PR description by Claude:
Security Audit is failing on `main` again. New advisory, nothing in our tree changed.

[GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2) — `smol-toml` DoS via malformed TOML, affects `<=1.7.0`.

Two paths resolved it:

```
knip > smol-toml                                          1.8.0  safe
@nightcrawler/sanity > sanity > @sanity/cli > smol-toml   1.6.1  vulnerable
```

`@sanity/cli@6.3.2` declares `smol-toml: ^1.6.1`, so the caret already permits the patched release — bun had just kept a separate nested copy. One override collapses both onto `1.8.0`; no upstream change needed, resolution stays inside the declared range.

Consistent with the 28 transitives already pinned this way (`js-yaml`, `sharp`, `nanoid`, …).

## Verified

`bun install` → single resolution `smol-toml@1.8.0`. `bun audit --audit-level=high` clean. `bun run validate` passes.

## Worth discussing separately

Third audit failure in two days from the same cause: `bun audit` queries a **live** advisory DB, so `main` breaks with no commit. The workflow also pins `bun-version: 'latest'`, so the audit tool moves too (CI ran 1.4.2 while local was 1.4.0).

Options if the team wants to stop the bleeding: a scheduled audit that files an issue instead of blocking PRs, `continue-on-error` plus a required weekly review, or at minimum pinning the bun version for determinism. Not doing any of that here.
