### PR TITLE
feat: update client hyperlink text and url on login page

### DIFF
--- a/apps/site/src/app/(unauthenticated)/[locale]/(contact)/login/page.tsx
+++ b/apps/site/src/app/(unauthenticated)/[locale]/(contact)/login/page.tsx
@@ -192,9 +192,11 @@ export default function Login() {
                 </Button> */}
 
                 <p className="text-left text-sm font-thin">
-                  Not yet a Todd Client?{' '}
-                  <Link href="/contact" className="font-normal underline">
-                    Learn how to become one
+                  <Link
+                    href="/index/introducing-iris"
+                    className="font-normal underline"
+                  >
+                    Learn more about Todd Iris
                   </Link>
                 </p>
               </form>


### PR DESCRIPTION
## Description

Fixes #1131

Updated the client hyperlink on the login page to direct users to "/index/introducing-iris" with the text "Learn more about Todd Iris".

## Checklist

- [x] You've used conventional commits where appropriate
